### PR TITLE
fix: comprehensive codebase audit (WP1-WP8)

### DIFF
--- a/src/servicenow_mcp/auth.py
+++ b/src/servicenow_mcp/auth.py
@@ -13,7 +13,7 @@ class BasicAuthProvider:
 
     async def get_headers(self) -> dict[str, str]:
         """Return HTTP headers with Basic auth credentials."""
-        credentials = f"{self._settings.servicenow_username}:{self._settings.servicenow_password}"
+        credentials = f"{self._settings.servicenow_username}:{self._settings.servicenow_password.get_secret_value()}"
         encoded = base64.b64encode(credentials.encode("utf-8")).decode("ascii")
         return {
             "Authorization": f"Basic {encoded}",

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -14,6 +14,7 @@ from servicenow_mcp.errors import (
     ServerError,
     ServiceNowMCPError,
 )
+from servicenow_mcp.utils import validate_identifier
 
 
 class ServiceNowClient:
@@ -33,8 +34,22 @@ class ServiceNowClient:
             await self._http_client.aclose()
             self._http_client = None
 
+    def _ensure_client(self) -> httpx.AsyncClient:
+        """Return the HTTP client, raising RuntimeError if not initialized."""
+        if self._http_client is None:
+            raise RuntimeError("Client not initialized. Use 'async with ServiceNowClient(...)' as context manager.")
+        return self._http_client
+
+    def _extract_result(self, data: dict[str, Any]) -> Any:
+        """Extract 'result' from API response data, raising ServerError if missing."""
+        try:
+            return data["result"]
+        except KeyError:
+            raise ServerError("Unexpected API response format: missing 'result' key") from None
+
     def _table_url(self, table: str, sys_id: str | None = None) -> str:
         """Build the REST API URL for a table resource."""
+        validate_identifier(table)
         base = f"{self._settings.servicenow_instance_url}/api/now/table/{table}"
         if sys_id:
             base = f"{base}/{sys_id}"
@@ -42,6 +57,7 @@ class ServiceNowClient:
 
     def _stats_url(self, table: str) -> str:
         """Build the stats/aggregate API URL."""
+        validate_identifier(table)
         return f"{self._settings.servicenow_instance_url}/api/now/stats/{table}"
 
     async def _headers(self) -> dict[str, str]:
@@ -63,7 +79,7 @@ class ServiceNowClient:
             raise NotFoundError(msg)
         if response.status_code >= 500:
             msg = self._extract_error_message(response, "ServiceNow server error")
-            raise ServerError(msg)
+            raise ServerError(msg, status_code=response.status_code)
         if response.status_code >= 400:
             msg = self._extract_error_message(response, "Request failed")
             raise ServiceNowMCPError(msg, status_code=response.status_code)
@@ -87,20 +103,20 @@ class ServiceNowClient:
         display_values: bool = False,
     ) -> dict[str, Any]:
         """Fetch a single record by sys_id."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {}
         if fields:
             params["sysparm_fields"] = ",".join(fields)
         if display_values:
             params["sysparm_display_value"] = "true"
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._table_url(table, sys_id),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def query_records(
         self,
@@ -112,7 +128,7 @@ class ServiceNowClient:
         order_by: str | None = None,
     ) -> dict[str, Any]:
         """Query records with encoded query string."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {
             "sysparm_query": query,
             "sysparm_limit": str(limit),
@@ -123,32 +139,35 @@ class ServiceNowClient:
         if order_by:
             params["sysparm_orderby"] = order_by
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._table_url(table),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
 
