### PR TITLE
fix: align release-please workflow with manifest config and correct token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,11 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   release-please:
@@ -16,9 +16,14 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
- Adds explicit `config-file` and `manifest-file` inputs to the release-please action\n- Uses `RELEASE_PLEASE_TOKEN` secret consistently\n- Adds `workflow_dispatch` trigger\n- Removes unused `id-token: write` from top-level permissions\n- Adds `version` output for potential future use