-        total_count = int(response.headers.get("X-Total-Count", "0"))
-        records = response.json()["result"]
+        try:
+            total_count = int(response.headers.get("X-Total-Count", "0"))
+        except (ValueError, TypeError):
+            total_count = 0
+        records = self._extract_result(response.json())
         return {"records": records, "count": total_count}
 
     async def get_metadata(self, table: str) -> list[dict[str, Any]]:
         """Fetch dictionary metadata for a table from sys_dictionary."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params = {
             "sysparm_query": f"name={table}",
             "sysparm_limit": "500",
         }
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._table_url("sys_dictionary"),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def aggregate(
         self,
@@ -168,7 +187,7 @@ class ServiceNowClient:
         Supports field-specific statistical operations. For example,
         avg_fields=["priority"] sets sysparm_avg_fields=priority.
         """
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {
             "sysparm_query": query,
             "sysparm_count": "true",
@@ -190,40 +209,40 @@ class ServiceNowClient:
         if display_value:
             params["sysparm_display_value"] = "true"
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._stats_url(table),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def create_record(self, table: str, data: dict[str, Any]) -> dict[str, Any]:
         """Create a new record via POST."""
-        assert self._http_client is not None
-        response = await self._http_client.post(
+        http = self._ensure_client()
+        response = await http.post(
             self._table_url(table),
             headers=await self._headers(),
             json=data,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def update_record(self, table: str, sys_id: str, data: dict[str, Any]) -> dict[str, Any]:
         """Update an existing record via PATCH."""
-        assert self._http_client is not None
-        response = await self._http_client.patch(
+        http = self._ensure_client()
+        response = await http.patch(
             self._table_url(table, sys_id),
             headers=await self._headers(),
             json=data,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def delete_record(self, table: str, sys_id: str) -> bool:
         """Delete a record via DELETE."""
-        assert self._http_client is not None
-        response = await self._http_client.delete(
+        http = self._ensure_client()
+        response = await http.delete(
             self._table_url(table, sys_id),
             headers=await self._headers(),
         )
@@ -242,23 +261,24 @@ class ServiceNowClient:
         fields: list[str] | None = None,
     ) -> dict[str, Any]:
         """Fetch an email record by ID."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {}
         if fields:
             params["sysparm_fields"] = ",".join(fields)
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._email_url(email_id),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     # ── Import Set API ─────────────────────────────────────────────────
 
     def _import_set_url(self, staging_table: str, sys_id: str) -> str:
         """Build the Import Set API URL."""
+        validate_identifier(staging_table)
         return f"{self._settings.servicenow_instance_url}/api/now/import/{staging_table}/{sys_id}"
 
     async def get_import_set_record(
@@ -267,13 +287,13 @@ class ServiceNowClient:
         sys_id: str,
     ) -> dict[str, Any]:
         """Retrieve an import set record from a staging table."""
-        assert self._http_client is not None
-        response = await self._http_client.get(
+        http = self._ensure_client()
+        response = await http.get(
             self._import_set_url(staging_table, sys_id),
             headers=await self._headers(),
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     # ── Reporting APIs ─────────────────────────────────────────────────
 
@@ -283,10 +303,12 @@ class ServiceNowClient:
 
     def _table_description_url(self, table: str) -> str:
         """Build the Reporting Table Description API URL."""
+        validate_identifier(table)
         return f"{self._settings.servicenow_instance_url}/api/now/reporting_table_description/{table}"
 
     def _field_descriptions_url(self, table: str) -> str:
         """Build the Reporting Field Description API URL."""
+        validate_identifier(table)
         return f"{self._settings.servicenow_instance_url}/api/now/reporting_table_description/field_description/{table}"
 
     async def list_reports(
@@ -298,7 +320,7 @@ class ServiceNowClient:
         per_page: int | None = None,
     ) -> list[dict[str, Any]]:
         """Retrieve a list of reports."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {}
         if search:
             params["sysparm_contains"] = search
@@ -311,33 +333,33 @@ class ServiceNowClient:
         if per_page is not None:
             params["sysparm_per_page"] = str(per_page)
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._reporting_url(),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def get_table_description(self, table: str) -> dict[str, Any]:
         """Get a table's description from the Reporting Table Description API."""
-        assert self._http_client is not None
-        response = await self._http_client.get(
+        http = self._ensure_client()
+        response = await http.get(
             self._table_description_url(table),
             headers=await self._headers(),
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def get_field_descriptions(self, table: str) -> list[dict[str, Any]]:
         """Get field descriptions for a table."""
-        assert self._http_client is not None
-        response = await self._http_client.get(
+        http = self._ensure_client()
+        response = await http.get(
             self._field_descriptions_url(table),
             headers=await self._headers(),
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     # ── Code Search API ────────────────────────────────────────────────
 
@@ -357,7 +379,7 @@ class ServiceNowClient:
         limit: int | None = None,
     ) -> dict[str, Any]:
         """Search code across ServiceNow script tables."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {"term": term}
         if table:
             params["table"] = table
@@ -366,36 +388,37 @@ class ServiceNowClient:
         if limit is not None:
             params["limit"] = str(limit)
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._code_search_url(),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def code_search_tables(
         self,
         search_group: str | None = None,
     ) -> dict[str, Any]:
         """Get the list of tables that would be searched for a given search group."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {}
         if search_group:
             params["search_group"] = search_group
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._code_search_tables_url(),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     # ── CMDB APIs ──────────────────────────────────────────────────────
 
     def _cmdb_instance_url(self, class_name: str, sys_id: str | None = None) -> str:
         """Build the CMDB Instance API URL."""
+        validate_identifier(class_name)
         base = f"{self._settings.servicenow_instance_url}/api/now/cmdb/instance/{class_name}"
         if sys_id:
             base = f"{base}/{sys_id}"
@@ -403,6 +426,7 @@ class ServiceNowClient:
 
     def _cmdb_meta_url(self, class_name: str) -> str:
         """Build the CMDB Meta API URL."""
+        validate_identifier(class_name)
         return f"{self._settings.servicenow_instance_url}/api/now/cmdb/meta/{class_name}"
 
     async def cmdb_query(
@@ -413,7 +437,7 @@ class ServiceNowClient:
         offset: int = 0,
     ) -> dict[str, Any]:
         """Query CMDB instances for a given class."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {
             "sysparm_limit": str(limit),
             "sysparm_offset": str(offset),
@@ -421,15 +445,18 @@ class ServiceNowClient:
         if query:
             params["sysparm_query"] = query
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._cmdb_instance_url(class_name),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
 
-        total_count = int(response.headers.get("X-Total-Count", "0"))
-        records = response.json()["result"]
+        try:
+            total_count = int(response.headers.get("X-Total-Count", "0"))
+        except (ValueError, TypeError):
+            total_count = 0
+        records = self._extract_result(response.json())
         return {"records": records, "count": total_count}
 
     async def cmdb_get_instance(
@@ -438,23 +465,23 @@ class ServiceNowClient:
         sys_id: str,
     ) -> dict[str, Any]:
         """Get a specific CMDB CI with its relationships."""
-        assert self._http_client is not None
-        response = await self._http_client.get(
+        http = self._ensure_client()
+        response = await http.get(
             self._cmdb_instance_url(class_name, sys_id),
             headers=await self._headers(),
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     async def cmdb_get_meta(self, class_name: str) -> dict[str, Any]:
         """Get metadata for a CMDB class."""
-        assert self._http_client is not None
-        response = await self._http_client.get(
+        http = self._ensure_client()
+        response = await http.get(
             self._cmdb_meta_url(class_name),
             headers=await self._headers(),
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())
 
     # ── Encoded Query Translator ───────────────────────────────────────
 
@@ -468,16 +495,16 @@ class ServiceNowClient:
         query: str,
     ) -> dict[str, Any]:
         """Translate an encoded query to a human-readable display name."""
-        assert self._http_client is not None
+        http = self._ensure_client()
         params: dict[str, str] = {
             "table": table,
             "query": query,
         }
 
-        response = await self._http_client.get(
+        response = await http.get(
             self._encoded_query_url(),
             headers=await self._headers(),
             params=params,
         )
         self._raise_for_status(response)
-        return response.json()["result"]
+        return self._extract_result(response.json())

--- a/src/servicenow_mcp/config.py
+++ b/src/servicenow_mcp/config.py
@@ -1,9 +1,12 @@
 """Configuration settings for the ServiceNow MCP server."""
 
-from pydantic import field_validator
+from functools import cached_property
+
+from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings
 
 _DEFAULT_LARGE_TABLES = "syslog,sys_audit,sys_log_transaction,sys_email_log"
+_VALID_PACKAGES = frozenset({"full", "introspection_only", "none"})
 
 
 class Settings(BaseSettings):
@@ -11,7 +14,7 @@ class Settings(BaseSettings):
 
     servicenow_instance_url: str
     servicenow_username: str
-    servicenow_password: str
+    servicenow_password: SecretStr
     mcp_tool_package: str = "full"
     servicenow_env: str = "dev"
     max_row_limit: int = 100
@@ -27,13 +30,33 @@ class Settings(BaseSettings):
     @field_validator("servicenow_instance_url")
     @classmethod
     def strip_trailing_slash(cls, v: str) -> str:
+        """Strip trailing slash and validate HTTPS scheme."""
+        if not v.startswith("https://"):
+            raise ValueError("servicenow_instance_url must start with https://")
         return v.rstrip("/")
 
-    @property
-    def large_table_names(self) -> list[str]:
-        """Parse comma-separated large table names into a list."""
-        return [t.strip() for t in self.large_table_names_csv.split(",") if t.strip()]
+    @field_validator("max_row_limit")
+    @classmethod
+    def validate_max_row_limit(cls, v: int) -> int:
+        """Ensure max_row_limit is between 1 and 10000."""
+        if v < 1 or v > 10000:
+            raise ValueError("max_row_limit must be between 1 and 10000")
+        return v
+
+    @field_validator("mcp_tool_package")
+    @classmethod
+    def validate_mcp_tool_package(cls, v: str) -> str:
+        """Validate mcp_tool_package against known packages."""
+        if v not in _VALID_PACKAGES:
+            raise ValueError(f"mcp_tool_package must be one of {sorted(_VALID_PACKAGES)}, got {v!r}")
+        return v
+
+    @cached_property
+    def large_table_names(self) -> frozenset[str]:
+        """Parse comma-separated large table names into a frozenset."""
+        return frozenset(t.strip() for t in self.large_table_names_csv.split(",") if t.strip())
 
     @property
     def is_production(self) -> bool:
-        return self.servicenow_env == "prod"
+        """Return True if the environment is production."""
+        return self.servicenow_env.lower() in {"prod", "production"}

--- a/src/servicenow_mcp/errors.py
+++ b/src/servicenow_mcp/errors.py
@@ -30,29 +30,22 @@ class NotFoundError(ServiceNowMCPError):
         super().__init__(message, status_code=404)
 
 
-class QuerySafetyError(ServiceNowMCPError):
-    """Query violates safety policies."""
+class ServerError(ServiceNowMCPError):
+    """ServiceNow server error (HTTP 5xx)."""
 
-    def __init__(self, message: str = "Query safety violation") -> None:
-        super().__init__(message)
-
-
-class WriteGatingError(ServiceNowMCPError):
-    """Write operation blocked by policy."""
-
-    def __init__(self, message: str = "Write operation not allowed") -> None:
-        super().__init__(message)
+    def __init__(self, message: str = "Internal server error", status_code: int = 500) -> None:
+        super().__init__(message, status_code=status_code)
 
 
 class PolicyError(ServiceNowMCPError):
     """Access denied by policy (deny list, masking, etc.)."""
 
-    def __init__(self, message: str = "Access denied by policy") -> None:
-        super().__init__(message)
+    def __init__(self, message: str = "Policy violation", status_code: int = 403) -> None:
+        super().__init__(message, status_code=status_code)
 
 
-class ServerError(ServiceNowMCPError):
-    """ServiceNow server error (HTTP 5xx)."""
+class QuerySafetyError(PolicyError):
+    """Query violates safety policies."""
 
-    def __init__(self, message: str = "ServiceNow server error") -> None:
-        super().__init__(message, status_code=500)
+    def __init__(self, message: str = "Query safety violation") -> None:
+        super().__init__(message, status_code=403)

--- a/src/servicenow_mcp/investigations/acl_conflicts.py
+++ b/src/servicenow_mcp/investigations/acl_conflicts.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
-from servicenow_mcp.utils import validate_identifier
+from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 
 async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any]:
@@ -29,9 +29,10 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     check_table_access(table)
 
     # Query ACLs for the table name and field-level ACLs
+    query = ServiceNowQuery().equals("name", table).or_starts_with("name", f"{table}.").build()
     acl_result = await client.query_records(
         "sys_security_acl",
-        f"name={table}^ORnameSTARTSWITH{table}.",
+        query,
         fields=["sys_id", "name", "operation", "condition", "script", "active"],
         limit=500,
     )

--- a/src/servicenow_mcp/investigations/deprecated_apis.py
+++ b/src/servicenow_mcp/investigations/deprecated_apis.py
@@ -33,7 +33,10 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     Params:
         limit: Maximum findings per pattern (default 20).
     """
-    limit = params.get("limit", 20)
+    try:
+        limit = int(params.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
     findings: list[dict[str, Any]] = []
 
     for pattern in DEPRECATED_PATTERNS:
@@ -68,6 +71,8 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
 
     element_id format: "table:sys_id".
     """
+    if ":" not in element_id:
+        return {"error": f"Invalid element_id format: expected 'table:sys_id', got '{element_id}'"}
     table, sys_id = element_id.split(":", 1)
     validate_identifier(table)
     if table not in _ALLOWED_TABLES:

--- a/src/servicenow_mcp/investigations/error_analysis.py
+++ b/src/servicenow_mcp/investigations/error_analysis.py
@@ -1,12 +1,11 @@
 """Investigation: analyze and cluster syslog errors."""
 
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
-from servicenow_mcp.utils import ServiceNowQuery, sanitize_query_value
+from servicenow_mcp.utils import ServiceNowQuery, sanitize_query_value, validate_identifier
 
 
 async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any]:
@@ -25,7 +24,12 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     except (TypeError, ValueError):
         hours = 24
     source_filter = params.get("source")
-    limit = params.get("limit", 100)
+    try:
+        limit = int(params.get("limit", 100))
+    except (TypeError, ValueError):
+        limit = 100
+
+    check_table_access("syslog")
 
     q = ServiceNowQuery().equals("level", "0").hours_ago("sys_created_on", hours)
     if source_filter:
@@ -75,7 +79,11 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
 
     element_id format: "syslog:sys_id".
     """
+    if ":" not in element_id:
+        return {"error": f"Invalid element_id format: expected 'table:sys_id', got '{element_id}'"}
     table, sys_id = element_id.split(":", 1)
+    validate_identifier(table)
+    validate_identifier(sys_id)
     if table != "syslog":
         return {
             "element": element_id,

--- a/src/servicenow_mcp/investigations/performance_bottlenecks.py
+++ b/src/servicenow_mcp/investigations/performance_bottlenecks.py
@@ -22,8 +22,17 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
         hours: Optional lookback period in hours (default None, queries all).
         limit: Maximum findings per category (default 20).
     """
-    limit = params.get("limit", 20)
-    hours = params.get("hours")
+    try:
+        limit = int(params.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+    raw_hours = params.get("hours")
+    hours: int | None = None
+    if raw_hours is not None:
+        try:
+            hours = int(raw_hours)
+        except (TypeError, ValueError):
+            hours = 24
     findings: list[dict[str, Any]] = []
 
     # 1. Active BRs grouped by collection (table)
@@ -128,6 +137,8 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
         }
     else:
         # element_id is a table name (heavy_automation category)
+        validate_identifier(element_id)
+        check_table_access(element_id)
         stats_result = await client.aggregate(element_id, query="")
         record_count = int(stats_result.get("stats", {}).get("count", 0))
 

--- a/src/servicenow_mcp/investigations/slow_transactions.py
+++ b/src/servicenow_mcp/investigations/slow_transactions.py
@@ -1,6 +1,5 @@
 """Investigation: find slow transactions via ServiceNow performance pattern tables."""
 
-from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from servicenow_mcp.client import ServiceNowClient
@@ -36,14 +35,14 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
         hours = max(0, int(params.get("hours", 24)))
     except (TypeError, ValueError):
         hours = 24
-    limit = params.get("limit", 20)
+    try:
+        limit = int(params.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
     categories_filter = params.get("categories")
     allowed_categories: set[str] | None = None
     if categories_filter:
         allowed_categories = {c.strip() for c in categories_filter.split(",")}
-
-    cutoff = datetime.now(tz=UTC) - timedelta(hours=hours)
-    cutoff_str = cutoff.strftime("%Y-%m-%d %H:%M:%S")
 
     findings: list[dict[str, Any]] = []
 
@@ -100,6 +99,8 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
 
     element_id format: "table:sys_id".
     """
+    if ":" not in element_id:
+        return {"error": f"Invalid element_id format: expected 'table:sys_id', got '{element_id}'"}
     table, sys_id = element_id.split(":", 1)
     if table not in _ALLOWED_TABLES:
         return {

--- a/src/servicenow_mcp/investigations/stale_automations.py
+++ b/src/servicenow_mcp/investigations/stale_automations.py
@@ -22,8 +22,14 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
         stale_days: Number of days to consider stale (default 30).
         limit: Maximum findings per category (default 20).
     """
-    stale_days = params.get("stale_days", 30)
-    limit = params.get("limit", 20)
+    try:
+        stale_days = int(params.get("stale_days", 30))
+    except (TypeError, ValueError):
+        stale_days = 30
+    try:
+        limit = int(params.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
 
     findings: list[dict[str, Any]] = []
 
@@ -116,6 +122,8 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
 
     element_id format: "table:sys_id" (e.g. "flow_context:fc001").
     """
+    if ":" not in element_id:
+        return {"error": f"Invalid element_id format: expected 'table:sys_id', got '{element_id}'"}
     table, sys_id = element_id.split(":", 1)
     if table not in _ALLOWED_TABLES:
         return {

--- a/src/servicenow_mcp/investigations/table_health.py
+++ b/src/servicenow_mcp/investigations/table_health.py
@@ -30,12 +30,18 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     validate_identifier(table)
     check_table_access(table)
 
-    hours = params.get("hours")
+    raw_hours = params.get("hours")
+    hours: int | None = None
+    if raw_hours is not None:
+        try:
+            hours = int(raw_hours)
+        except (TypeError, ValueError):
+            hours = 24
 
     # Build time-filtered query fragments for each query
     br_q = ServiceNowQuery().equals("collection", table).equals("active", "true")
     cs_q = ServiceNowQuery().equals("table", table).equals("active", "true")
-    acl_q = ServiceNowQuery().raw(f"name={table}^ORnameSTARTSWITH{table}.")
+    acl_q = ServiceNowQuery().equals("name", table).or_starts_with("name", f"{table}.")
     uip_q = ServiceNowQuery().equals("table", table).equals("active", "true")
     syslog_q = ServiceNowQuery().equals("level", "0").like("source", table)
 

--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -31,9 +31,9 @@ def get_package(name: str) -> list[str]:
     """
     if name not in PACKAGE_REGISTRY:
         raise ValueError(f"Unknown tool package '{name}'. Available packages: {', '.join(PACKAGE_REGISTRY.keys())}")
-    return PACKAGE_REGISTRY[name]
+    return list(PACKAGE_REGISTRY[name])
 
 
 def list_packages() -> dict[str, list[str]]:
     """Return all registered packages and their tool groups."""
-    return dict(PACKAGE_REGISTRY)
+    return {k: list(v) for k, v in PACKAGE_REGISTRY.items()}

--- a/src/servicenow_mcp/policy.py
+++ b/src/servicenow_mcp/policy.py
@@ -34,7 +34,7 @@ _SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
 MASK_VALUE = "***MASKED***"
 
 # Date field patterns used to detect date-bounded filters
-_DATE_FIELD_PATTERNS = [
+_DATE_FIELD_PATTERNS: list[str] = [
     "sys_created_on",
     "sys_updated_on",
     "opened_at",
@@ -42,13 +42,20 @@ _DATE_FIELD_PATTERNS = [
     "sys_recorded_at",
 ]
 
+# Regex to match: a date field name following a condition separator, with a comparison operator
+_DATE_CONSTRAINT_RE: re.Pattern[str] = re.compile(
+    r"(?:^|\^(?:OR)?)"  # start of string or ^ or ^OR separator
+    r"(" + "|".join(re.escape(f) for f in _DATE_FIELD_PATTERNS) + r")"  # date field name
+    r"(>=?|<=?|BETWEEN|javascript:gs\.\w+Ago)",  # comparison operator
+)
+
 
 def check_table_access(table: str) -> None:
     """Raise PolicyError if the table is on the deny list.
 
     Returns None if access is allowed.
     """
-    if table in DENIED_TABLES:
+    if table.lower() in DENIED_TABLES:
         raise PolicyError(f"Access to table '{table}' is denied by policy")
 
 
@@ -90,8 +97,12 @@ def mask_audit_entry(entry: dict[str, Any]) -> dict[str, Any]:
 
 
 def _has_date_filter(query: str) -> bool:
-    """Check if the query contains a date-bounded filter."""
-    return any(field in query for field in _DATE_FIELD_PATTERNS)
+    """Check if the query contains a structural date-bounded filter.
+
+    Verifies that a recognized date field appears with a comparison operator
+    (>, >=, <, <=, BETWEEN, or gs.*Ago functions), not merely as a substring.
+    """
+    return bool(_DATE_CONSTRAINT_RE.search(query))
 
 
 def enforce_query_safety(
@@ -109,6 +120,9 @@ def enforce_query_safety(
 
     # Cap limit at max_row_limit
     effective_limit = settings.max_row_limit if limit is None or limit > settings.max_row_limit else limit
+
+    # Floor limit at 1 to prevent zero or negative values
+    effective_limit = max(1, effective_limit)
 
     # Large tables require date-bounded filters
     if table in settings.large_table_names and not _has_date_filter(query):
@@ -128,8 +142,13 @@ def can_write(
 ) -> bool:
     """Check if write operations are allowed for the given table and environment."""
     # Always block writes to denied tables
-    if table in DENIED_TABLES:
+    if table.lower() in DENIED_TABLES:
+        logger.warning("Write blocked: table '%s' is on deny list", table)
         return False
 
     # In production, require explicit override
-    return not (settings.is_production and not override)
+    if settings.is_production and not override:
+        logger.warning("Write blocked: table '%s' in production environment '%s'", table, settings.servicenow_env)
+        return False
+
+    return True

--- a/src/servicenow_mcp/state.py
+++ b/src/servicenow_mcp/state.py
@@ -17,18 +17,32 @@ class PreviewTokenStore:
     Expired tokens are automatically rejected on get/consume.
     """
 
-    def __init__(self, ttl_seconds: int = 300) -> None:
+    def __init__(self, ttl_seconds: int = 300, max_size: int = 1000) -> None:
         self._ttl = ttl_seconds
+        self._max_size = max_size
         self._store: dict[str, dict[str, Any]] = {}
 
     def create(self, payload: dict[str, Any]) -> str:
-        """Store a payload and return a new UUID token."""
+        """Store a payload and return a new UUID token.
+
+        Raises RuntimeError if the store is full after sweeping expired entries.
+        """
+        self._sweep_expired()
+        if len(self._store) >= self._max_size:
+            raise RuntimeError("Preview token store is full")
         token = str(uuid.uuid4())
         self._store[token] = {
             "payload": payload,
             "created_at": time.monotonic(),
         }
         return token
+
+    def _sweep_expired(self) -> None:
+        """Remove all expired entries from the store."""
+        now = time.monotonic()
+        expired_keys = [k for k, entry in self._store.items() if (now - entry["created_at"]) > self._ttl]
+        for k in expired_keys:
+            del self._store[k]
 
     def _is_expired(self, entry: dict[str, Any]) -> bool:
         """Check if a store entry has exceeded its TTL."""

--- a/src/servicenow_mcp/tools/changes.py
+++ b/src/servicenow_mcp/tools/changes.py
@@ -148,7 +148,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             async with ServiceNowClient(settings, auth_provider) as client:
                 versions_result = await client.query_records(
                     "sys_update_version",
-                    f"name={update_name}^ORDERBYDESCsys_recorded_at",
+                    ServiceNowQuery().equals("name", update_name).order_by("sys_recorded_at", descending=True).build(),
                     fields=["sys_id", "name", "payload", "sys_recorded_at"],
                     limit=2,
                 )

--- a/src/servicenow_mcp/tools/developer.py
+++ b/src/servicenow_mcp/tools/developer.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import FastMCP
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
-from servicenow_mcp.policy import can_write
+from servicenow_mcp.policy import MASK_VALUE, _is_sensitive_field, can_write, check_table_access, mask_sensitive_fields
 from servicenow_mcp.state import PreviewTokenStore, SeededRecordTracker
 from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
 from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id, validate_identifier
@@ -136,13 +136,17 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 updated = await client.update_record("sys_properties", prop_sys_id, {"value": value})
                 new_value = updated.get("value", value)
 
+            # Mask values for sensitive property names
+            display_old = MASK_VALUE if _is_sensitive_field(name) else old_value
+            display_new = MASK_VALUE if _is_sensitive_field(name) else new_value
+
             return json.dumps(
                 format_response(
                     data={
                         "name": name,
                         "sys_id": prop_sys_id,
-                        "old_value": old_value,
-                        "new_value": new_value,
+                        "old_value": display_old,
+                        "new_value": display_new,
                     },
                     correlation_id=correlation_id,
                 )
@@ -169,6 +173,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         correlation_id = generate_correlation_id()
         try:
             validate_identifier(table)
+            check_table_access(table)
 
             # Write gate
             if not can_write(table, settings):
@@ -254,6 +259,18 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     )
                 )
 
+            # Write gate — check first entry's table (all entries share same seed context)
+            for entry in entries:
+                if not can_write(entry["table"], settings):
+                    return json.dumps(
+                        format_response(
+                            data=None,
+                            correlation_id=correlation_id,
+                            status="error",
+                            error="Write operations are blocked in production environments",
+                        )
+                    )
+
             deleted_count = 0
             failed_records: list[dict[str, str]] = []
             sem = asyncio.Semaphore(10)
@@ -324,6 +341,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         correlation_id = generate_correlation_id()
         try:
             validate_identifier(table)
+            check_table_access(table)
 
             # Write gate
             if not can_write(table, settings):
@@ -346,7 +364,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             diff: dict[str, dict[str, str]] = {}
             for field, new_value in changes_dict.items():
                 old_value = current.get(field, "")
-                diff[field] = {"old": old_value, "new": new_value}
+                if _is_sensitive_field(field):
+                    diff[field] = {"old": MASK_VALUE, "new": MASK_VALUE}
+                else:
+                    diff[field] = {"old": old_value, "new": new_value}
 
             # Store preview for later apply
             token = preview_store.create(
@@ -403,6 +424,18 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id = payload["sys_id"]
             changes = payload["changes"]
 
+            check_table_access(table)
+
+            if not can_write(table, settings):
+                return json.dumps(
+                    format_response(
+                        data=None,
+                        correlation_id=correlation_id,
+                        status="error",
+                        error="Write operations are blocked in production environments",
+                    )
+                )
+
             async with ServiceNowClient(settings, auth_provider) as client:
                 updated = await client.update_record(table, sys_id, changes)
 
@@ -411,7 +444,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     data={
                         "table": table,
                         "sys_id": sys_id,
-                        "record": updated,
+                        "record": mask_sensitive_fields(updated),
                     },
                     correlation_id=correlation_id,
                 )

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import FastMCP
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
-from servicenow_mcp.policy import check_table_access
+from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
 from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
 from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id, validate_identifier
 
@@ -188,7 +188,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             check_table_access(table)
 
             async with ServiceNowClient(settings, auth_provider) as client:
-                record = await client.get_record(table, sys_id)
+                record = mask_sensitive_fields(await client.get_record(table, sys_id))
 
                 # Parse script for GlideRecord('table_name') references
                 script = record.get("script", "")

--- a/src/servicenow_mcp/tools/metadata.py
+++ b/src/servicenow_mcp/tools/metadata.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import check_table_access, enforce_query_safety, mask_sensitive_fields
 from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
@@ -65,12 +65,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             check_table_access(table)
 
             encoded_query = query if query else ""
+            safety = enforce_query_safety(table, encoded_query, limit, settings)
+            effective_limit = safety["limit"]
 
             async with ServiceNowClient(settings, auth_provider) as client:
                 result = await client.query_records(
                     table,
                     encoded_query,
-                    limit=limit,
+                    limit=effective_limit,
                 )
 
             return json.dumps(
@@ -152,11 +154,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         try:
             matches: list[dict[str, Any]] = []
             search_method = "code_search_api"
+            effective_limit = min(limit, settings.max_row_limit)
 
             async with ServiceNowClient(settings, auth_provider) as client:
                 # Try Code Search API first (indexed, single call)
                 try:
-                    cs_result = await client.code_search(term=target, limit=limit * len(SCRIPT_TABLES))
+                    cs_result = await client.code_search(term=target, limit=effective_limit * len(SCRIPT_TABLES))
                     search_results = cs_result.get("search_results", [])
                     for sr in search_results:
                         result_table = sr.get("className", "")
@@ -183,7 +186,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                                 table,
                                 query,
                                 fields=["sys_id", "name", "sys_class_name"],
-                                limit=limit,
+                                limit=effective_limit,
                             )
                             for record in result["records"]:
                                 matches.append(

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -26,6 +26,8 @@ _BINARY_OPERATORS = {
     "starts_with",
     "like",
 }
+_OR_BINARY_OPERATORS = {"or_equals", "or_starts_with"}
+_LIST_OPERATORS = {"in_list", "not_in_list"}
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -39,10 +41,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
           - operator: equals, not_equals, greater_than, greater_or_equal,
                       less_than, less_or_equal, contains, starts_with, like,
                       is_empty, is_not_empty, hours_ago, minutes_ago,
-                      days_ago, older_than_days
+                      days_ago, older_than_days, or_equals, or_starts_with,
+                      in_list, not_in_list, order_by
           - field: The field name (e.g. "sys_created_on", "active")
           - value: The comparison value (string for most operators, integer for
-                   time operators). Not required for is_empty / is_not_empty.
+                   time operators, list of strings for in_list/not_in_list).
+                   Not required for is_empty / is_not_empty.
+          - descending: (optional, for order_by only) boolean, default false.
 
         Args:
             conditions: JSON array of condition objects.
@@ -97,7 +102,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                             )
                         )
                     getattr(query, operator)(field, int(value))
-                elif operator in _BINARY_OPERATORS:
+                elif operator in _BINARY_OPERATORS or operator in _OR_BINARY_OPERATORS:
                     if value is None:
                         return json.dumps(
                             format_response(
@@ -108,8 +113,29 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                             )
                         )
                     getattr(query, operator)(field, str(value))
+                elif operator in _LIST_OPERATORS:
+                    if value is None or not isinstance(value, list):
+                        return json.dumps(
+                            format_response(
+                                data=None,
+                                correlation_id=correlation_id,
+                                status="error",
+                                error=f"Operator '{operator}' requires a 'value' that is a list of strings.",
+                            )
+                        )
+                    getattr(query, operator)(field, [str(v) for v in value])
+                elif operator == "order_by":
+                    descending = bool(condition.get("descending", False))
+                    query.order_by(field, descending=descending)
                 else:
-                    valid = sorted(_UNARY_OPERATORS | _TIME_OPERATORS | _BINARY_OPERATORS)
+                    valid = sorted(
+                        _UNARY_OPERATORS
+                        | _TIME_OPERATORS
+                        | _BINARY_OPERATORS
+                        | _OR_BINARY_OPERATORS
+                        | _LIST_OPERATORS
+                        | {"order_by"}
+                    )
                     return json.dumps(
                         format_response(
                             data=None,

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -2,9 +2,29 @@
 
 import re
 import uuid
+import warnings
 from typing import Any
 
 _IDENTIFIER_RE = re.compile(r"^[a-z0-9_]+$")
+
+# Operators recognised by ``or_condition()``.
+_ALLOWED_OPERATORS: frozenset[str] = frozenset(
+    {
+        "=",
+        "!=",
+        ">",
+        ">=",
+        "<",
+        "<=",
+        "CONTAINS",
+        "STARTSWITH",
+        "LIKE",
+        "ISEMPTY",
+        "ISNOTEMPTY",
+        "IN",
+        "NOT IN",
+    }
+)
 
 
 def validate_identifier(name: str) -> None:
@@ -60,12 +80,21 @@ def build_encoded_query(conditions: dict[str, str] | str) -> str:
     """Convert a dict of conditions to a ServiceNow encoded query string.
 
     If a string is passed, it is returned unchanged.
+
+    .. deprecated::
+        Use :class:`ServiceNowQuery` instead.  This helper performs no
+        field-name validation and only basic value sanitization.
     """
+    warnings.warn(
+        "build_encoded_query() is deprecated — use ServiceNowQuery instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if isinstance(conditions, str):
         return conditions
     if not conditions:
         return ""
-    return "^".join(f"{key}={value}" for key, value in conditions.items())
+    return "^".join(f"{key}={sanitize_query_value(value)}" for key, value in conditions.items())
 
 
 class ServiceNowQuery:
@@ -77,90 +106,229 @@ class ServiceNowQuery:
     # --- Comparison operators ---
 
     def equals(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add field=value condition."""
+        """Add ``field=value`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}={value}")
         return self
 
     def not_equals(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add field!=value condition."""
+        """Add ``field!=value`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}!={value}")
         return self
 
     def greater_than(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add field>value condition."""
+        """Add ``field>value`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}>{value}")
         return self
 
     def greater_or_equal(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add field>=value condition."""
+        """Add ``field>=value`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}>={value}")
         return self
 
     def less_than(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add field<value condition."""
+        """Add ``field<value`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}<{value}")
         return self
 
     def less_or_equal(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add field<=value condition."""
+        """Add ``field<=value`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}<={value}")
         return self
 
     # --- String operators ---
 
     def contains(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add fieldCONTAINSvalue condition."""
+        """Add ``fieldCONTAINSvalue`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}CONTAINS{value}")
         return self
 
     def starts_with(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add fieldSTARTSWITHvalue condition."""
+        """Add ``fieldSTARTSWITHvalue`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}STARTSWITH{value}")
         return self
 
     def like(self, field: str, value: str) -> "ServiceNowQuery":
-        """Add fieldLIKEvalue condition."""
+        """Add ``fieldLIKEvalue`` condition."""
+        validate_identifier(field)
+        value = sanitize_query_value(value)
         self._parts.append(f"{field}LIKE{value}")
         return self
 
     # --- Null operators ---
 
     def is_empty(self, field: str) -> "ServiceNowQuery":
-        """Add fieldISEMPTY condition."""
+        """Add ``fieldISEMPTY`` condition."""
+        validate_identifier(field)
         self._parts.append(f"{field}ISEMPTY")
         return self
 
     def is_not_empty(self, field: str) -> "ServiceNowQuery":
-        """Add fieldISNOTEMPTY condition."""
+        """Add ``fieldISNOTEMPTY`` condition."""
+        validate_identifier(field)
         self._parts.append(f"{field}ISNOTEMPTY")
         return self
 
     # --- GlideSystem time filters (server-side, timezone-correct) ---
 
     def hours_ago(self, field: str, hours: int) -> "ServiceNowQuery":
-        """Add field>=javascript:gs.hoursAgoStart(hours) condition."""
+        """Add ``field>=javascript:gs.hoursAgoStart(hours)`` condition.
+
+        Args:
+            field: Field name (validated as identifier).
+            hours: Number of hours, 1-8760 (1 year).
+        """
+        validate_identifier(field)
+        hours = int(hours)
+        if not (1 <= hours <= 8760):
+            raise ValueError(f"hours must be between 1 and 8760, got {hours}")
         self._parts.append(f"{field}>=javascript:gs.hoursAgoStart({hours})")
         return self
 
     def minutes_ago(self, field: str, minutes: int) -> "ServiceNowQuery":
-        """Add field>=javascript:gs.minutesAgoStart(minutes) condition."""
+        """Add ``field>=javascript:gs.minutesAgoStart(minutes)`` condition.
+
+        Args:
+            field: Field name (validated as identifier).
+            minutes: Number of minutes, 1-525600 (1 year).
+        """
+        validate_identifier(field)
+        minutes = int(minutes)
+        if not (1 <= minutes <= 525600):
+            raise ValueError(f"minutes must be between 1 and 525600, got {minutes}")
         self._parts.append(f"{field}>=javascript:gs.minutesAgoStart({minutes})")
         return self
 
     def days_ago(self, field: str, days: int) -> "ServiceNowQuery":
-        """Add field>=javascript:gs.daysAgoStart(days) condition."""
+        """Add ``field>=javascript:gs.daysAgoStart(days)`` condition.
+
+        Args:
+            field: Field name (validated as identifier).
+            days: Number of days, 1-365.
+        """
+        validate_identifier(field)
+        days = int(days)
+        if not (1 <= days <= 365):
+            raise ValueError(f"days must be between 1 and 365, got {days}")
         self._parts.append(f"{field}>=javascript:gs.daysAgoStart({days})")
         return self
 
     def older_than_days(self, field: str, days: int) -> "ServiceNowQuery":
-        """Add field<=javascript:gs.daysAgoEnd(days) condition for records before the cutoff."""
+        """Add ``field<=javascript:gs.daysAgoEnd(days)`` condition for records before the cutoff.
+
+        Args:
+            field: Field name (validated as identifier).
+            days: Number of days, 1-3650 (10 years).
+        """
+        validate_identifier(field)
+        days = int(days)
+        if not (1 <= days <= 3650):
+            raise ValueError(f"days must be between 1 and 3650, got {days}")
         self._parts.append(f"{field}<=javascript:gs.daysAgoEnd({days})")
+        return self
+
+    # --- IN / NOT IN operators ---
+
+    def in_list(self, field: str, values: list[str]) -> "ServiceNowQuery":
+        """Add ``fieldINvalue1,value2,...`` condition.
+
+        Args:
+            field: Field name (validated as identifier).
+            values: List of values; each is sanitized individually.
+        """
+        validate_identifier(field)
+        sanitized = ",".join(sanitize_query_value(v) for v in values)
+        self._parts.append(f"{field}IN{sanitized}")
+        return self
+
+    def not_in_list(self, field: str, values: list[str]) -> "ServiceNowQuery":
+        """Add ``fieldNOT INvalue1,value2,...`` condition.
+
+        Args:
+            field: Field name (validated as identifier).
+            values: List of values; each is sanitized individually.
+        """
+        validate_identifier(field)
+        sanitized = ",".join(sanitize_query_value(v) for v in values)
+        self._parts.append(f"{field}NOT IN{sanitized}")
+        return self
+
+    # --- OR conditions ---
+
+    def or_condition(self, field: str, operator: str, value: str) -> "ServiceNowQuery":
+        """Append an OR condition: ``^ORfield<OPERATOR>value``.
+
+        Args:
+            field: Field name (validated as identifier).
+            operator: One of the allowed ServiceNow operators (e.g. ``=``, ``!=``, ``CONTAINS``).
+            value: Condition value (sanitized).
+        """
+        validate_identifier(field)
+        if operator not in _ALLOWED_OPERATORS:
+            raise ValueError(f"Unknown operator: {operator!r}. Allowed: {sorted(_ALLOWED_OPERATORS)}")
+        value = sanitize_query_value(value)
+        self._parts.append(f"^OR{field}{operator}{value}")
+        return self
+
+    def or_equals(self, field: str, value: str) -> "ServiceNowQuery":
+        """Convenience: append ``^ORfield=value``.
+
+        Args:
+            field: Field name (validated as identifier).
+            value: Condition value (sanitized).
+        """
+        return self.or_condition(field, "=", value)
+
+    def or_starts_with(self, field: str, value: str) -> "ServiceNowQuery":
+        """Convenience: append ``^ORfieldSTARTSWITHvalue``.
+
+        Args:
+            field: Field name (validated as identifier).
+            value: Condition value (sanitized).
+        """
+        return self.or_condition(field, "STARTSWITH", value)
+
+    # --- Ordering ---
+
+    def order_by(self, field: str, descending: bool = False) -> "ServiceNowQuery":
+        """Append an ``ORDERBY`` or ``ORDERBYDESC`` directive.
+
+        Args:
+            field: Field name (validated as identifier).
+            descending: If ``True`` use ``ORDERBYDESC``, otherwise ``ORDERBY``.
+        """
+        validate_identifier(field)
+        prefix = "ORDERBYDESC" if descending else "ORDERBY"
+        self._parts.append(f"{prefix}{field}")
         return self
 
     # --- Raw fragment ---
 
     def raw(self, fragment: str) -> "ServiceNowQuery":
-        """Append a raw encoded query fragment."""
+        """Append a raw encoded query fragment.
+
+        .. warning::
+
+            This method performs **no** validation or sanitization.
+            Only use it for trusted, pre-validated query fragments.
+            Prefer the typed builder methods whenever possible to
+            ensure field-name validation and value escaping.
+        """
         if fragment:
             self._parts.append(fragment)
         return self

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -280,6 +280,52 @@ class TestChangesDiffArtifact:
         assert "// old version" in diff_text
         assert "// new version" in diff_text
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_diff_artifact_uses_builder_order_by(self, settings, auth_provider):
+        """Verifies the query uses ServiceNowQuery builder with inline ORDERBYDESC."""
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_update_version").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "v2",
+                            "name": "sys_script_include_abc",
+                            "payload": "<new/>",
+                            "sys_recorded_at": "2026-02-21 10:00:00",
+                        },
+                        {
+                            "sys_id": "v1",
+                            "name": "sys_script_include_abc",
+                            "payload": "<old/>",
+                            "sys_recorded_at": "2026-02-20 10:00:00",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["changes_diff_artifact"](table="sys_script_include", sys_id="abc")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+
+        # Verify the query uses the builder-generated format with equals() + order_by()
+        request = route.calls[0].request
+        url_str = str(request.url)
+
+        # Builder produces: name=sys_script_include_abc^ORDERBYDESCsys_recorded_at
+        assert "name%3Dsys_script_include_abc" in url_str or "name=sys_script_include_abc" in url_str
+        assert "ORDERBYDESCsys_recorded_at" in url_str
+
+        # Verify that order_by is NOT sent as a separate sysparm_orderby parameter
+        parsed = urlparse(url_str)
+        qs = parse_qs(parsed.query)
+        assert "sysparm_orderby" not in qs
+
 
 class TestChangesLastTouched:
     """Tests for the changes_last_touched tool."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -881,3 +881,178 @@ class TestServiceNowClientEncodedQueryTranslator:
         url = str(route.calls[0].request.url)
         assert "table" in url
         assert "query" in url
+
+
+class TestClientNotInitialized:
+    """Test that calling methods without async with context raises RuntimeError."""
+
+    @pytest.mark.asyncio
+    async def test_get_record_without_context_manager(self, settings, auth_provider):
+        """get_record raises RuntimeError when client is not initialized."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.get_record("incident", "abc123")
+
+    @pytest.mark.asyncio
+    async def test_query_records_without_context_manager(self, settings, auth_provider):
+        """query_records raises RuntimeError when client is not initialized."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.query_records("incident", "active=true")
+
+
+class TestMissingResultKey:
+    """Test that missing 'result' key in API response raises ServerError."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_record_missing_result_key(self, settings, auth_provider):
+        """ServerError raised when API response lacks 'result' key."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import ServerError
+
+        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+            return_value=httpx.Response(
+                200,
+                json={"error": "something went wrong"},
+            )
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ServerError, match="missing 'result' key"):
+                await client.get_record("incident", "abc123")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_query_records_missing_result_key(self, settings, auth_provider):
+        """ServerError raised when query response lacks 'result' key."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import ServerError
+
+        respx.get(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": []},
+                headers={"X-Total-Count": "0"},
+            )
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ServerError, match="missing 'result' key"):
+                await client.query_records("incident", "active=true")
+
+
+class TestInvalidTotalCount:
+    """Test that invalid X-Total-Count header defaults to 0."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_query_records_invalid_total_count(self, settings, auth_provider):
+        """Non-numeric X-Total-Count defaults to 0."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        respx.get(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [{"sys_id": "1"}]},
+                headers={"X-Total-Count": "invalid"},
+            )
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.query_records("incident", "active=true")
+
+        assert result["count"] == 0
+        assert len(result["records"]) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cmdb_query_invalid_total_count(self, settings, auth_provider):
+        """Non-numeric X-Total-Count in CMDB query defaults to 0."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        respx.get(f"{BASE_URL}/api/now/cmdb/instance/cmdb_ci_linux_server").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [{"sys_id": "ci1"}]},
+                headers={"X-Total-Count": "not_a_number"},
+            )
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.cmdb_query("cmdb_ci_linux_server")
+
+        assert result["count"] == 0
+        assert len(result["records"]) == 1
+
+
+class TestUrlBuilderValidation:
+    """Test that URL builder methods validate identifiers."""
+
+    def test_table_url_rejects_invalid_name(self, settings, auth_provider):
+        """_table_url raises ValueError for invalid table name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._table_url("INVALID-TABLE!")
+
+    def test_stats_url_rejects_invalid_name(self, settings, auth_provider):
+        """_stats_url raises ValueError for invalid table name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._stats_url("bad/table")
+
+    def test_import_set_url_rejects_invalid_name(self, settings, auth_provider):
+        """_import_set_url raises ValueError for invalid staging table name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._import_set_url("../etc/passwd", "abc123")
+
+    def test_cmdb_instance_url_rejects_invalid_name(self, settings, auth_provider):
+        """_cmdb_instance_url raises ValueError for invalid class name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._cmdb_instance_url("INVALID-CLASS!")
+
+    def test_cmdb_meta_url_rejects_invalid_name(self, settings, auth_provider):
+        """_cmdb_meta_url raises ValueError for invalid class name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._cmdb_meta_url("bad class")
+
+    def test_table_description_url_rejects_invalid_name(self, settings, auth_provider):
+        """_table_description_url raises ValueError for invalid table name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._table_description_url("bad-table")
+
+    def test_field_descriptions_url_rejects_invalid_name(self, settings, auth_provider):
+        """_field_descriptions_url raises ValueError for invalid table name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            client._field_descriptions_url("bad.table")
+
+    def test_table_url_accepts_valid_name(self, settings, auth_provider):
+        """_table_url accepts valid snake_case table names."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        url = client._table_url("incident")
+        assert "incident" in url

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,7 +28,7 @@ class TestSettings:
 
         assert settings.servicenow_instance_url == "https://test.service-now.com"
         assert settings.servicenow_username == "admin"
-        assert settings.servicenow_password == "password123"
+        assert settings.servicenow_password.get_secret_value() == "password123"
 
     def test_missing_instance_url_raises(self):
         """Missing SERVICENOW_INSTANCE_URL raises validation error."""
@@ -126,7 +126,7 @@ class TestSettings:
         with patch.dict("os.environ", env, clear=True):
             settings = Settings(_env_file=None)
 
-        assert settings.large_table_names == ["table_a", "table_b", "table_c"]
+        assert settings.large_table_names == frozenset({"table_a", "table_b", "table_c"})
 
     def test_instance_url_trailing_slash_stripped(self):
         """Trailing slash is stripped from instance URL."""
@@ -157,3 +157,80 @@ class TestSettings:
             settings = Settings(_env_file=None)
 
         assert settings.is_production is False
+
+    def test_is_production_with_production_string(self):
+        """is_production returns True when env is 'production'."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env(SERVICENOW_ENV="production")
+        with patch.dict("os.environ", env, clear=True):
+            settings = Settings(_env_file=None)
+
+        assert settings.is_production is True
+
+    def test_is_production_case_insensitive(self):
+        """is_production returns True for case-insensitive 'PROD'."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env(SERVICENOW_ENV="PROD")
+        with patch.dict("os.environ", env, clear=True):
+            settings = Settings(_env_file=None)
+
+        assert settings.is_production is True
+
+    def test_invalid_url_scheme_rejected(self):
+        """Instance URL without https:// scheme is rejected."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env(SERVICENOW_INSTANCE_URL="http://test.service-now.com")
+        with patch.dict("os.environ", env, clear=True), pytest.raises(ValueError, match="https://"):
+            Settings(_env_file=None)
+
+    def test_max_row_limit_too_low_rejected(self):
+        """max_row_limit below 1 is rejected."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env(MAX_ROW_LIMIT="0")
+        with patch.dict("os.environ", env, clear=True), pytest.raises(ValueError, match="between 1 and 10000"):
+            Settings(_env_file=None)
+
+    def test_max_row_limit_too_high_rejected(self):
+        """max_row_limit above 10000 is rejected."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env(MAX_ROW_LIMIT="99999")
+        with patch.dict("os.environ", env, clear=True), pytest.raises(ValueError, match="between 1 and 10000"):
+            Settings(_env_file=None)
+
+    def test_invalid_tool_package_rejected(self):
+        """Unknown mcp_tool_package is rejected."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env(MCP_TOOL_PACKAGE="foo")
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises(ValueError, match="mcp_tool_package must be one of"),
+        ):
+            Settings(_env_file=None)
+
+    def test_large_table_names_is_frozenset(self):
+        """large_table_names returns a frozenset."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env()
+        with patch.dict("os.environ", env, clear=True):
+            settings = Settings(_env_file=None)
+
+        assert isinstance(settings.large_table_names, frozenset)
+
+    def test_large_table_names_cached(self):
+        """large_table_names returns the same cached object on repeated access."""
+        from servicenow_mcp.config import Settings
+
+        env = self._make_env()
+        with patch.dict("os.environ", env, clear=True):
+            settings = Settings(_env_file=None)
+
+        first = settings.large_table_names
+        second = settings.large_table_names
+        assert first is second

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -733,3 +733,103 @@ class TestSensitiveFieldMasking:
         assert result["data"]["new_value"] == "***MASKED***"
         # Name should still be visible
         assert result["data"]["name"] == "my.api_key_token"
+
+
+# ── Coverage: generic exception handlers ──────────────────────────────────
+
+
+class TestDevToggleGenericException:
+    """Tests for dev_toggle generic exception handler (lines 82-83)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unexpected_exception(self, settings, auth_provider):
+        """dev_toggle returns error envelope when an unexpected exception occurs."""
+        from unittest.mock import AsyncMock, patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        with patch(
+            "servicenow_mcp.tools.developer.ServiceNowClient.__aenter__",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("connection failed"),
+        ):
+            raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "connection failed" in result["error"]
+
+
+class TestDevSetPropertyGenericException:
+    """Tests for dev_set_property generic exception handler (lines 154-155)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unexpected_exception(self, settings, auth_provider):
+        """dev_set_property returns error envelope when an unexpected exception occurs."""
+        from unittest.mock import AsyncMock, patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        with patch(
+            "servicenow_mcp.tools.developer.ServiceNowClient.__aenter__",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("network failure"),
+        ):
+            raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "network failure" in result["error"]
+
+
+class TestDevCleanupGenericException:
+    """Tests for dev_cleanup generic exception handler (lines 322-323)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unexpected_exception(self, settings, auth_provider):
+        """dev_cleanup returns error envelope when an unexpected exception occurs."""
+        from unittest.mock import patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        # Patch SeededRecordTracker.get to raise an unexpected exception
+        with patch(
+            "servicenow_mcp.state.SeededRecordTracker.get",
+            side_effect=RuntimeError("tracker exploded"),
+        ):
+            raw = await tools["dev_cleanup"](tag="test-tag")
+
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "tracker exploded" in result["error"]
+
+
+class TestTablePreviewUpdateSensitiveField:
+    """Tests for table_preview_update with sensitive field (line 368)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sensitive_field_masked_in_diff(self, settings, auth_provider):
+        """Diff masks both old and new values for sensitive fields like 'password'."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_user/u001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "u001",
+                        "user_name": "admin",
+                        "password": "old_secret",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        changes_json = json.dumps({"password": "new_secret"})
+        raw = await tools["table_preview_update"](table="sys_user", sys_id="u001", changes=changes_json)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        diff = result["data"]["diff"]
+        assert "password" in diff
+        assert diff["password"]["old"] == "***MASKED***"
+        assert diff["password"]["new"] == "***MASKED***"

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -517,3 +517,219 @@ class TestDeveloperErrorHandling:
         retry_result = json.loads(retry_raw)
         assert retry_result["status"] == "success"
         assert retry_result["data"]["deleted_count"] == 1
+
+
+# ── Security: write gating & table access ────────────────────────────────
+
+
+class TestDevCleanupWriteGate:
+    """Tests for write-gate enforcement on dev_cleanup."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dev_cleanup_blocked_in_production(self, prod_settings):
+        """Cleanup returns error when environment is production."""
+        from unittest.mock import patch as mock_patch
+
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.developer import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        # Patch SeededRecordTracker.get to return a fake entry so the tag lookup succeeds
+        with mock_patch(
+            "servicenow_mcp.state.SeededRecordTracker.get",
+            return_value=[{"table": "incident", "sys_ids": ["rec1"]}],
+        ):
+            raw = await tools["dev_cleanup"](tag="test-tag")
+
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "blocked" in result["error"].lower() or "production" in result["error"].lower()
+
+
+class TestTableApplyUpdateSecurity:
+    """Tests for write-gate and table-access enforcement on table_apply_update."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_table_apply_update_blocked_in_production(self, prod_settings):
+        """Apply returns error when environment is production."""
+        from unittest.mock import patch as mock_patch
+
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.developer import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        # Patch the preview store to return a valid payload
+        with mock_patch(
+            "servicenow_mcp.state.PreviewTokenStore.consume",
+            return_value={"table": "incident", "sys_id": "inc001", "changes": {"state": "2"}},
+        ):
+            raw = await tools["table_apply_update"](preview_token="fake-token")
+
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "blocked" in result["error"].lower() or "production" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_table_apply_update_denied_table(self, settings, auth_provider):
+        """Apply returns error when token references a denied table."""
+        from unittest.mock import patch as mock_patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        # Patch the preview store to return a payload with a denied table
+        with mock_patch(
+            "servicenow_mcp.state.PreviewTokenStore.consume",
+            return_value={"table": "sys_user_has_password", "sys_id": "x", "changes": {"value": "y"}},
+        ):
+            raw = await tools["table_apply_update"](preview_token="fake-token")
+
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "denied" in result["error"].lower()
+
+
+class TestTablePreviewUpdateSecurity:
+    """Tests for table-access enforcement on table_preview_update."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_table_preview_update_denied_table(self, settings, auth_provider):
+        """Preview returns error when table is on the deny list."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["table_preview_update"](
+            table="sys_user_has_password",
+            sys_id="x",
+            changes=json.dumps({"value": "y"}),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "denied" in result["error"].lower()
+
+
+class TestDevSeedTestDataSecurity:
+    """Tests for table-access enforcement on dev_seed_test_data."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dev_seed_test_data_denied_table(self, settings, auth_provider):
+        """Seed returns error when table is on the deny list."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_seed_test_data"](
+            table="sys_user_has_password",
+            records=json.dumps([{"value": "test"}]),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "denied" in result["error"].lower()
+
+
+# ── Security: sensitive field masking ─────────────────────────────────────
+
+
+class TestSensitiveFieldMasking:
+    """Tests for sensitive field masking in developer tool responses."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_table_apply_update_masks_sensitive_fields(self, settings, auth_provider):
+        """Apply update masks sensitive fields like 'password' in the returned record."""
+        # Step 1: Create a preview
+        respx.get(f"{BASE_URL}/api/now/table/sys_user/u001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "u001",
+                        "user_name": "admin",
+                        "password": "old_secret",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["table_preview_update"](
+            table="sys_user",
+            sys_id="u001",
+            changes=json.dumps({"user_name": "new_admin"}),
+        )
+        preview_result = json.loads(preview_raw)
+        token = preview_result["data"]["token"]
+
+        # Step 2: Apply — response includes a password field
+        respx.patch(f"{BASE_URL}/api/now/table/sys_user/u001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "u001",
+                        "user_name": "new_admin",
+                        "password": "still_secret",
+                    }
+                },
+            )
+        )
+
+        raw = await tools["table_apply_update"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["record"]["user_name"] == "new_admin"
+        assert result["data"]["record"]["password"] == "***MASKED***"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dev_set_property_masks_sensitive_value(self, settings, auth_provider):
+        """Setting a property with a sensitive name masks old/new values in response."""
+        # Mock query to find the property
+        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "prop002",
+                            "name": "my.api_key_token",
+                            "value": "old_secret_key",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        # Mock PATCH to update value
+        respx.patch(f"{BASE_URL}/api/now/table/sys_properties/prop002").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "prop002",
+                        "name": "my.api_key_token",
+                        "value": "new_secret_key",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_set_property"](name="my.api_key_token", value="new_secret_key")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["old_value"] == "***MASKED***"
+        assert result["data"]["new_value"] == "***MASKED***"
+        # Name should still be visible
+        assert result["data"]["name"] == "my.api_key_token"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -183,6 +183,47 @@ class TestDocsArtifactSummary:
 
         assert result["status"] == "error"
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_masks_sensitive_fields(self, settings, auth_provider):
+        """Sensitive fields in the artifact record are masked in the response."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_sensitive").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "br_sensitive",
+                        "name": "Sensitive BR",
+                        "script": "gs.log('hello');",
+                        "collection": "incident",
+                        "active": "true",
+                        "password": "super_secret_123",
+                        "auth_token": "tok_abc",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/sn_codesearch/code_search/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"search_results": []}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="br_sensitive")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        artifact = result["data"]["artifact"]
+        # Non-sensitive fields should be present
+        assert artifact["name"] == "Sensitive BR"
+        assert artifact["script"] == "gs.log('hello');"
+        # Sensitive fields should be masked
+        assert artifact["password"] != "super_secret_123"
+        assert artifact["password"] == "***MASKED***"
+        assert artifact["auth_token"] == "***MASKED***"
+
 
 # ── docs_test_scenarios ───────────────────────────────────────────────────
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,154 @@
+"""Tests for the custom exception hierarchy."""
+
+from servicenow_mcp.errors import (
+    AuthError,
+    ForbiddenError,
+    NotFoundError,
+    PolicyError,
+    QuerySafetyError,
+    ServerError,
+    ServiceNowMCPError,
+)
+
+
+class TestBaseError:
+    """Tests for ServiceNowMCPError base class."""
+
+    def test_base_error(self) -> None:
+        """ServiceNowMCPError stores message and status_code correctly."""
+        err = ServiceNowMCPError("something broke", status_code=418)
+        assert str(err) == "something broke"
+        assert err.status_code == 418
+
+    def test_base_error_default_status_code(self) -> None:
+        """ServiceNowMCPError defaults status_code to None."""
+        err = ServiceNowMCPError("oops")
+        assert str(err) == "oops"
+        assert err.status_code is None
+
+
+class TestHTTPErrors:
+    """Tests for HTTP-mapped error subclasses."""
+
+    def test_auth_error_defaults(self) -> None:
+        """AuthError has status_code=401 and default message."""
+        err = AuthError()
+        assert err.status_code == 401
+        assert str(err) == "Authentication failed"
+
+    def test_forbidden_error_defaults(self) -> None:
+        """ForbiddenError has status_code=403 and default message."""
+        err = ForbiddenError()
+        assert err.status_code == 403
+        assert str(err) == "Access forbidden"
+
+    def test_not_found_error_defaults(self) -> None:
+        """NotFoundError has status_code=404 and default message."""
+        err = NotFoundError()
+        assert err.status_code == 404
+        assert str(err) == "Resource not found"
+
+    def test_server_error_defaults(self) -> None:
+        """ServerError has status_code=500 and default message."""
+        err = ServerError()
+        assert err.status_code == 500
+        assert str(err) == "Internal server error"
+
+    def test_server_error_custom_status(self) -> None:
+        """ServerError accepts a custom status_code for other 5xx errors."""
+        err = ServerError("Bad gateway", status_code=502)
+        assert err.status_code == 502
+        assert str(err) == "Bad gateway"
+
+
+class TestPolicyErrors:
+    """Tests for policy error subclasses."""
+
+    def test_policy_error_status_code(self) -> None:
+        """PolicyError has status_code=403."""
+        err = PolicyError()
+        assert err.status_code == 403
+        assert str(err) == "Policy violation"
+
+    def test_query_safety_error_status_code(self) -> None:
+        """QuerySafetyError has status_code=403."""
+        err = QuerySafetyError()
+        assert err.status_code == 403
+        assert str(err) == "Query safety violation"
+
+
+class TestErrorHierarchy:
+    """Tests for isinstance relationships in the error hierarchy."""
+
+    def test_auth_error_is_servicenow_mcp_error(self) -> None:
+        """AuthError is a ServiceNowMCPError."""
+        assert isinstance(AuthError(), ServiceNowMCPError)
+
+    def test_forbidden_error_is_servicenow_mcp_error(self) -> None:
+        """ForbiddenError is a ServiceNowMCPError."""
+        assert isinstance(ForbiddenError(), ServiceNowMCPError)
+
+    def test_not_found_error_is_servicenow_mcp_error(self) -> None:
+        """NotFoundError is a ServiceNowMCPError."""
+        assert isinstance(NotFoundError(), ServiceNowMCPError)
+
+    def test_server_error_is_servicenow_mcp_error(self) -> None:
+        """ServerError is a ServiceNowMCPError."""
+        assert isinstance(ServerError(), ServiceNowMCPError)
+
+    def test_policy_error_is_servicenow_mcp_error(self) -> None:
+        """PolicyError is a ServiceNowMCPError."""
+        assert isinstance(PolicyError(), ServiceNowMCPError)
+
+    def test_query_safety_error_is_policy_error(self) -> None:
+        """QuerySafetyError is a PolicyError."""
+        assert isinstance(QuerySafetyError(), PolicyError)
+
+    def test_query_safety_error_is_servicenow_mcp_error(self) -> None:
+        """QuerySafetyError is a ServiceNowMCPError."""
+        assert isinstance(QuerySafetyError(), ServiceNowMCPError)
+
+    def test_all_errors_are_exceptions(self) -> None:
+        """All error classes are Exception subclasses."""
+        for cls in (AuthError, ForbiddenError, NotFoundError, ServerError, PolicyError, QuerySafetyError):
+            assert isinstance(cls(), Exception)
+
+
+class TestCustomMessages:
+    """Tests that all errors accept custom messages."""
+
+    def test_auth_error_custom_message(self) -> None:
+        """AuthError accepts a custom message."""
+        err = AuthError("token expired")
+        assert str(err) == "token expired"
+        assert err.status_code == 401
+
+    def test_forbidden_error_custom_message(self) -> None:
+        """ForbiddenError accepts a custom message."""
+        err = ForbiddenError("insufficient scope")
+        assert str(err) == "insufficient scope"
+        assert err.status_code == 403
+
+    def test_not_found_error_custom_message(self) -> None:
+        """NotFoundError accepts a custom message."""
+        err = NotFoundError("record does not exist")
+        assert str(err) == "record does not exist"
+        assert err.status_code == 404
+
+    def test_server_error_custom_message(self) -> None:
+        """ServerError accepts a custom message."""
+        err = ServerError("service unavailable")
+        assert str(err) == "service unavailable"
+        assert err.status_code == 500
+
+    def test_policy_error_custom_message(self) -> None:
+        """PolicyError accepts a custom message."""
+        err = PolicyError("table denied")
+        assert str(err) == "table denied"
+        assert err.status_code == 403
+
+    def test_query_safety_error_custom_message(self) -> None:
+        """QuerySafetyError accepts a custom message."""
+        err = QuerySafetyError("missing date filter")
+        assert str(err) == "missing date filter"
+        assert err.status_code == 403

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -1462,3 +1462,447 @@ class TestPerformanceBottlenecksElseBranch:
 
         assert result["status"] == "error"
         assert "denied" in result["error"].lower()
+
+
+# ── Direct module tests for coverage gaps ─────────────────────────────────
+
+
+class TestPerformanceBottlenecksCoverage:
+    """Tests for performance_bottlenecks coverage gaps: invalid params and non-empty loop bodies."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_params_and_nonempty_records(self, settings, auth_provider):
+        """Invalid limit/hours fall back to defaults; non-empty sysauto_script and flow_context records hit loop bodies."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import performance_bottlenecks
+
+        # Active BRs — empty (no heavy automation findings)
+        respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        # Scheduled jobs — non-empty (hits lines 78-79)
+        respx.get(f"{BASE_URL}/api/now/table/sysauto_script").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc",
+                            "name": "test_job",
+                            "run_type": "daily",
+                            "run_dayofweek": "1",
+                            "sys_updated_on": "2026-02-20 10:00:00",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        # Flow contexts — non-empty (hits lines 100-101)
+        respx.get(f"{BASE_URL}/api/now/table/flow_context").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "flow1",
+                            "name": "Running Flow",
+                            "state": "IN_PROGRESS",
+                            "sys_created_on": "2026-02-20 08:00:00",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await performance_bottlenecks.run(
+                client,
+                {"limit": "not_a_number", "hours": "bad", "table": "incident"},
+            )
+
+        # Invalid limit falls back to 20 (lines 27-28)
+        assert result["params"]["limit"] == 20
+        # Invalid hours falls back to 24 (lines 34-35)
+        assert result["params"]["hours"] == 24
+        # Should have findings from both sysauto_script and flow_context loops
+        categories = [f["category"] for f in result["findings"]]
+        assert "frequent_job" in categories
+        assert "long_running_flow" in categories
+
+
+class TestStaleAutomationsCoverage:
+    """Tests for stale_automations coverage gaps: invalid params and non-empty loop bodies."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_params_and_nonempty_records(self, settings, auth_provider):
+        """Invalid stale_days/limit fall back to defaults; non-empty records hit loop bodies."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import stale_automations
+
+        # Stuck flows — empty
+        respx.get(f"{BASE_URL}/api/now/table/flow_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        # Disabled BRs — non-empty (hits lines 64-65)
+        respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "br001",
+                            "name": "Disabled BR",
+                            "collection": "incident",
+                            "sys_updated_on": "2026-01-01 00:00:00",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        # Disabled script includes — non-empty (hits lines 83-84)
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_include").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "si001",
+                            "name": "OldHelper",
+                            "api_name": "global.OldHelper",
+                            "sys_updated_on": "2026-01-01 00:00:00",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        # Stale scheduled jobs — non-empty (hits lines 102-103)
+        respx.get(f"{BASE_URL}/api/now/table/sysauto_script").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "sj001",
+                            "name": "Stale Job",
+                            "run_type": "daily",
+                            "last_run": "2025-01-01 00:00:00",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await stale_automations.run(
+                client,
+                {"stale_days": "bad", "limit": "bad", "table": "incident"},
+            )
+
+        # Invalid stale_days falls back to 30 (lines 27-28)
+        assert result["params"]["stale_days"] == 30
+        # Invalid limit falls back to 20 (lines 31-32)
+        assert result["params"]["limit"] == 20
+        # Non-empty loop bodies produce findings
+        categories = [f["category"] for f in result["findings"]]
+        assert "disabled_business_rule" in categories
+        assert "disabled_script_include" in categories
+        assert "stale_scheduled_job" in categories
+
+
+class TestErrorAnalysisCoverage:
+    """Tests for error_analysis coverage gaps: invalid params and source filter."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_hours_and_limit(self, settings, auth_provider):
+        """Invalid hours/limit fall back to defaults."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import error_analysis
+
+        respx.get(f"{BASE_URL}/api/now/table/syslog").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await error_analysis.run(client, {"hours": "bad", "limit": "bad"})
+
+        # Invalid hours falls back to 24 (lines 24-25)
+        assert result["params"]["hours"] == 24
+        # Invalid limit falls back to 100 (lines 29-30)
+        assert result["params"]["limit"] == 100
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_source_filter(self, settings, auth_provider):
+        """Source filter triggers the .like() branch (line 36)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import error_analysis
+
+        respx.get(f"{BASE_URL}/api/now/table/syslog").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await error_analysis.run(client, {"source": "my_source"})
+
+        assert result["params"]["source"] == "my_source"
+        assert result["investigation"] == "error_analysis"
+
+
+class TestDeprecatedApisCoverage:
+    """Tests for deprecated_apis coverage gaps: invalid limit and code_search exception."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_limit(self, settings, auth_provider):
+        """Invalid limit falls back to default 20."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import deprecated_apis
+
+        respx.get(f"{BASE_URL}/api/sn_codesearch/code_search/search").mock(
+            return_value=httpx.Response(200, json={"result": {"search_results": []}})
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await deprecated_apis.run(client, {"limit": "bad"})
+
+        # Invalid limit falls back to 20 (lines 38-39)
+        assert result["params"]["limit"] == 20
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_code_search_exception_skips_pattern(self, settings, auth_provider):
+        """When code_search raises for one pattern, it's skipped (lines 56-58)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import deprecated_apis
+
+        call_count = 0
+
+        def side_effect(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First pattern raises an error
+                return httpx.Response(500, json={"error": {"message": "Server Error"}})
+            return httpx.Response(200, json={"result": {"search_results": []}})
+
+        respx.get(f"{BASE_URL}/api/sn_codesearch/code_search/search").mock(side_effect=side_effect)
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await deprecated_apis.run(client, {})
+
+        # Should complete without error, skipping the failed pattern
+        assert result["investigation"] == "deprecated_apis"
+        assert "patterns_searched" in result
+
+
+class TestSlowTransactionsCoverage:
+    """Tests for slow_transactions coverage gaps."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_hours_and_limit(self, settings, auth_provider):
+        """Invalid hours/limit fall back to defaults (lines 36-37, 40-41)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import slow_transactions
+
+        for table in [
+            "sys_query_pattern",
+            "sys_transaction_pattern",
+            "sys_script_pattern",
+            "sys_mutex_pattern",
+            "sysevent_pattern",
+            "sys_interaction_pattern",
+            "syslog_cancellation",
+        ]:
+            respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
+                return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+            )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await slow_transactions.run(client, {"hours": "bad", "limit": "bad"})
+
+        assert result["params"]["hours"] == 24
+        assert result["params"]["limit"] == 20
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_categories_filter(self, settings, auth_provider):
+        """Category filter skips non-matching tables (lines 45, 51)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import slow_transactions
+
+        # Only mock the table that matches the category filter
+        respx.get(f"{BASE_URL}/api/now/table/sys_query_pattern").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await slow_transactions.run(client, {"categories": "slow_query"})
+
+        assert result["params"]["categories"] == "slow_query"
+        # Only one table should have been queried (the rest skipped)
+        assert result["investigation"] == "slow_transactions"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_query_records_exception_skips_table(self, settings, auth_provider):
+        """When query_records raises for a table, it's skipped (lines 84-86)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import slow_transactions
+
+        # First table errors, rest succeed with empty
+        respx.get(f"{BASE_URL}/api/now/table/sys_query_pattern").mock(
+            return_value=httpx.Response(500, json={"error": {"message": "Server Error"}})
+        )
+        for table in [
+            "sys_transaction_pattern",
+            "sys_script_pattern",
+            "sys_mutex_pattern",
+            "sysevent_pattern",
+            "sys_interaction_pattern",
+            "syslog_cancellation",
+        ]:
+            respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
+                return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+            )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await slow_transactions.run(client, {})
+
+        # Should complete without error despite one table failing
+        assert result["investigation"] == "slow_transactions"
+
+
+class TestTableHealthCoverage:
+    """Tests for table_health coverage gaps."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_missing_table_param(self, settings, auth_provider):
+        """Missing table param returns error (line 23)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import table_health
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await table_health.run(client, {})
+
+        assert result["error"] == "Missing required parameter: table"
+        assert result["finding_count"] == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_hours_param(self, settings, auth_provider):
+        """Invalid hours falls back to 24 (lines 38-39)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import table_health
+
+        # Aggregate count
+        respx.get(f"{BASE_URL}/api/now/stats/incident").mock(
+            return_value=httpx.Response(200, json={"result": {"stats": {"count": "10"}}})
+        )
+        for tbl in ["sys_script", "sys_script_client", "sys_security_acl", "sys_ui_policy", "syslog"]:
+            respx.get(f"{BASE_URL}/api/now/table/{tbl}").mock(
+                return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+            )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await table_health.run(client, {"table": "incident", "hours": "bad"})
+
+        assert result["hours"] == 24
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_health_indicators_thresholds(self, settings, auth_provider):
+        """Triggers all health indicator thresholds (lines 101, 103, 105)."""
+        from servicenow_mcp.auth import BasicAuthProvider
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.investigations import table_health
+
+        # Aggregate count
+        respx.get(f"{BASE_URL}/api/now/stats/incident").mock(
+            return_value=httpx.Response(200, json={"result": {"stats": {"count": "500"}}})
+        )
+        # >10 business rules (hits line 101)
+        respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [{"sys_id": f"br{i}", "name": f"BR {i}", "when": "before"} for i in range(12)]},
+                headers={"X-Total-Count": "12"},
+            )
+        )
+        # Client scripts — empty
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_client").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        # >20 ACLs (hits line 103)
+        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [{"sys_id": f"acl{i}", "name": "incident.*.read", "operation": "read"} for i in range(22)]
+                },
+                headers={"X-Total-Count": "22"},
+            )
+        )
+        # UI policies — empty
+        respx.get(f"{BASE_URL}/api/now/table/sys_ui_policy").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        # >=1 syslog error (hits line 105)
+        respx.get(f"{BASE_URL}/api/now/table/syslog").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "log1",
+                            "message": "Error",
+                            "source": "incident",
+                            "sys_created_on": "2026-02-20 10:00:00",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        auth = BasicAuthProvider(settings)
+        async with ServiceNowClient(settings, auth) as client:
+            result = await table_health.run(client, {"table": "incident"})
+
+        # All three thresholds should be triggered
+        assert len(result["health_indicators"]) == 3
+        indicators_text = " ".join(result["health_indicators"])
+        assert "business rule" in indicators_text.lower()
+        assert "acl" in indicators_text.lower()
+        assert "errors" in indicators_text.lower()

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -323,7 +323,7 @@ class TestTableHealth:
         # ACLs — query now includes exact name match OR field-level prefix
         respx.get(
             f"{BASE_URL}/api/now/table/sys_security_acl",
-            params__contains={"sysparm_query": "name=incident^ORnameSTARTSWITHincident."},
+            params__contains={"sysparm_query": "name=incident^^ORnameSTARTSWITHincident."},
         ).mock(
             return_value=httpx.Response(
                 200,
@@ -406,7 +406,7 @@ class TestAclConflicts:
         """Detects two ACLs with the same name but different conditions."""
         respx.get(
             f"{BASE_URL}/api/now/table/sys_security_acl",
-            params__contains={"sysparm_query": "name=incident^ORnameSTARTSWITHincident."},
+            params__contains={"sysparm_query": "name=incident^^ORnameSTARTSWITHincident."},
         ).mock(
             return_value=httpx.Response(
                 200,
@@ -447,7 +447,7 @@ class TestAclConflicts:
         """Unique ACL names produce no conflicts."""
         respx.get(
             f"{BASE_URL}/api/now/table/sys_security_acl",
-            params__contains={"sysparm_query": "name=incident^ORnameSTARTSWITHincident."},
+            params__contains={"sysparm_query": "name=incident^^ORnameSTARTSWITHincident."},
         ).mock(
             return_value=httpx.Response(
                 200,
@@ -1213,3 +1213,252 @@ class TestExplainSecurityRestrictions:
 
         assert result["status"] == "error"
         assert "Invalid identifier" in result["error"]
+
+
+# ── WP5: element_id split guard tests ────────────────────────────────────
+
+
+class TestExplainElementIdSplitGuard:
+    """Tests that explain() returns an error dict for element_ids with no colon."""
+
+    @pytest.mark.asyncio
+    async def test_deprecated_apis_no_colon(self, settings, auth_provider):
+        """deprecated_apis explain() returns error for element_id without colon."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="deprecated_apis",
+            element_id="invalid_no_colon",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "error" in result["data"]
+        assert "expected 'table:sys_id'" in result["data"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_error_analysis_no_colon(self, settings, auth_provider):
+        """error_analysis explain() returns error for element_id without colon."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="error_analysis",
+            element_id="invalid_no_colon",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "error" in result["data"]
+        assert "expected 'table:sys_id'" in result["data"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_slow_transactions_no_colon(self, settings, auth_provider):
+        """slow_transactions explain() returns error for element_id without colon."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="slow_transactions",
+            element_id="invalid_no_colon",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "error" in result["data"]
+        assert "expected 'table:sys_id'" in result["data"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_stale_automations_no_colon(self, settings, auth_provider):
+        """stale_automations explain() returns error for element_id without colon."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="stale_automations",
+            element_id="invalid_no_colon",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "error" in result["data"]
+        assert "expected 'table:sys_id'" in result["data"]["error"]
+
+
+# ── WP5: Type coercion tests ─────────────────────────────────────────────
+
+
+class TestTypeCoercion:
+    """Tests that numeric params passed as strings are properly coerced."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_slow_transactions_string_limit(self, settings, auth_provider):
+        """slow_transactions run() accepts limit as a string."""
+        for table in [
+            "sys_query_pattern",
+            "sys_transaction_pattern",
+            "sys_script_pattern",
+            "sys_mutex_pattern",
+            "sysevent_pattern",
+            "sys_interaction_pattern",
+            "syslog_cancellation",
+        ]:
+            respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
+                return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+            )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_run"](
+            investigation="slow_transactions",
+            params='{"limit": "50"}',
+        )
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["params"]["limit"] == 50
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_stale_automations_string_stale_days(self, settings, auth_provider):
+        """stale_automations run() accepts stale_days as a string."""
+        for table in ["flow_context", "sys_script", "sys_script_include", "sysauto_script"]:
+            respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
+                return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+            )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_run"](
+            investigation="stale_automations",
+            params='{"stale_days": "30", "limit": "10"}',
+        )
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["params"]["stale_days"] == 30
+        assert result["data"]["params"]["limit"] == 10
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_performance_bottlenecks_string_hours_and_limit(self, settings, auth_provider):
+        """performance_bottlenecks run() accepts hours and limit as strings."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sysauto_script").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/flow_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_run"](
+            investigation="performance_bottlenecks",
+            params='{"hours": "12", "limit": "5"}',
+        )
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["params"]["hours"] == 12
+        assert result["data"]["params"]["limit"] == 5
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_table_health_string_hours(self, settings, auth_provider):
+        """table_health run() accepts hours as a string."""
+        respx.get(f"{BASE_URL}/api/now/stats/incident").mock(
+            return_value=httpx.Response(200, json={"result": {"stats": {"count": "100"}}})
+        )
+        for table in ["sys_script", "sys_script_client", "sys_security_acl", "sys_ui_policy", "syslog"]:
+            respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
+                return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+            )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_run"](
+            investigation="table_health",
+            params='{"table": "incident", "hours": "48"}',
+        )
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["hours"] == 48
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deprecated_apis_string_limit(self, settings, auth_provider):
+        """deprecated_apis run() accepts limit as a string."""
+        respx.get(f"{BASE_URL}/api/sn_codesearch/code_search/search").mock(
+            return_value=httpx.Response(200, json={"result": {"search_results": []}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_run"](
+            investigation="deprecated_apis",
+            params='{"limit": "50"}',
+        )
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["params"]["limit"] == 50
+
+
+# ── WP5: check_table_access test for error_analysis ──────────────────────
+
+
+class TestErrorAnalysisCheckTableAccess:
+    """Tests that error_analysis run() calls check_table_access."""
+
+    @pytest.mark.asyncio
+    async def test_check_table_access_propagates_through_dispatcher(self, settings, auth_provider):
+        """error_analysis run() propagates PolicyError through the dispatcher."""
+        from unittest.mock import patch
+
+        from servicenow_mcp.errors import PolicyError
+
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        with patch(
+            "servicenow_mcp.investigations.error_analysis.check_table_access",
+            side_effect=PolicyError("Access to table 'syslog' is denied by policy"),
+        ):
+            raw = await tools["investigate_run"](investigation="error_analysis")
+            result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "denied" in result["error"].lower()
+
+
+# ── WP5: validate_identifier + check_table_access for perf bottlenecks ───
+
+
+class TestPerformanceBottlenecksElseBranch:
+    """Tests for performance_bottlenecks explain() else-branch (table name only)."""
+
+    @pytest.mark.asyncio
+    async def test_explain_invalid_table_chars(self, settings, auth_provider):
+        """explain() with invalid chars in table name raises ValueError."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="performance_bottlenecks",
+            element_id="INVALID_TABLE",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "Invalid identifier" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_explain_special_chars_table(self, settings, auth_provider):
+        """explain() with special chars in table name (no colon) raises ValueError."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="performance_bottlenecks",
+            element_id="my-table!",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "Invalid identifier" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_explain_denied_table_else_branch(self, settings, auth_provider):
+        """explain() with a denied table name in the else-branch returns error."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["investigate_explain"](
+            investigation="performance_bottlenecks",
+            element_id="sys_user_token",
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "denied" in result["error"].lower()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -145,6 +145,33 @@ class TestMetaListArtifacts:
         assert "correlation_id" in result
         assert len(result["correlation_id"]) > 0
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_meta_list_artifacts_limit_capped(self, settings, auth_provider):
+        """Limit exceeding max_row_limit is capped via enforce_query_safety."""
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": []},
+                headers={"X-Total-Count": "0"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        # Pass limit=9999, which should be capped to settings.max_row_limit (default 100)
+        raw = await tools["meta_list_artifacts"](artifact_type="business_rule", limit=9999)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        # Verify the request used the capped limit, not the original 9999
+        request = route.calls[0].request
+        url_str = str(request.url)
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(url_str)
+        qs = parse_qs(parsed.query)
+        assert qs["sysparm_limit"] == [str(settings.max_row_limit)]
+
 
 class TestMetaGetArtifact:
     """Tests for the meta_get_artifact tool."""
@@ -290,6 +317,43 @@ class TestMetaFindReferences:
 
         assert result["status"] == "success"
         assert result["data"]["matches"] == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_meta_find_references_limit_capped(self, settings, auth_provider):
+        """Limit exceeding max_row_limit is capped in fallback per-table queries."""
+        # Code Search API fails → triggers fallback
+        respx.get(f"{BASE_URL}/api/sn_codesearch/code_search/search").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
+        )
+
+        routes: dict[str, respx.Route] = {}
+        for table in SCRIPT_TABLES:
+            routes[table] = respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"result": []},
+                    headers={"X-Total-Count": "0"},
+                )
+            )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        # Pass limit=9999, which should be capped to settings.max_row_limit (default 100)
+        raw = await tools["meta_find_references"](target="SomeTarget", limit=9999)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["search_method"] == "table_scan_fallback"
+
+        # Verify every fallback table query used the capped limit
+        from urllib.parse import parse_qs, urlparse
+
+        for table, route in routes.items():
+            assert route.called, f"Expected query to {table}"
+            request = route.calls[0].request
+            parsed = urlparse(str(request.url))
+            qs = parse_qs(parsed.query)
+            assert qs["sysparm_limit"] == [str(settings.max_row_limit)], f"Table '{table}' should have capped limit"
 
 
 class TestMetaWhatWrites:

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -89,3 +89,21 @@ class TestPackageRegistry:
         from servicenow_mcp.packages import PACKAGE_REGISTRY
 
         assert "dev_debug" not in PACKAGE_REGISTRY
+
+    def test_get_package_returns_copy(self):
+        """get_package returns a copy — mutating it does not affect the registry."""
+        from servicenow_mcp.packages import get_package
+
+        groups = get_package("full")
+        groups.append("should_not_persist")
+        fresh = get_package("full")
+        assert "should_not_persist" not in fresh
+
+    def test_list_packages_returns_copies(self):
+        """list_packages returns deep copies of value lists."""
+        from servicenow_mcp.packages import list_packages
+
+        packages = list_packages()
+        packages["full"].append("should_not_persist")
+        fresh = list_packages()
+        assert "should_not_persist" not in fresh["full"]

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,5 +1,7 @@
 """Tests for policy engine."""
 
+import logging
+
 import pytest
 
 from servicenow_mcp.errors import PolicyError, QuerySafetyError
@@ -35,6 +37,20 @@ class TestDenyList:
 
         result = check_table_access("sys_script_include")
         assert result is None
+
+    def test_denied_table_case_insensitive(self):
+        """Denied table check is case-insensitive."""
+        from servicenow_mcp.policy import check_table_access
+
+        with pytest.raises(PolicyError, match="denied"):
+            check_table_access("SYS_USER_HAS_PASSWORD")
+
+    def test_denied_table_mixed_case(self):
+        """Denied table check handles mixed case."""
+        from servicenow_mcp.policy import check_table_access
+
+        with pytest.raises(PolicyError, match="denied"):
+            check_table_access("Oauth_Credential")
 
 
 class TestSensitiveFieldMasking:
@@ -223,6 +239,51 @@ class TestQuerySafety:
         result = enforce_query_safety("incident", "active=true", limit=50, settings=settings)
         assert result["limit"] == 50
 
+    def test_date_filter_bypass_substring_in_value(self, settings):
+        """Date field appearing only as a value (not a filter field) should not pass."""
+        from servicenow_mcp.policy import enforce_query_safety
+
+        with pytest.raises(QuerySafetyError, match="date"):
+            enforce_query_safety("syslog", "description=sys_created_on", limit=50, settings=settings)
+
+    def test_date_filter_with_operator_passes(self, settings):
+        """Date field with a comparison operator passes the check."""
+        from servicenow_mcp.policy import enforce_query_safety
+
+        result = enforce_query_safety(
+            "syslog",
+            "sys_created_on>=2024-01-01",
+            limit=50,
+            settings=settings,
+        )
+        assert result["limit"] == 50
+
+    def test_date_filter_with_gs_function_passes(self, settings):
+        """Date field with gs.*Ago function passes the check."""
+        from servicenow_mcp.policy import enforce_query_safety
+
+        result = enforce_query_safety(
+            "syslog",
+            "sys_created_on>=javascript:gs.hoursAgoStart(24)",
+            limit=50,
+            settings=settings,
+        )
+        assert result["limit"] == 50
+
+    def test_limit_zero_floored_to_one(self, settings):
+        """Limit of 0 is floored to 1."""
+        from servicenow_mcp.policy import enforce_query_safety
+
+        result = enforce_query_safety("incident", "active=true", limit=0, settings=settings)
+        assert result["limit"] == 1
+
+    def test_limit_negative_floored_to_one(self, settings):
+        """Negative limit is floored to 1."""
+        from servicenow_mcp.policy import enforce_query_safety
+
+        result = enforce_query_safety("incident", "active=true", limit=-5, settings=settings)
+        assert result["limit"] == 1
+
 
 class TestWriteGating:
     """Test write operation gating."""
@@ -250,3 +311,27 @@ class TestWriteGating:
         from servicenow_mcp.policy import can_write
 
         assert can_write("sys_user_has_password", settings) is False
+
+    def test_write_to_denied_table_case_insensitive(self, settings):
+        """Write deny-list check is case-insensitive."""
+        from servicenow_mcp.policy import can_write
+
+        assert can_write("SYS_USER_HAS_PASSWORD", settings) is False
+
+    def test_write_blocked_denied_table_logs_warning(self, settings, caplog):
+        """Write blocked by deny list logs a warning."""
+        from servicenow_mcp.policy import can_write
+
+        with caplog.at_level(logging.WARNING, logger="servicenow_mcp.policy"):
+            can_write("sys_user_has_password", settings)
+
+        assert any("deny list" in record.message for record in caplog.records)
+
+    def test_write_blocked_in_prod_logs_warning(self, prod_settings, caplog):
+        """Write blocked in production logs a warning."""
+        from servicenow_mcp.policy import can_write
+
+        with caplog.at_level(logging.WARNING, logger="servicenow_mcp.policy"):
+            can_write("incident", prod_settings)
+
+        assert any("production environment" in record.message for record in caplog.records)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from servicenow_mcp.state import PreviewTokenStore, SeededRecordTracker
 
 
@@ -96,6 +98,49 @@ class TestPreviewTokenStore:
             result_at_boundary = store.consume(token)
 
         assert result_at_boundary is not None
+
+    def test_store_max_size(self):
+        """create() raises RuntimeError when max_size is reached and no entries are expired."""
+        store = PreviewTokenStore(ttl_seconds=300, max_size=3)
+        store.create({"table": "incident"})
+        store.create({"table": "problem"})
+        store.create({"table": "change_request"})
+
+        with pytest.raises(RuntimeError, match="store is full"):
+            store.create({"table": "kb_knowledge"})
+
+    def test_sweep_expired_on_create(self):
+        """create() sweeps expired entries first, allowing new tokens when space is freed."""
+        fake_time = 1000.0
+        with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time):
+            store = PreviewTokenStore(ttl_seconds=60, max_size=2)
+            store.create({"table": "incident"})
+            store.create({"table": "problem"})
+
+        # Advance time past TTL — expired entries should be swept on next create()
+        with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time + 61):
+            token = store.create({"table": "change_request"})
+            result = store.get(token)
+
+        assert result is not None
+        assert result["table"] == "change_request"
+
+    def test_sweep_expired_frees_space(self):
+        """_sweep_expired() removes expired entries, reducing store size."""
+        fake_time = 1000.0
+        with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time):
+            store = PreviewTokenStore(ttl_seconds=60, max_size=10)
+            store.create({"table": "incident"})
+            store.create({"table": "problem"})
+            store.create({"table": "change_request"})
+
+        assert len(store._store) == 3
+
+        # Advance time past TTL and sweep
+        with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time + 61):
+            store._sweep_expired()
+
+        assert len(store._store) == 0
 
 
 class TestSeededRecordTracker:

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -240,3 +240,24 @@ class TestBuildQuery:
         assert result["status"] == "success"
         # The ^ in the value should be escaped to ^^
         assert result["data"]["query"] == "name=foo^^bar"
+
+    def test_hours_ago_missing_value_returns_error(self, settings, auth_provider):
+        """Time operator without value key returns error (line 96)."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = tools["build_query"](
+            conditions='[{"operator": "hours_ago", "field": "sys_created_on"}]',
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "requires an integer 'value'" in result["error"]
+
+    def test_unexpected_exception_returns_error(self, settings, auth_provider):
+        """Unexpected exception in ServiceNowQuery triggers generic handler (lines 155-156)."""
+        from unittest.mock import patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        with patch("servicenow_mcp.tools.utility.ServiceNowQuery", side_effect=RuntimeError("boom")):
+            raw = tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "boom" in result["error"]

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -131,3 +131,112 @@ class TestBuildQuery:
         result = json.loads(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "nameSTARTSWITHincident"
+
+    def test_or_equals_operator(self, settings, auth_provider):
+        """Test or_equals OR condition."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "equals", "field": "state", "value": "1"},
+                {"operator": "or_equals", "field": "state", "value": "2"},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["query"] == "state=1^^ORstate=2"
+
+    def test_or_starts_with_operator(self, settings, auth_provider):
+        """Test or_starts_with OR condition."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "starts_with", "field": "name", "value": "INC"},
+                {"operator": "or_starts_with", "field": "name", "value": "REQ"},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["query"] == "nameSTARTSWITHINC^^ORnameSTARTSWITHREQ"
+
+    def test_in_list_operator(self, settings, auth_provider):
+        """Test in_list operator with a list of values."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "in_list", "field": "state", "value": ["1", "2", "3"]},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["query"] == "stateIN1,2,3"
+
+    def test_not_in_list_operator(self, settings, auth_provider):
+        """Test not_in_list operator with a list of values."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "not_in_list", "field": "priority", "value": ["4", "5"]},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["query"] == "priorityNOT IN4,5"
+
+    def test_in_list_requires_list_value(self, settings, auth_provider):
+        """in_list with a non-list value returns an error."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "in_list", "field": "state", "value": "1"},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "list of strings" in result["error"]
+
+    def test_order_by_ascending(self, settings, auth_provider):
+        """Test order_by operator (ascending by default)."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "equals", "field": "active", "value": "true"},
+                {"operator": "order_by", "field": "sys_created_on"},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["query"] == "active=true^ORDERBYsys_created_on"
+
+    def test_order_by_descending(self, settings, auth_provider):
+        """Test order_by operator with descending=true."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "equals", "field": "active", "value": "true"},
+                {"operator": "order_by", "field": "sys_created_on", "descending": True},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        assert result["data"]["query"] == "active=true^ORDERBYDESCsys_created_on"
+
+    def test_value_injection_prevented(self, settings, auth_provider):
+        """Value containing ^ is escaped by the builder, preventing injection."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        conditions = json.dumps(
+            [
+                {"operator": "equals", "field": "name", "value": "foo^bar"},
+            ]
+        )
+        raw = tools["build_query"](conditions=conditions)
+        result = json.loads(raw)
+        assert result["status"] == "success"
+        # The ^ in the value should be escaped to ^^
+        assert result["data"]["query"] == "name=foo^^bar"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 """Tests for utility functions."""
 
 import uuid
+import warnings
+
+import pytest
 
 
 class TestCorrelationId:
@@ -80,13 +83,17 @@ class TestBuildEncodedQuery:
     def test_single_condition(self):
         from servicenow_mcp.utils import build_encoded_query
 
-        query = build_encoded_query({"active": "true"})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            query = build_encoded_query({"active": "true"})
         assert query == "active=true"
 
     def test_multiple_conditions(self):
         from servicenow_mcp.utils import build_encoded_query
 
-        query = build_encoded_query({"active": "true", "priority": "1"})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            query = build_encoded_query({"active": "true", "priority": "1"})
         assert "active=true" in query
         assert "priority=1" in query
         assert "^" in query
@@ -94,15 +101,37 @@ class TestBuildEncodedQuery:
     def test_empty_dict(self):
         from servicenow_mcp.utils import build_encoded_query
 
-        query = build_encoded_query({})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            query = build_encoded_query({})
         assert query == ""
 
     def test_passthrough_string(self):
         """If given a string, return it unchanged."""
         from servicenow_mcp.utils import build_encoded_query
 
-        query = build_encoded_query("active=true^priority=1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            query = build_encoded_query("active=true^priority=1")
         assert query == "active=true^priority=1"
+
+    def test_deprecation_warning(self):
+        """Calling build_encoded_query emits a DeprecationWarning."""
+        from servicenow_mcp.utils import build_encoded_query
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            build_encoded_query({"active": "true"})
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_value_sanitization(self):
+        """Dict values containing ^ are sanitized."""
+        from servicenow_mcp.utils import build_encoded_query
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            query = build_encoded_query({"description": "a^b"})
+        assert query == "description=a^^b"
 
 
 class TestServiceNowQuery:
@@ -217,3 +246,313 @@ class TestServiceNowQuery:
 
         q = ServiceNowQuery().equals("active", "true").equals("state", "1")
         assert str(q) == q.build()
+
+
+class TestServiceNowQueryValidation:
+    """Test that field-name validation and value sanitization work correctly."""
+
+    def test_invalid_field_name_raises(self):
+        """Field names with invalid characters are rejected."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().equals("DROP TABLE", "1")
+
+    def test_invalid_field_uppercase_raises(self):
+        """Uppercase field names are rejected."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().equals("Priority", "1")
+
+    def test_invalid_field_special_chars_raises(self):
+        """Special characters in field names are rejected."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().contains("field;evil", "val")
+
+    def test_invalid_field_in_is_empty(self):
+        """Null operators also validate field names."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().is_empty("bad-field")
+
+    def test_invalid_field_in_is_not_empty(self):
+        """is_not_empty validates field names."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().is_not_empty("bad.field")
+
+    def test_caret_in_value_gets_escaped(self):
+        """A caret in a value should be doubled."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("description", "a^b").build()
+        assert result == "description=a^^b"
+
+    def test_caret_in_contains_value(self):
+        """Value sanitization works in contains()."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().contains("script", "x^y").build()
+        assert result == "scriptCONTAINSx^^y"
+
+    def test_caret_in_less_than_value(self):
+        """Value sanitization works in less_than()."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().less_than("field", "a^b").build()
+        assert result == "field<a^^b"
+
+    def test_all_comparison_methods_validate_field(self):
+        """Every comparison method rejects invalid field names."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        methods_with_value = [
+            "equals",
+            "not_equals",
+            "greater_than",
+            "greater_or_equal",
+            "less_than",
+            "less_or_equal",
+            "contains",
+            "starts_with",
+            "like",
+        ]
+        for method_name in methods_with_value:
+            with pytest.raises(ValueError, match="Invalid identifier"):
+                getattr(ServiceNowQuery(), method_name)("BAD!", "val")
+
+
+class TestServiceNowQueryTimeRanges:
+    """Test range checking and int coercion for time-based methods."""
+
+    def test_hours_ago_zero_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="hours must be between 1 and 8760"):
+            ServiceNowQuery().hours_ago("sys_created_on", 0)
+
+    def test_hours_ago_negative_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="hours must be between 1 and 8760"):
+            ServiceNowQuery().hours_ago("sys_created_on", -5)
+
+    def test_hours_ago_exceeds_max_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="hours must be between 1 and 8760"):
+            ServiceNowQuery().hours_ago("sys_created_on", 8761)
+
+    def test_hours_ago_boundary_valid(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        ServiceNowQuery().hours_ago("sys_created_on", 1)
+        ServiceNowQuery().hours_ago("sys_created_on", 8760)
+
+    def test_minutes_ago_zero_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="minutes must be between 1 and 525600"):
+            ServiceNowQuery().minutes_ago("sys_created_on", 0)
+
+    def test_minutes_ago_exceeds_max_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="minutes must be between 1 and 525600"):
+            ServiceNowQuery().minutes_ago("sys_created_on", 525601)
+
+    def test_minutes_ago_boundary_valid(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        ServiceNowQuery().minutes_ago("sys_created_on", 1)
+        ServiceNowQuery().minutes_ago("sys_created_on", 525600)
+
+    def test_days_ago_zero_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="days must be between 1 and 365"):
+            ServiceNowQuery().days_ago("sys_created_on", 0)
+
+    def test_days_ago_exceeds_max_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="days must be between 1 and 365"):
+            ServiceNowQuery().days_ago("sys_created_on", 366)
+
+    def test_days_ago_boundary_valid(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        ServiceNowQuery().days_ago("sys_created_on", 1)
+        ServiceNowQuery().days_ago("sys_created_on", 365)
+
+    def test_older_than_days_zero_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="days must be between 1 and 3650"):
+            ServiceNowQuery().older_than_days("sys_updated_on", 0)
+
+    def test_older_than_days_exceeds_max_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="days must be between 1 and 3650"):
+            ServiceNowQuery().older_than_days("sys_updated_on", 3651)
+
+    def test_older_than_days_boundary_valid(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        ServiceNowQuery().older_than_days("sys_updated_on", 1)
+        ServiceNowQuery().older_than_days("sys_updated_on", 3650)
+
+    def test_int_coercion_from_float(self):
+        """Float-ish values should be coerced to int."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().hours_ago("sys_created_on", 24).build()  # type: ignore[arg-type]
+        assert "24" in result
+
+    def test_time_methods_validate_field(self):
+        """Time-based methods also validate field names."""
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().hours_ago("BAD FIELD", 1)
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().minutes_ago("BAD!", 1)
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().days_ago("BAD!", 1)
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().older_than_days("BAD!", 1)
+
+
+class TestServiceNowQueryOrConditions:
+    """Test OR condition methods."""
+
+    def test_or_equals(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("active", "true").or_equals("priority", "1").build()
+        assert result == "active=true^^ORpriority=1"
+
+    def test_or_starts_with(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("active", "true").or_starts_with("name", "inc").build()
+        assert result == "active=true^^ORnameSTARTSWITHinc"
+
+    def test_or_condition_with_contains(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("active", "true").or_condition("script", "CONTAINS", "test").build()
+        assert result == "active=true^^ORscriptCONTAINStest"
+
+    def test_or_condition_unknown_operator_raises(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Unknown operator"):
+            ServiceNowQuery().or_condition("field", "BADOP", "val")
+
+    def test_or_condition_validates_field(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().or_condition("BAD!", "=", "val")
+
+    def test_or_condition_sanitizes_value(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("a", "1").or_equals("b", "x^y").build()
+        assert result == "a=1^^ORb=x^^y"
+
+
+class TestServiceNowQueryOrderBy:
+    """Test order_by method."""
+
+    def test_order_by_ascending(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("active", "true").order_by("sys_created_on").build()
+        assert result == "active=true^ORDERBYsys_created_on"
+
+    def test_order_by_descending(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("active", "true").order_by("sys_created_on", descending=True).build()
+        assert result == "active=true^ORDERBYDESCsys_created_on"
+
+    def test_order_by_validates_field(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().order_by("BAD FIELD")
+
+    def test_order_by_standalone(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().order_by("priority").build()
+        assert result == "ORDERBYpriority"
+
+
+class TestServiceNowQueryInList:
+    """Test in_list and not_in_list methods."""
+
+    def test_in_list_basic(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().in_list("state", ["1", "2", "3"]).build()
+        assert result == "stateIN1,2,3"
+
+    def test_not_in_list_basic(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().not_in_list("state", ["6", "7"]).build()
+        assert result == "stateNOT IN6,7"
+
+    def test_in_list_single_value(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().in_list("priority", ["1"]).build()
+        assert result == "priorityIN1"
+
+    def test_in_list_validates_field(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().in_list("BAD!", ["1"])
+
+    def test_not_in_list_validates_field(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            ServiceNowQuery().not_in_list("BAD!", ["1"])
+
+    def test_in_list_sanitizes_values(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().in_list("description", ["a^b", "c"]).build()
+        assert result == "descriptionINa^^b,c"
+
+    def test_not_in_list_sanitizes_values(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().not_in_list("name", ["x^y"]).build()
+        assert result == "nameNOT INx^^y"
+
+    def test_in_list_chained(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().equals("active", "true").in_list("state", ["1", "2"]).build()
+        assert result == "active=true^stateIN1,2"
+
+    def test_in_list_empty_list(self):
+        from servicenow_mcp.utils import ServiceNowQuery
+
+        result = ServiceNowQuery().in_list("state", []).build()
+        assert result == "stateIN"


### PR DESCRIPTION
## Summary

Security & robustness improvements across the entire codebase, organized into 8 work packages.

**33 files changed** — 2,114 insertions, 150 deletions — **420 tests passing (+74 new)**

---

## WP1: ServiceNowQuery Builder Hardening

- Auto-validate field names against injection patterns
- Auto-sanitize values in query expressions
- New `OR`, ordering, and in-list methods on the query builder

## WP2: Config Validation

- `SecretStr` for password field to prevent accidental logging
- HTTPS enforcement on instance URLs
- `max_row_limit` range validation
- Case-insensitive `is_production` detection

## WP3: Policy Engine

- Structural date detection (not just regex)
- Case-insensitive table deny-list checks
- Limit flooring to prevent zero/negative limits
- Write block logging for audit trails

## WP4: Tool Fixes

- Write gates added to mutation endpoints
- `check_table_access` enforced before all table operations
- Sensitive field masking on returned records
- Migrated all tool modules to use the query builder

## WP5: Investigation Modules

- `element_id` split guards to prevent index errors
- Dead code removal across investigation modules
- Type coercion for numeric parameters
- `check_table_access` enforcement and builder migration

## WP6: Client Robustness

- Replaced bare `assert` with `RuntimeError` for production safety
- New `_extract_result` helper to reduce repeated response parsing
- Safe `X-Total-Count` header parsing (handles missing/non-numeric)
- `validate_identifier` in all URL builder methods

## WP7: Packages & State

- Defensive copies on package registry access
- Max store size limit on `PreviewTokenStore`
- Expired entry sweep on token store operations

## WP8: Error Hierarchy

- `ServerError` now carries custom HTTP status codes
- `PolicyError` maps to HTTP 403
- `WriteGatingError` removed (consolidated into `PolicyError`)
- Full type annotations on all error classes