### PR TITLE
feat: record CRUD tools, shared safe_tool_call, mandatory field validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ uvx servicenow-devtools-mcp
 - Row limits: User-supplied limit parameters capped at MAX_ROW_LIMIT (default 100)
 - Large tables: syslog, sys_audit, etc. require date-bounded filters
 - Write gating: All write operations blocked when SERVICENOW_ENV=prod (unless explicitly overridden)
+- Mandatory field validation: record creation validates all required fields are present before submission
 - Standardized responses: Tools return JSON with correlation_id, status, data, and optionally pagination and warnings when relevant
 ````
 
@@ -288,8 +289,8 @@ The server reads from `.env` and `.env.local` files automatically (`.env.local` 
 
 | Tool | Description | Key Parameters |
 |---|---|---|
-| `record_create` | Create a new record in a table | `table`, `data` (JSON string) |
-| `record_preview_create` | Preview a record creation and get a confirmation token | `table`, `data` (JSON string) |
+| `record_create` | Create a new record in a table (validates mandatory fields) | `table`, `data` (JSON string) |
+| `record_preview_create` | Preview a record creation with mandatory field check and get a confirmation token | `table`, `data` (JSON string) |
 | `record_update` | Update an existing record | `table`, `sys_id`, `changes` (JSON string) |
 | `record_preview_update` | Preview a record update with field-level diff | `table`, `sys_id`, `changes` (JSON string) |
 | `record_delete` | Delete a record | `table`, `sys_id` |
@@ -354,6 +355,7 @@ The server includes built-in guardrails that are always active:
 - **Row limit caps** -- User-supplied `limit` parameters are capped at `MAX_ROW_LIMIT` (default 100). If a larger value is requested, the limit is reduced and a warning is included in the response
 - **Large table protection** -- Tables listed in `LARGE_TABLE_NAMES_CSV` require date-bounded filters in queries to prevent full-table scans
 - **Write gating** -- All write operations (`record_*`, `dev_toggle`, `dev_set_property`) are blocked when `SERVICENOW_ENV=prod`
+- **Mandatory field validation** -- Record creation tools (`record_create`, `record_preview_create`, `record_apply`) pre-flight check that all mandatory fields (from sys_dictionary) are provided, returning a clear error listing any missing fields before the API call is made
 - **Standardized responses** -- Every tool returns a JSON envelope with `correlation_id`, `status`, and `data`, and may include `pagination` and `warnings` when applicable, for consistent error handling
 
 ---
@@ -390,7 +392,7 @@ cd servicenow-devtools-mcp
 # Install dependencies
 uv sync
 
-# Run unit tests (464 tests)
+# Run unit tests (474 tests)
 uv run pytest
 
 # Run integration tests (requires .env.local with real credentials)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-devtools-mcp?color=00c9a7&style=flat-square" alt="PyPI version"></a>
   <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-devtools-mcp?style=flat-square" alt="Python versions"></a>
   <a href="https://github.com/xerrion/servicenow-devtools-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/xerrion/servicenow-devtools-mcp?style=flat-square" alt="License"></a>
-  <img src="https://img.shields.io/badge/tools-33-00d4ff?style=flat-square" alt="Tool count">
+  <img src="https://img.shields.io/badge/tools-36-00d4ff?style=flat-square" alt="Tool count">
 </p>
 
 # servicenow-devtools-mcp
@@ -19,7 +19,8 @@ A developer & debug-focused [Model Context Protocol (MCP)](https://modelcontextp
 - :link: **Relationship Mapping** -- find incoming and outgoing references for any record
 - :package: **Change Intelligence** -- inspect update sets, diff artifact versions, audit trails, generate release notes
 - :bug: **Debug & Trace** -- trace record timelines, flow executions, email chains, integration errors, import set runs
-- :test_tube: **Developer Actions** -- toggle artifacts, set properties, seed test data, preview-then-apply updates
+- :test_tube: **Record CRUD** -- create, update, delete records with direct or preview-then-apply patterns
+- :wrench: **Developer Utilities** -- toggle artifacts on/off, set system properties
 - :mag_right: **Investigations** -- 7 built-in analysis modules (stale automations, deprecated APIs, table health, ACL conflicts, error analysis, slow transactions, performance bottlenecks)
 - :page_facing_up: **Documentation** -- generate logic maps, artifact summaries, test scenarios, code review notes
 - :shield: **Safety** -- table deny lists, sensitive field masking, row limit caps, write gating in production
@@ -130,7 +131,7 @@ uvx servicenow-devtools-mcp
 ## ServiceNow MCP Server Setup
 
 You have access to a ServiceNow MCP server (`servicenow-devtools-mcp`) that provides
-33 tools for interacting with a ServiceNow instance.
+36 tools for interacting with a ServiceNow instance.
 
 ### Installation
 
@@ -169,7 +170,7 @@ uvx servicenow-devtools-mcp
 }
 ```
 
-### Available Tools (33 total)
+### Available Tools (36 total)
 
 **Introspection (4):** table_describe, table_get, table_query, table_aggregate
   - Describe table schema, fetch records by sys_id, query with encoded queries, compute stats
@@ -186,8 +187,11 @@ uvx servicenow-devtools-mcp
 **Debug & Trace (6):** debug_trace, debug_flow_execution, debug_email_trace, debug_integration_health, debug_importset_run, debug_field_mutation_story
   - Build event timelines, inspect flow executions, trace emails, check integration errors, inspect import sets, trace field mutations
 
-**Developer Actions (6):** dev_toggle, dev_set_property, dev_seed_test_data, dev_cleanup, table_preview_update, table_apply_update
-  - Toggle artifacts on/off, set system properties, seed/cleanup test data, preview and apply record updates (two-step confirmation)
+**Record CRUD (7):** record_create, record_preview_create, record_update, record_preview_update, record_delete, record_preview_delete, record_apply
+  - Create, update, delete records directly or via preview-then-apply confirmation pattern
+
+**Developer Utilities (2):** dev_toggle, dev_set_property
+  - Toggle artifacts on/off, set system properties
 
 **Investigations (2 dispatchers, 7 modules):** investigate_run, investigate_explain
   - Modules: stale_automations, deprecated_apis, table_health, acl_conflicts, error_analysis, slow_transactions, performance_bottlenecks
@@ -280,16 +284,24 @@ The server reads from `.env` and `.env.local` files automatically (`.env.local` 
 | `debug_importset_run` | Inspect import set run with row-level results | `import_set_sys_id` |
 | `debug_field_mutation_story` | Chronological mutation history of a single field | `table`, `sys_id`, `field`, `limit?` |
 
-### :test_tube: Developer Actions
+### :test_tube: Record CRUD
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `record_create` | Create a new record in a table | `table`, `data` (JSON string) |
+| `record_preview_create` | Preview a record creation and get a confirmation token | `table`, `data` (JSON string) |
+| `record_update` | Update an existing record | `table`, `sys_id`, `changes` (JSON string) |
+| `record_preview_update` | Preview a record update with field-level diff | `table`, `sys_id`, `changes` (JSON string) |
+| `record_delete` | Delete a record | `table`, `sys_id` |
+| `record_preview_delete` | Preview a deletion showing the record to be removed | `table`, `sys_id` |
+| `record_apply` | Apply a previously previewed action (create, update, or delete) | `preview_token` |
+
+### :wrench: Developer Utilities
 
 | Tool | Description | Key Parameters |
 |---|---|---|
 | `dev_toggle` | Toggle active/inactive on a platform artifact | `artifact_type`, `sys_id`, `active` |
 | `dev_set_property` | Set a system property value (returns old value) | `name`, `value` |
-| `dev_seed_test_data` | Create test data records with cleanup tracking | `table`, `records` (JSON string), `tag?` |
-| `dev_cleanup` | Delete all records previously seeded with a tag | `tag` |
-| `table_preview_update` | Preview a record update with field-level diff | `table`, `sys_id`, `changes` (JSON string) |
-| `table_apply_update` | Apply a previously previewed update | `preview_token` |
 
 ### :mag_right: Investigations
 
@@ -327,8 +339,8 @@ Control which tools are loaded using the `MCP_TOOL_PACKAGE` environment variable
 
 | Package | Tools Loaded | Use Case |
 |---|---|---|
-| `full` (default) | All 33 tools | Full development and debugging |
-| `introspection_only` | Introspection + Relationships + Metadata (10 tools) | Read-only exploration |
+| `full` (default) | All 36 tools | Full development and debugging |
+| `introspection_only` | Introspection + Relationships + Metadata + Utility (11 tools) | Read-only exploration |
 | `none` | Only `list_tool_packages` | Minimal / testing |
 
 ---
@@ -341,7 +353,7 @@ The server includes built-in guardrails that are always active:
 - **Sensitive field masking** -- Fields whose names contain patterns like `password`, `token`, `secret`, `credential`, `api_key`, or `private_key` are masked with the literal value `***MASKED***` in responses
 - **Row limit caps** -- User-supplied `limit` parameters are capped at `MAX_ROW_LIMIT` (default 100). If a larger value is requested, the limit is reduced and a warning is included in the response
 - **Large table protection** -- Tables listed in `LARGE_TABLE_NAMES_CSV` require date-bounded filters in queries to prevent full-table scans
-- **Write gating** -- All write operations (`dev_toggle`, `dev_set_property`, `dev_seed_test_data`, `table_preview_update`, etc.) are blocked when `SERVICENOW_ENV=prod`
+- **Write gating** -- All write operations (`record_*`, `dev_toggle`, `dev_set_property`) are blocked when `SERVICENOW_ENV=prod`
 - **Standardized responses** -- Every tool returns a JSON envelope with `correlation_id`, `status`, and `data`, and may include `pagination` and `warnings` when applicable, for consistent error handling
 
 ---
@@ -362,7 +374,7 @@ Here are some real-world prompts you can use with an AI agent that has this MCP 
 
 > Find all scripts that reference the "cmdb_ci_server" table and check them for anti-patterns.
 
-> Seed 3 test incidents with different priorities, verify they were created, then clean them up.
+> Create a new incident with priority 1 and short description "Server outage". Show me a preview first.
 
 > Show me the performance bottlenecks investigation and explain any slow transactions found.
 
@@ -378,7 +390,7 @@ cd servicenow-devtools-mcp
 # Install dependencies
 uv sync
 
-# Run unit tests (207 tests)
+# Run unit tests (464 tests)
 uv run pytest
 
 # Run integration tests (requires .env.local with real credentials)

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -77,7 +77,7 @@
     <rect width="90" height="28" rx="14" fill="#00c9a7" opacity="0.15"/>
     <rect width="90" height="28" rx="14" fill="none" stroke="#00c9a7" stroke-width="1" opacity="0.4"/>
     <text x="45" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="13" fill="#00c9a7" text-anchor="middle" font-weight="600">
-      33 Tools
+      36 Tools
     </text>
   </g>
 

--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -16,6 +16,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "changes",
         "debug",
         "developer",
+        "dev_utils",
         "investigations",
         "documentation",
         "utility",

--- a/src/servicenow_mcp/policy.py
+++ b/src/servicenow_mcp/policy.py
@@ -152,3 +152,19 @@ def can_write(
         return False
 
     return True
+
+
+def write_blocked_reason(table: str, settings: Settings) -> str | None:
+    """Pre-flight local policy check for write operations.
+
+    Checks local policy only (denied tables, production env).
+    ServiceNow-side ACL denials will surface as ForbiddenError
+    from the HTTP layer and should be handled by callers.
+
+    Returns a reason string if writes are blocked, or None if allowed.
+    """
+    if table.lower() in DENIED_TABLES:
+        return f"Write operations are blocked for table '{table}' (restricted table)"
+    if settings.is_production:
+        return "Write operations are blocked in production environments"
+    return None

--- a/src/servicenow_mcp/policy.py
+++ b/src/servicenow_mcp/policy.py
@@ -59,7 +59,7 @@ def check_table_access(table: str) -> None:
         raise PolicyError(f"Access to table '{table}' is denied by policy")
 
 
-def _is_sensitive_field(field_name: str) -> bool:
+def is_sensitive_field(field_name: str) -> bool:
     """Check if a field name matches sensitive patterns."""
     return any(pattern.search(field_name) for pattern in _SENSITIVE_PATTERNS)
 
@@ -68,7 +68,7 @@ def mask_sensitive_fields(record: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of the record with sensitive fields masked."""
     masked = dict(record)
     for key in masked:
-        if _is_sensitive_field(key):
+        if is_sensitive_field(key):
             masked[key] = MASK_VALUE
     return masked
 
@@ -88,7 +88,7 @@ def mask_audit_entry(entry: dict[str, Any]) -> dict[str, Any]:
     # Determine the field name from whichever key is present
     field_name = masked.get("fieldname") or masked.get("field") or ""
 
-    if _is_sensitive_field(field_name):
+    if is_sensitive_field(field_name):
         for key in ("oldvalue", "newvalue", "old_value", "new_value"):
             if key in masked:
                 masked[key] = MASK_VALUE
@@ -141,16 +141,12 @@ def can_write(
     override: bool = False,
 ) -> bool:
     """Check if write operations are allowed for the given table and environment."""
-    # Always block writes to denied tables
-    if table.lower() in DENIED_TABLES:
-        logger.warning("Write blocked: table '%s' is on deny list", table)
+    if override:
+        return True
+    reason = write_blocked_reason(table, settings)
+    if reason is not None:
+        logger.warning("Write blocked: %s", reason)
         return False
-
-    # In production, require explicit override
-    if settings.is_production and not override:
-        logger.warning("Write blocked: table '%s' in production environment '%s'", table, settings.servicenow_env)
-        return False
-
     return True
 
 

--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -20,6 +20,7 @@ _TOOL_GROUP_MODULES: dict[str, str] = {
     "changes": "servicenow_mcp.tools.changes",
     "debug": "servicenow_mcp.tools.debug",
     "developer": "servicenow_mcp.tools.developer",
+    "dev_utils": "servicenow_mcp.tools.dev_utils",
     "investigations": "servicenow_mcp.tools.investigations",
     "documentation": "servicenow_mcp.tools.documentation",
     "utility": "servicenow_mcp.tools.utility",

--- a/src/servicenow_mcp/state.py
+++ b/src/servicenow_mcp/state.py
@@ -1,9 +1,4 @@
-"""In-memory state management for stateful MCP tool workflows.
-
-Provides:
-- PreviewTokenStore: token-based preview/apply workflow with TTL
-- SeededRecordTracker: tracks records created by dev_seed_test_data for cleanup
-"""
+"""In-memory state store for preview tokens."""
 
 import time
 import uuid
@@ -68,31 +63,3 @@ class PreviewTokenStore:
             return None
         del self._store[token]
         return entry["payload"]
-
-
-class SeededRecordTracker:
-    """Tracks records created by dev_seed_test_data for cleanup.
-
-    Records are grouped by a seed tag (string). Each tag maps to a list
-    of {table, sys_ids} entries, allowing cleanup across multiple tables.
-    """
-
-    def __init__(self) -> None:
-        self._store: dict[str, list[dict[str, Any]]] = {}
-
-    def track(self, tag: str, table: str, sys_ids: list[str]) -> None:
-        """Record that sys_ids were created in table under the given tag."""
-        if tag not in self._store:
-            self._store[tag] = []
-        self._store[tag].append({"table": table, "sys_ids": sys_ids})
-
-    def get(self, tag: str) -> list[dict[str, Any]] | None:
-        """Return all tracked records for a tag, or None if unknown."""
-        entries = self._store.get(tag)
-        if entries is None:
-            return None
-        return list(entries)
-
-    def remove(self, tag: str) -> None:
-        """Remove all tracked records for a tag."""
-        self._store.pop(tag, None)

--- a/src/servicenow_mcp/tools/changes.py
+++ b/src/servicenow_mcp/tools/changes.py
@@ -14,6 +14,7 @@ from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
     generate_correlation_id,
+    safe_tool_call,
     validate_identifier,
 )
 
@@ -41,7 +42,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             update_set_id: The sys_id of the update set to inspect.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(update_set_id)
 
             async with ServiceNowClient(settings, auth_provider) as client:
@@ -116,16 +118,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def changes_diff_artifact(table: str, sys_id: str) -> str:
@@ -139,7 +133,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the artifact record.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
 
@@ -196,16 +191,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def changes_last_touched(
@@ -221,7 +208,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             limit: Maximum number of audit entries to return (default 20).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
 
@@ -267,16 +255,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def changes_release_notes(
@@ -290,7 +270,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             format: Output format (currently only 'markdown' supported).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(update_set_id)
 
             async with ServiceNowClient(settings, auth_provider) as client:
@@ -364,13 +345,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/debug.py
+++ b/src/servicenow_mcp/tools/debug.py
@@ -14,6 +14,7 @@ from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
     generate_correlation_id,
+    safe_tool_call,
     validate_identifier,
 )
 
@@ -35,7 +36,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             minutes: How many minutes of history to include (default 60).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
 
@@ -153,16 +155,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def debug_flow_execution(context_id: str) -> str:
@@ -172,7 +166,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             context_id: The sys_id of the flow context (sys_flow_context).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             async with ServiceNowClient(settings, auth_provider) as client:
                 # Fetch flow context
                 context = mask_sensitive_fields(await client.get_record("sys_flow_context", context_id))
@@ -223,16 +218,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def debug_email_trace(record_sys_id: str) -> str:
@@ -242,7 +229,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             record_sys_id: The sys_id of the record whose emails to trace.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             async with ServiceNowClient(settings, auth_provider) as client:
                 email_result = await client.query_records(
                     "sys_email",
@@ -285,16 +273,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def debug_integration_health(
@@ -308,7 +288,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             hours: How many hours of history to review (default 24).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             errors = []
 
             async with ServiceNowClient(settings, auth_provider) as client:
@@ -394,16 +375,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def debug_importset_run(import_set_sys_id: str) -> str:
@@ -413,7 +386,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             import_set_sys_id: The sys_id of the import set (sys_import_set).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             async with ServiceNowClient(settings, auth_provider) as client:
                 # Fetch import set header
                 import_set = mask_sensitive_fields(await client.get_record("sys_import_set", import_set_sys_id))
@@ -468,16 +442,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def debug_field_mutation_story(
@@ -495,7 +461,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             limit: Maximum number of audit entries to return (default 50).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             validate_identifier(field)
             check_table_access(table)
@@ -548,13 +515,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/dev_utils.py
+++ b/src/servicenow_mcp/tools/dev_utils.py
@@ -7,15 +7,20 @@ from mcp.server.fastmcp import FastMCP
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
-from servicenow_mcp.errors import ForbiddenError
 from servicenow_mcp.policy import (
     MASK_VALUE,
-    _is_sensitive_field,
     check_table_access,
+    is_sensitive_field,
     write_blocked_reason,
 )
 from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
-from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id, validate_identifier
+from servicenow_mcp.utils import (
+    ServiceNowQuery,
+    format_response,
+    generate_correlation_id,
+    safe_tool_call,
+    validate_identifier,
+)
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -31,7 +36,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             active: Whether to set the artifact active (true) or inactive (false).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             # Resolve artifact type to table name
             table = ARTIFACT_TABLES.get(artifact_type)
             if table is None:
@@ -81,24 +87,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def dev_set_property(name: str, value: str) -> str:
@@ -109,7 +99,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             value: The new value to set.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             # Write gate
             check_table_access("sys_properties")
             reason = write_blocked_reason("sys_properties", settings)
@@ -150,8 +141,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 new_value = updated.get("value", value)
 
             # Mask values for sensitive property names
-            display_old = MASK_VALUE if _is_sensitive_field(name) else old_value
-            display_new = MASK_VALUE if _is_sensitive_field(name) else new_value
+            display_old = MASK_VALUE if is_sensitive_field(name) else old_value
+            display_new = MASK_VALUE if is_sensitive_field(name) else new_value
 
             return json.dumps(
                 format_response(
@@ -164,21 +155,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/dev_utils.py
+++ b/src/servicenow_mcp/tools/dev_utils.py
@@ -1,0 +1,184 @@
+"""Developer utility tools for toggling artifacts and managing system properties."""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.config import Settings
+from servicenow_mcp.errors import ForbiddenError
+from servicenow_mcp.policy import (
+    MASK_VALUE,
+    _is_sensitive_field,
+    check_table_access,
+    write_blocked_reason,
+)
+from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
+from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id, validate_identifier
+
+
+def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """Register developer utility tools on the MCP server."""
+
+    @mcp.tool()
+    async def dev_toggle(artifact_type: str, sys_id: str, active: bool) -> str:
+        """Toggle the active field on a ServiceNow artifact (business rule, script include, etc.).
+
+        Args:
+            artifact_type: The type of artifact (e.g. 'business_rule', 'script_include').
+            sys_id: The sys_id of the artifact record.
+            active: Whether to set the artifact active (true) or inactive (false).
+        """
+        correlation_id = generate_correlation_id()
+        try:
+            # Resolve artifact type to table name
+            table = ARTIFACT_TABLES.get(artifact_type)
+            if table is None:
+                return json.dumps(
+                    format_response(
+                        data=None,
+                        correlation_id=correlation_id,
+                        status="error",
+                        error=f"Unknown artifact type: '{artifact_type}'. "
+                        f"Valid types: {', '.join(sorted(ARTIFACT_TABLES.keys()))}",
+                    )
+                )
+
+            check_table_access(table)
+            validate_identifier(sys_id)
+
+            # Write gate
+            reason = write_blocked_reason(table, settings)
+            if reason:
+                return json.dumps(
+                    format_response(
+                        data=None,
+                        correlation_id=correlation_id,
+                        status="error",
+                        error=reason,
+                    )
+                )
+
+            async with ServiceNowClient(settings, auth_provider) as client:
+                # Read current state
+                current = await client.get_record(table, sys_id)
+                old_active = current.get("active", "unknown")
+
+                # Update active field
+                updated = await client.update_record(table, sys_id, {"active": str(active).lower()})
+                new_active = updated.get("active", "unknown")
+
+            return json.dumps(
+                format_response(
+                    data={
+                        "sys_id": sys_id,
+                        "artifact_type": artifact_type,
+                        "table": table,
+                        "old_active": old_active,
+                        "new_active": new_active,
+                    },
+                    correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
+                )
+            )
+        except Exception as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=str(e),
+                )
+            )
+
+    @mcp.tool()
+    async def dev_set_property(name: str, value: str) -> str:
+        """Set a ServiceNow system property value. Returns the old value.
+
+        Args:
+            name: The property name (e.g. 'glide.ui.session_timeout').
+            value: The new value to set.
+        """
+        correlation_id = generate_correlation_id()
+        try:
+            # Write gate
+            check_table_access("sys_properties")
+            reason = write_blocked_reason("sys_properties", settings)
+            if reason:
+                return json.dumps(
+                    format_response(
+                        data=None,
+                        correlation_id=correlation_id,
+                        status="error",
+                        error=reason,
+                    )
+                )
+
+            async with ServiceNowClient(settings, auth_provider) as client:
+                # Find the property by name
+                result = await client.query_records(
+                    "sys_properties",
+                    ServiceNowQuery().equals("name", name).build(),
+                    limit=1,
+                )
+                records = result["records"]
+                if not records:
+                    return json.dumps(
+                        format_response(
+                            data=None,
+                            correlation_id=correlation_id,
+                            status="error",
+                            error=f"Property '{name}' not found",
+                        )
+                    )
+
+                prop = records[0]
+                prop_sys_id = prop["sys_id"]
+                old_value = prop.get("value", "")
+
+                # Update the property value
+                updated = await client.update_record("sys_properties", prop_sys_id, {"value": value})
+                new_value = updated.get("value", value)
+
+            # Mask values for sensitive property names
+            display_old = MASK_VALUE if _is_sensitive_field(name) else old_value
+            display_new = MASK_VALUE if _is_sensitive_field(name) else new_value
+
+            return json.dumps(
+                format_response(
+                    data={
+                        "name": name,
+                        "sys_id": prop_sys_id,
+                        "old_value": display_old,
+                        "new_value": display_new,
+                    },
+                    correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
+                )
+            )
+        except Exception as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=str(e),
+                )
+            )

--- a/src/servicenow_mcp/tools/developer.py
+++ b/src/servicenow_mcp/tools/developer.py
@@ -1,22 +1,25 @@
 """Record CRUD tools for creating, reading, updating, and deleting ServiceNow records."""
 
 import json
+import logging
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
-from servicenow_mcp.errors import ForbiddenError
 from servicenow_mcp.policy import (
     MASK_VALUE,
-    _is_sensitive_field,
     check_table_access,
+    is_sensitive_field,
     mask_sensitive_fields,
     write_blocked_reason,
 )
 from servicenow_mcp.state import PreviewTokenStore
-from servicenow_mcp.utils import format_response, generate_correlation_id, validate_identifier
+from servicenow_mcp.utils import format_response, generate_correlation_id, safe_tool_call, validate_identifier
+
+logger = logging.getLogger(__name__)
 
 
 def _write_gate(table: str, settings: Settings, correlation_id: str) -> str | None:
@@ -40,6 +43,27 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     # In-memory preview token store, shared across preview/apply tools via closure
     preview_store = PreviewTokenStore()
 
+    async def _check_mandatory_fields(
+        client: ServiceNowClient,
+        table: str,
+        data: dict[str, Any],
+    ) -> list[str]:
+        """Return list of mandatory field names missing from data.
+
+        Best-effort: if metadata fetch fails, logs a warning and returns
+        an empty list so the create can proceed (ServiceNow will still
+        validate server-side).
+        """
+        try:
+            metadata = await client.get_metadata(table)
+        except Exception:
+            logger.warning("Failed to fetch metadata for mandatory field check on table '%s'", table)
+            return []
+        mandatory_fields = [
+            entry["element"] for entry in metadata if entry.get("mandatory") == "true" and entry.get("element")
+        ]
+        return [f for f in mandatory_fields if f not in data]
+
     @mcp.tool()
     async def record_create(table: str, data: str) -> str:
         """Create a new record in a ServiceNow table.
@@ -49,7 +73,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             data: A JSON string of field-value pairs for the new record.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
 
@@ -60,6 +85,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             record_data = json.loads(data)
 
             async with ServiceNowClient(settings, auth_provider) as client:
+                missing = await _check_mandatory_fields(client, table, record_data)
+                if missing:
+                    return json.dumps(
+                        format_response(
+                            data={"table": table, "missing_fields": missing},
+                            correlation_id=correlation_id,
+                            status="error",
+                            error=f"Missing mandatory fields for table '{table}': {', '.join(missing)}",
+                        )
+                    )
                 created = await client.create_record(table, record_data)
 
             return json.dumps(
@@ -72,24 +107,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def record_preview_create(table: str, data: str) -> str:
@@ -100,7 +119,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             data: A JSON string of field-value pairs for the new record.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
 
@@ -110,7 +130,19 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
             record_data = json.loads(data)
 
-            # Store for later apply - no HTTP call needed for create preview
+            async with ServiceNowClient(settings, auth_provider) as client:
+                missing = await _check_mandatory_fields(client, table, record_data)
+                if missing:
+                    return json.dumps(
+                        format_response(
+                            data={"table": table, "missing_fields": missing},
+                            correlation_id=correlation_id,
+                            status="error",
+                            error=f"Missing mandatory fields for table '{table}': {', '.join(missing)}",
+                        )
+                    )
+
+            # Store for later apply - no further HTTP call needed
             token = preview_store.create(
                 {
                     "action": "create",
@@ -130,24 +162,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def record_update(table: str, sys_id: str, changes: str) -> str:
@@ -159,7 +175,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             changes: A JSON string of field-value pairs to update.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             validate_identifier(sys_id)
             check_table_access(table)
@@ -183,24 +200,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def record_preview_update(table: str, sys_id: str, changes: str) -> str:
@@ -212,7 +213,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             changes: A JSON string of field-value pairs to change.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             validate_identifier(sys_id)
             check_table_access(table)
@@ -230,7 +232,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             diff: dict[str, dict[str, str]] = {}
             for field, new_value in changes_dict.items():
                 old_value = current.get(field, "")
-                if _is_sensitive_field(field):
+                if is_sensitive_field(field):
                     diff[field] = {"old": MASK_VALUE, "new": MASK_VALUE}
                 else:
                     diff[field] = {"old": old_value, "new": new_value}
@@ -256,24 +258,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def record_delete(table: str, sys_id: str) -> str:
@@ -284,7 +270,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the record to delete.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             validate_identifier(sys_id)
             check_table_access(table)
@@ -306,24 +293,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def record_preview_delete(table: str, sys_id: str) -> str:
@@ -334,7 +305,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the record to delete.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             validate_identifier(sys_id)
             check_table_access(table)
@@ -367,24 +339,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def record_apply(preview_token: str) -> str:
@@ -394,7 +350,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             preview_token: The single-use token returned by record_preview_create, record_preview_update, or record_preview_delete.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             # Consume the token (single-use)
             payload = preview_store.consume(preview_token)
             if payload is None:
@@ -418,6 +375,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
             async with ServiceNowClient(settings, auth_provider) as client:
                 if action == "create":
+                    missing = await _check_mandatory_fields(client, payload["table"], payload["data"])
+                    if missing:
+                        return json.dumps(
+                            format_response(
+                                data={"table": payload["table"], "missing_fields": missing},
+                                correlation_id=correlation_id,
+                                status="error",
+                                error=f"Missing mandatory fields for table '{payload['table']}': {', '.join(missing)}",
+                            )
+                        )
                     result = await client.create_record(table, payload["data"])
                     return json.dumps(
                         format_response(
@@ -471,21 +438,4 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         )
                     )
 
-        except ForbiddenError as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Access denied by ServiceNow ACL: {e}",
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/developer.py
+++ b/src/servicenow_mcp/tools/developer.py
@@ -1,253 +1,84 @@
-"""Developer action tools for toggling artifacts, managing properties, seeding data, and preview/apply workflows."""
+"""Record CRUD tools for creating, reading, updating, and deleting ServiceNow records."""
 
-import asyncio
 import json
-import uuid
-from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
+from servicenow_mcp.errors import ForbiddenError
 from servicenow_mcp.policy import (
-    DENIED_TABLES,
     MASK_VALUE,
     _is_sensitive_field,
     check_table_access,
     mask_sensitive_fields,
+    write_blocked_reason,
 )
-from servicenow_mcp.state import PreviewTokenStore, SeededRecordTracker
-from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
-from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id, validate_identifier
+from servicenow_mcp.state import PreviewTokenStore
+from servicenow_mcp.utils import format_response, generate_correlation_id, validate_identifier
 
 
-def _write_blocked_reason(table: str, settings: "Settings") -> str | None:
-    """Return an error message if writes are blocked, or None if allowed."""
-    if table.lower() in DENIED_TABLES:
-        return f"Write operations are blocked for table '{table}' (restricted table)"
-    if settings.is_production:
-        return "Write operations are blocked in production environments"
+def _write_gate(table: str, settings: Settings, correlation_id: str) -> str | None:
+    """Check write access and return a JSON error envelope if blocked, or None if allowed."""
+    reason = write_blocked_reason(table, settings)
+    if reason:
+        return json.dumps(
+            format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=reason,
+            )
+        )
     return None
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """Register developer action tools on the MCP server."""
+    """Register record CRUD tools on the MCP server."""
 
-    # In-memory state stores, shared across tools via closure
+    # In-memory preview token store, shared across preview/apply tools via closure
     preview_store = PreviewTokenStore()
-    seed_tracker = SeededRecordTracker()
 
     @mcp.tool()
-    async def dev_toggle(artifact_type: str, sys_id: str, active: bool) -> str:
-        """Toggle the active field on a ServiceNow artifact (business rule, script include, etc.).
+    async def record_create(table: str, data: str) -> str:
+        """Create a new record in a ServiceNow table.
 
         Args:
-            artifact_type: The type of artifact (e.g. 'business_rule', 'script_include').
-            sys_id: The sys_id of the artifact record.
-            active: Whether to set the artifact active (true) or inactive (false).
-        """
-        correlation_id = generate_correlation_id()
-        try:
-            # Resolve artifact type to table name
-            table = ARTIFACT_TABLES.get(artifact_type)
-            if table is None:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=f"Unknown artifact type: '{artifact_type}'. "
-                        f"Valid types: {', '.join(sorted(ARTIFACT_TABLES.keys()))}",
-                    )
-                )
-
-            check_table_access(table)
-            validate_identifier(sys_id)
-
-            # Write gate
-            reason = _write_blocked_reason(table, settings)
-            if reason:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=reason,
-                    )
-                )
-
-            async with ServiceNowClient(settings, auth_provider) as client:
-                # Read current state
-                current = await client.get_record(table, sys_id)
-                old_active = current.get("active", "unknown")
-
-                # Update active field
-                updated = await client.update_record(table, sys_id, {"active": str(active).lower()})
-                new_active = updated.get("active", "unknown")
-
-            return json.dumps(
-                format_response(
-                    data={
-                        "sys_id": sys_id,
-                        "artifact_type": artifact_type,
-                        "table": table,
-                        "old_active": old_active,
-                        "new_active": new_active,
-                    },
-                    correlation_id=correlation_id,
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
-
-    @mcp.tool()
-    async def dev_set_property(name: str, value: str) -> str:
-        """Set a ServiceNow system property value. Returns the old value.
-
-        Args:
-            name: The property name (e.g. 'glide.ui.session_timeout').
-            value: The new value to set.
-        """
-        correlation_id = generate_correlation_id()
-        try:
-            # Write gate
-            check_table_access("sys_properties")
-            reason = _write_blocked_reason("sys_properties", settings)
-            if reason:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=reason,
-                    )
-                )
-
-            async with ServiceNowClient(settings, auth_provider) as client:
-                # Find the property by name
-                result = await client.query_records(
-                    "sys_properties",
-                    ServiceNowQuery().equals("name", name).build(),
-                    limit=1,
-                )
-                records = result["records"]
-                if not records:
-                    return json.dumps(
-                        format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error=f"Property '{name}' not found",
-                        )
-                    )
-
-                prop = records[0]
-                prop_sys_id = prop["sys_id"]
-                old_value = prop.get("value", "")
-
-                # Update the property value
-                updated = await client.update_record("sys_properties", prop_sys_id, {"value": value})
-                new_value = updated.get("value", value)
-
-            # Mask values for sensitive property names
-            display_old = MASK_VALUE if _is_sensitive_field(name) else old_value
-            display_new = MASK_VALUE if _is_sensitive_field(name) else new_value
-
-            return json.dumps(
-                format_response(
-                    data={
-                        "name": name,
-                        "sys_id": prop_sys_id,
-                        "old_value": display_old,
-                        "new_value": display_new,
-                    },
-                    correlation_id=correlation_id,
-                )
-            )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                )
-            )
-
-    @mcp.tool()
-    async def dev_seed_test_data(table: str, records: str, tag: str | None = None) -> str:
-        """Create test data records in a ServiceNow table. Returns sys_ids and a cleanup tag.
-
-        Args:
-            table: The table to insert records into (e.g. 'incident').
-            records: A JSON string containing an array of record objects to create.
-            tag: Optional tag for grouping seeded records for cleanup. Auto-generated if omitted.
+            table: The table to create the record in (e.g. 'incident').
+            data: A JSON string of field-value pairs for the new record.
         """
         correlation_id = generate_correlation_id()
         try:
             validate_identifier(table)
             check_table_access(table)
 
-            # Write gate
-            reason = _write_blocked_reason(table, settings)
-            if reason:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=reason,
-                    )
-                )
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
 
-            # Parse records JSON string
-            record_list = json.loads(records)
+            record_data = json.loads(data)
 
-            # Auto-generate tag if not provided
-            seed_tag = tag if tag else f"seed-{uuid.uuid4().hex[:8]}"
-
-            sys_ids: list[str] = []
-            errors: list[str] = []
-            sem = asyncio.Semaphore(10)
             async with ServiceNowClient(settings, auth_provider) as client:
-
-                async def _create_one(record_data: dict[str, Any]) -> dict[str, Any]:
-                    async with sem:
-                        return await client.create_record(table, record_data)
-
-                results = await asyncio.gather(
-                    *(_create_one(record_data) for record_data in record_list),
-                    return_exceptions=True,
-                )
-                for result in results:
-                    if isinstance(result, BaseException):
-                        errors.append(str(result))
-                    else:
-                        sys_ids.append(result["sys_id"])
-
-            # Track only successful creates for cleanup
-            if sys_ids:
-                seed_tracker.track(seed_tag, table, sys_ids)
+                created = await client.create_record(table, record_data)
 
             return json.dumps(
                 format_response(
                     data={
                         "table": table,
-                        "created_count": len(sys_ids),
-                        "sys_ids": sys_ids,
-                        "tag": seed_tag,
-                        "failed_count": len(errors),
-                        "errors": errors,
+                        "sys_id": created["sys_id"],
+                        "record": mask_sensitive_fields(created),
                     },
                     correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
                 )
             )
         except Exception as e:
@@ -261,87 +92,51 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             )
 
     @mcp.tool()
-    async def dev_cleanup(tag: str) -> str:
-        """Delete all records previously seeded with the given tag.
+    async def record_preview_create(table: str, data: str) -> str:
+        """Preview a record creation without executing it. Returns a token to apply later.
 
         Args:
-            tag: The seed tag returned by dev_seed_test_data.
+            table: The table to create the record in (e.g. 'incident').
+            data: A JSON string of field-value pairs for the new record.
         """
         correlation_id = generate_correlation_id()
         try:
-            # Look up tracked records
-            entries = seed_tracker.get(tag)
-            if entries is None:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=f"No records found for tag '{tag}'",
-                    )
-                )
+            validate_identifier(table)
+            check_table_access(table)
 
-            # Write gate — check each entry's table for access and write permissions
-            for entry in entries:
-                tbl = entry["table"]
-                check_table_access(tbl)
-                reason = _write_blocked_reason(tbl, settings)
-                if reason:
-                    return json.dumps(
-                        format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error=reason,
-                        )
-                    )
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
 
-            deleted_count = 0
-            failed_records: list[dict[str, str]] = []
-            sem = asyncio.Semaphore(10)
-            async with ServiceNowClient(settings, auth_provider) as client:
-                delete_meta: list[tuple[str, str]] = []
-                for entry in entries:
-                    tbl = entry["table"]
-                    for sid in entry["sys_ids"]:
-                        delete_meta.append((tbl, sid))
+            record_data = json.loads(data)
 
-                async def _delete_one(tbl: str, sid: str) -> None:
-                    async with sem:
-                        await client.delete_record(tbl, sid)
-
-                results = await asyncio.gather(
-                    *(_delete_one(tbl, sid) for tbl, sid in delete_meta),
-                    return_exceptions=True,
-                )
-                for i, result in enumerate(results):
-                    tbl, sid = delete_meta[i]
-                    if isinstance(result, BaseException):
-                        failed_records.append({"table": tbl, "sys_id": sid, "error": str(result)})
-                    else:
-                        deleted_count += 1
-
-            # Only remove the tag if ALL deletions succeeded
-            if not failed_records:
-                seed_tracker.remove(tag)
-            else:
-                # Update tracker to keep only failed records
-                remaining: dict[str, list[str]] = {}
-                for fr in failed_records:
-                    remaining.setdefault(fr["table"], []).append(fr["sys_id"])
-                seed_tracker.remove(tag)
-                for tbl, sids in remaining.items():
-                    seed_tracker.track(tag, tbl, sids)
+            # Store for later apply - no HTTP call needed for create preview
+            token = preview_store.create(
+                {
+                    "action": "create",
+                    "table": table,
+                    "data": record_data,
+                }
+            )
 
             return json.dumps(
                 format_response(
                     data={
-                        "tag": tag,
-                        "deleted_count": deleted_count,
-                        "failed_count": len(failed_records),
-                        "failed_records": failed_records,
+                        "token": token,
+                        "table": table,
+                        "action": "create",
+                        "data": mask_sensitive_fields(record_data),
                     },
                     correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
                 )
             )
         except Exception as e:
@@ -355,7 +150,60 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             )
 
     @mcp.tool()
-    async def table_preview_update(table: str, sys_id: str, changes: str) -> str:
+    async def record_update(table: str, sys_id: str, changes: str) -> str:
+        """Update an existing record in a ServiceNow table.
+
+        Args:
+            table: The table containing the record (e.g. 'incident').
+            sys_id: The sys_id of the record to update.
+            changes: A JSON string of field-value pairs to update.
+        """
+        correlation_id = generate_correlation_id()
+        try:
+            validate_identifier(table)
+            validate_identifier(sys_id)
+            check_table_access(table)
+
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
+
+            changes_dict = json.loads(changes)
+
+            async with ServiceNowClient(settings, auth_provider) as client:
+                updated = await client.update_record(table, sys_id, changes_dict)
+
+            return json.dumps(
+                format_response(
+                    data={
+                        "table": table,
+                        "sys_id": sys_id,
+                        "record": mask_sensitive_fields(updated),
+                    },
+                    correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
+                )
+            )
+        except Exception as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=str(e),
+                )
+            )
+
+    @mcp.tool()
+    async def record_preview_update(table: str, sys_id: str, changes: str) -> str:
         """Preview an update to a record: shows field-level diff and returns a token to apply.
 
         Args:
@@ -369,19 +217,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             validate_identifier(sys_id)
             check_table_access(table)
 
-            # Write gate
-            reason = _write_blocked_reason(table, settings)
-            if reason:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=reason,
-                    )
-                )
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
 
-            # Parse changes JSON string
             changes_dict = json.loads(changes)
 
             async with ServiceNowClient(settings, auth_provider) as client:
@@ -399,6 +238,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             # Store preview for later apply
             token = preview_store.create(
                 {
+                    "action": "update",
                     "table": table,
                     "sys_id": sys_id,
                     "changes": changes_dict,
@@ -416,6 +256,15 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
+                )
+            )
         except Exception as e:
             return json.dumps(
                 format_response(
@@ -427,11 +276,122 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             )
 
     @mcp.tool()
-    async def table_apply_update(preview_token: str) -> str:
-        """Apply a previously previewed update using the preview token.
+    async def record_delete(table: str, sys_id: str) -> str:
+        """Delete a record from a ServiceNow table.
 
         Args:
-            preview_token: The token returned by table_preview_update.
+            table: The table containing the record (e.g. 'incident').
+            sys_id: The sys_id of the record to delete.
+        """
+        correlation_id = generate_correlation_id()
+        try:
+            validate_identifier(table)
+            validate_identifier(sys_id)
+            check_table_access(table)
+
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
+
+            async with ServiceNowClient(settings, auth_provider) as client:
+                await client.delete_record(table, sys_id)
+
+            return json.dumps(
+                format_response(
+                    data={
+                        "table": table,
+                        "sys_id": sys_id,
+                        "deleted": True,
+                    },
+                    correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
+                )
+            )
+        except Exception as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=str(e),
+                )
+            )
+
+    @mcp.tool()
+    async def record_preview_delete(table: str, sys_id: str) -> str:
+        """Preview a record deletion: shows the record that will be deleted and returns a token to confirm.
+
+        Args:
+            table: The table containing the record (e.g. 'incident').
+            sys_id: The sys_id of the record to delete.
+        """
+        correlation_id = generate_correlation_id()
+        try:
+            validate_identifier(table)
+            validate_identifier(sys_id)
+            check_table_access(table)
+
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
+
+            async with ServiceNowClient(settings, auth_provider) as client:
+                record = await client.get_record(table, sys_id)
+
+            # Store preview for later apply
+            token = preview_store.create(
+                {
+                    "action": "delete",
+                    "table": table,
+                    "sys_id": sys_id,
+                    "record_snapshot": record,
+                }
+            )
+
+            return json.dumps(
+                format_response(
+                    data={
+                        "token": token,
+                        "table": table,
+                        "sys_id": sys_id,
+                        "record_snapshot": mask_sensitive_fields(record),
+                    },
+                    correlation_id=correlation_id,
+                )
+            )
+        except ForbiddenError as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
+                )
+            )
+        except Exception as e:
+            return json.dumps(
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=str(e),
+                )
+            )
+
+    @mcp.tool()
+    async def record_apply(preview_token: str) -> str:
+        """Apply a previously previewed action (create, update, or delete) using the preview token.
+
+        Args:
+            preview_token: The single-use token returned by record_preview_create, record_preview_update, or record_preview_delete.
         """
         correlation_id = generate_correlation_id()
         try:
@@ -447,34 +407,77 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     )
                 )
 
+            action = payload["action"]
             table = payload["table"]
-            sys_id = payload["sys_id"]
-            changes = payload["changes"]
 
+            # Defense in depth - re-check access and write gate
             check_table_access(table)
-
-            reason = _write_blocked_reason(table, settings)
-            if reason:
-                return json.dumps(
-                    format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=reason,
-                    )
-                )
+            blocked = _write_gate(table, settings, correlation_id)
+            if blocked:
+                return blocked
 
             async with ServiceNowClient(settings, auth_provider) as client:
-                updated = await client.update_record(table, sys_id, changes)
+                if action == "create":
+                    result = await client.create_record(table, payload["data"])
+                    return json.dumps(
+                        format_response(
+                            data={
+                                "action": "create",
+                                "table": table,
+                                "sys_id": result["sys_id"],
+                                "record": mask_sensitive_fields(result),
+                            },
+                            correlation_id=correlation_id,
+                        )
+                    )
 
+                elif action == "update":
+                    sys_id = payload["sys_id"]
+                    result = await client.update_record(table, sys_id, payload["changes"])
+                    return json.dumps(
+                        format_response(
+                            data={
+                                "action": "update",
+                                "table": table,
+                                "sys_id": sys_id,
+                                "record": mask_sensitive_fields(result),
+                            },
+                            correlation_id=correlation_id,
+                        )
+                    )
+
+                elif action == "delete":
+                    sys_id = payload["sys_id"]
+                    await client.delete_record(table, sys_id)
+                    return json.dumps(
+                        format_response(
+                            data={
+                                "action": "delete",
+                                "table": table,
+                                "sys_id": sys_id,
+                                "deleted": True,
+                            },
+                            correlation_id=correlation_id,
+                        )
+                    )
+
+                else:
+                    return json.dumps(
+                        format_response(
+                            data=None,
+                            correlation_id=correlation_id,
+                            status="error",
+                            error=f"Unknown preview action: '{action}'",
+                        )
+                    )
+
+        except ForbiddenError as e:
             return json.dumps(
                 format_response(
-                    data={
-                        "table": table,
-                        "sys_id": sys_id,
-                        "record": mask_sensitive_fields(updated),
-                    },
+                    data=None,
                     correlation_id=correlation_id,
+                    status="error",
+                    error=f"Access denied by ServiceNow ACL: {e}",
                 )
             )
         except Exception as e:

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -12,7 +12,13 @@ from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
 from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
-from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id, validate_identifier
+from servicenow_mcp.utils import (
+    ServiceNowQuery,
+    format_response,
+    generate_correlation_id,
+    safe_tool_call,
+    validate_identifier,
+)
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -29,7 +35,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             table: The table name to map.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
 
@@ -150,15 +157,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except Exception as exc:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(exc),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def docs_artifact_summary(artifact_type: str, sys_id: str) -> str:
@@ -172,7 +172,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the artifact.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             table = ARTIFACT_TABLES.get(artifact_type)
             if not table:
                 valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
@@ -216,15 +217,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except Exception as exc:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(exc),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def docs_test_scenarios(artifact_type: str, sys_id: str) -> str:
@@ -238,7 +232,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the artifact.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             table = ARTIFACT_TABLES.get(artifact_type)
             if not table:
                 valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
@@ -274,15 +269,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except Exception as exc:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(exc),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def docs_review_notes(artifact_type: str, sys_id: str) -> str:
@@ -296,7 +284,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the artifact.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             table = ARTIFACT_TABLES.get(artifact_type)
             if not table:
                 valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
@@ -332,15 +321,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
             )
-        except Exception as exc:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(exc),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
 
 # ── Helper functions ──────────────────────────────────────────────────────

--- a/src/servicenow_mcp/tools/introspection.py
+++ b/src/servicenow_mcp/tools/introspection.py
@@ -12,7 +12,7 @@ from servicenow_mcp.policy import (
     enforce_query_safety,
     mask_sensitive_fields,
 )
-from servicenow_mcp.utils import format_response, generate_correlation_id, validate_identifier
+from servicenow_mcp.utils import format_response, generate_correlation_id, safe_tool_call, validate_identifier
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -26,7 +26,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             table: The ServiceNow table name (e.g., 'incident', 'sys_user').
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
             async with ServiceNowClient(settings, auth_provider) as client:
@@ -50,16 +51,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def table_get(
@@ -77,7 +70,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             display_values: If True, return display values instead of raw values.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
             field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
@@ -88,16 +82,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 format_response(data=record, correlation_id=correlation_id),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def table_query(
@@ -120,7 +106,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         """
         correlation_id = generate_correlation_id()
         warnings: list[str] = []
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
             safety = enforce_query_safety(table, query, limit, settings)
@@ -157,16 +144,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def table_aggregate(
@@ -193,7 +172,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sum_fields: Comma-separated fields to compute sum for.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
             enforce_query_safety(table, query, None, settings)
@@ -218,13 +198,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 format_response(data=result, correlation_id=correlation_id),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/investigations.py
+++ b/src/servicenow_mcp/tools/investigations.py
@@ -10,7 +10,7 @@ from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.investigations import INVESTIGATION_REGISTRY
 from servicenow_mcp.policy import check_table_access
-from servicenow_mcp.utils import format_response, generate_correlation_id, validate_identifier
+from servicenow_mcp.utils import format_response, generate_correlation_id, safe_tool_call, validate_identifier
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -31,7 +31,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             params: JSON string of parameters for the investigation.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             module = INVESTIGATION_REGISTRY.get(investigation)
             if module is None:
                 available = ", ".join(sorted(INVESTIGATION_REGISTRY.keys()))
@@ -55,15 +56,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 result = await module.run(client, params_dict)
 
             return json.dumps(format_response(data=result, correlation_id=correlation_id))
-        except Exception as exc:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(exc),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def investigate_explain(
@@ -77,7 +71,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             element_id: The element identifier (e.g. "flow_context:fc001" or a table name).
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             module = INVESTIGATION_REGISTRY.get(investigation)
             if module is None:
                 available = ", ".join(sorted(INVESTIGATION_REGISTRY.keys()))
@@ -102,12 +97,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 result = await module.explain(client, element_id)
 
             return json.dumps(format_response(data=result, correlation_id=correlation_id))
-        except Exception as exc:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(exc),
-                )
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/metadata.py
+++ b/src/servicenow_mcp/tools/metadata.py
@@ -13,6 +13,7 @@ from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
     generate_correlation_id,
+    safe_tool_call,
     validate_identifier,
 )
 
@@ -55,7 +56,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             limit: Maximum number of artifacts to return.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             table = ARTIFACT_TABLES.get(artifact_type)
             if table is None:
                 valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
@@ -86,16 +88,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def meta_get_artifact(
@@ -109,7 +103,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the artifact to retrieve.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             table = ARTIFACT_TABLES.get(artifact_type)
             if table is None:
                 valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
@@ -124,16 +119,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 format_response(data=record, correlation_id=correlation_id),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def meta_find_references(
@@ -150,7 +137,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             limit: Maximum number of matches to return per table.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             matches: list[dict[str, Any]] = []
             search_method = "code_search_api"
             effective_limit = min(limit, settings.max_row_limit)
@@ -212,16 +200,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def meta_what_writes(
@@ -235,7 +215,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             field: Optional field name to narrow results. When provided, only returns writers whose script references this field.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             if field:
                 validate_identifier(field)
@@ -270,13 +251,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/tools/relationships.py
+++ b/src/servicenow_mcp/tools/relationships.py
@@ -14,6 +14,7 @@ from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
     generate_correlation_id,
+    safe_tool_call,
     validate_identifier,
 )
 
@@ -30,7 +31,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the target record.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
             # Query sys_dictionary for reference fields pointing to this table
@@ -88,16 +90,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)
 
     @mcp.tool()
     async def rel_references_from(table: str, sys_id: str) -> str:
@@ -108,7 +102,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the source record.
         """
         correlation_id = generate_correlation_id()
-        try:
+
+        async def _run() -> str:
             validate_identifier(table)
             check_table_access(table)
             async with ServiceNowClient(settings, auth_provider) as client:
@@ -147,13 +142,5 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
                 indent=2,
             )
-        except Exception as e:
-            return json.dumps(
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=str(e),
-                ),
-                indent=2,
-            )
+
+        return await safe_tool_call(_run, correlation_id)

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -1,9 +1,16 @@
 """Utility functions for correlation IDs, response formatting and query building."""
 
+import json
+import logging
 import re
 import uuid
 import warnings
+from collections.abc import Awaitable, Callable
 from typing import Any
+
+from servicenow_mcp.errors import ForbiddenError
+
+logger = logging.getLogger(__name__)
 
 _IDENTIFIER_RE = re.compile(r"^[a-z0-9_]+$")
 
@@ -342,3 +349,34 @@ class ServiceNowQuery:
     def __str__(self) -> str:
         """Return the built query string."""
         return self.build()
+
+
+async def safe_tool_call(
+    fn: Callable[[], Awaitable[str]],
+    correlation_id: str,
+) -> str:
+    """Wrap an MCP tool body with standard error handling.
+
+    Catches ForbiddenError (ACL denial) and generic exceptions,
+    returning consistent JSON error envelopes via format_response.
+    """
+    try:
+        return await fn()
+    except ForbiddenError as e:
+        return json.dumps(
+            format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=f"Access denied by ServiceNow ACL: {e}",
+            )
+        )
+    except Exception as e:
+        return json.dumps(
+            format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=str(e),
+            )
+        )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,7 +19,7 @@ class TestBasicAuthProvider:
         }
         env.update(overrides)
         with patch.dict("os.environ", env, clear=True):
-            return Settings()
+            return Settings(_env_file=None)
 
     @pytest.mark.asyncio
     async def test_get_headers_returns_authorization(self):
@@ -95,7 +95,7 @@ class TestCreateAuth:
             "SERVICENOW_PASSWORD": "s3cret",
         }
         with patch.dict("os.environ", env, clear=True):
-            return Settings()
+            return Settings(_env_file=None)
 
     def test_create_auth_returns_basic_provider(self):
         """create_auth returns a BasicAuthProvider."""

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -1,0 +1,296 @@
+"""Tests for developer utility tools (dev_toggle, dev_set_property)."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from servicenow_mcp.auth import BasicAuthProvider
+
+BASE_URL = "https://test.service-now.com"
+
+
+@pytest.fixture
+def auth_provider(settings):
+    """Create a BasicAuthProvider from test settings."""
+    return BasicAuthProvider(settings)
+
+
+def _register_and_get_tools(settings, auth_provider):
+    """Helper: register dev_utils tools on a fresh MCP server and return tool map."""
+    from mcp.server.fastmcp import FastMCP
+
+    from servicenow_mcp.tools.dev_utils import register_tools
+
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider)
+    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+
+# -- dev_toggle ----------------------------------------------------------------
+
+
+class TestDevToggle:
+    """Tests for the dev_toggle tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_toggles_active_field(self, settings, auth_provider):
+        """Toggles the active field and returns old/new values."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "br001",
+                        "name": "My Business Rule",
+                        "active": "true",
+                    }
+                },
+            )
+        )
+        respx.patch(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "br001",
+                        "name": "My Business Rule",
+                        "active": "false",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["old_active"] == "true"
+        assert result["data"]["new_active"] == "false"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocked_in_prod(self, prod_settings, auth_provider):
+        """Returns error when environment is production."""
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.dev_utils import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unknown_artifact_type(self, settings, auth_provider):
+        """Returns error for unknown artifact type."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_toggle"](artifact_type="unknown_type", sys_id="br001", active=False)
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_denied_table_returns_error(self, settings, auth_provider):
+        """Returns error when resolved table is denied by policy."""
+        from unittest.mock import patch as mock_patch
+
+        from servicenow_mcp.errors import ForbiddenError
+
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        with mock_patch(
+            "servicenow_mcp.tools.dev_utils.check_table_access",
+            side_effect=ForbiddenError("Access forbidden"),
+        ):
+            raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
+
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "acl" in result["error"].lower() or "forbidden" in result["error"].lower()
+
+
+# -- dev_set_property ----------------------------------------------------------
+
+
+class TestDevSetProperty:
+    """Tests for the dev_set_property tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_updates_property_value(self, settings, auth_provider):
+        """Updates a system property and returns old value."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "prop001",
+                            "name": "glide.ui.session_timeout",
+                            "value": "30",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        respx.patch(f"{BASE_URL}/api/now/table/sys_properties/prop001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "prop001",
+                        "name": "glide.ui.session_timeout",
+                        "value": "60",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["old_value"] == "30"
+        assert result["data"]["new_value"] == "60"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blocked_in_prod(self, prod_settings):
+        """Returns error when environment is production."""
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.dev_utils import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_property_not_found(self, settings, auth_provider):
+        """Returns error when property doesn't exist."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": []},
+                headers={"X-Total-Count": "0"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_set_property"](name="nonexistent.property", value="x")
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+
+
+# -- Sensitive field masking ---------------------------------------------------
+
+
+class TestDevUtilsSensitiveFieldMasking:
+    """Tests for sensitive field masking in dev_utils tool responses."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dev_set_property_masks_sensitive_value(self, settings, auth_provider):
+        """Setting a property with a sensitive name masks old/new values in response."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "prop002",
+                            "name": "my.api_key_token",
+                            "value": "old_secret_key",
+                        }
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        respx.patch(f"{BASE_URL}/api/now/table/sys_properties/prop002").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "prop002",
+                        "name": "my.api_key_token",
+                        "value": "new_secret_key",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["dev_set_property"](name="my.api_key_token", value="new_secret_key")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["old_value"] == "***MASKED***"
+        assert result["data"]["new_value"] == "***MASKED***"
+        assert result["data"]["name"] == "my.api_key_token"
+
+
+# -- Generic exception handlers ------------------------------------------------
+
+
+class TestDevToggleGenericException:
+    """Tests for dev_toggle generic exception handler."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unexpected_exception(self, settings, auth_provider):
+        """dev_toggle returns error envelope when an unexpected exception occurs."""
+        from unittest.mock import AsyncMock, patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        with patch(
+            "servicenow_mcp.tools.dev_utils.ServiceNowClient.__aenter__",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("connection failed"),
+        ):
+            raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "connection failed" in result["error"]
+
+
+class TestDevSetPropertyGenericException:
+    """Tests for dev_set_property generic exception handler."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unexpected_exception(self, settings, auth_provider):
+        """dev_set_property returns error envelope when an unexpected exception occurs."""
+        from unittest.mock import AsyncMock, patch
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        with patch(
+            "servicenow_mcp.tools.dev_utils.ServiceNowClient.__aenter__",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("network failure"),
+        ):
+            raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "network failure" in result["error"]

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -728,3 +728,194 @@ class TestRecordApply:
 
         assert result["status"] == "error"
         assert "acl" in result["error"].lower()
+
+
+# -- mandatory field validation ------------------------------------------------
+
+METADATA_URL = f"{BASE_URL}/api/now/table/sys_dictionary"
+
+METADATA_WITH_TWO_MANDATORY = {
+    "result": [
+        {"element": "short_description", "mandatory": "true", "internal_type": "string"},
+        {"element": "category", "mandatory": "true", "internal_type": "string"},
+        {"element": "description", "mandatory": "false", "internal_type": "string"},
+    ]
+}
+
+METADATA_NO_MANDATORY = {
+    "result": [
+        {"element": "short_description", "mandatory": "false", "internal_type": "string"},
+        {"element": "description", "mandatory": "false", "internal_type": "string"},
+    ]
+}
+
+
+class TestMandatoryFieldValidation:
+    """Tests for mandatory field pre-flight validation on record creation."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_create_missing_mandatory_fields(self, settings, auth_provider):
+        """Returns error when mandatory fields are missing from create data."""
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=METADATA_WITH_TWO_MANDATORY))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test incident"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "missing_fields" in result["data"]
+        assert "category" in result["data"]["missing_fields"]
+        assert "Missing mandatory fields" in result["error"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_create_all_mandatory_present(self, settings, auth_provider):
+        """Proceeds with create when all mandatory fields are present."""
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=METADATA_WITH_TWO_MANDATORY))
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "result": {
+                        "sys_id": "new001",
+                        "short_description": "Test",
+                        "category": "software",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test", "category": "software"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == "new001"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_preview_create_missing_mandatory_fields(self, settings, auth_provider):
+        """Returns error when mandatory fields are missing from preview create data."""
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=METADATA_WITH_TWO_MANDATORY))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "category" in result["data"]["missing_fields"]
+        assert "Missing mandatory fields" in result["error"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_preview_create_all_mandatory_present(self, settings, auth_provider):
+        """Returns preview token when all mandatory fields are present."""
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=METADATA_WITH_TWO_MANDATORY))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test", "category": "software"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "token" in result["data"]
+        assert result["data"]["action"] == "create"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_apply_create_missing_mandatory_fields(self, settings, auth_provider):
+        """record_apply catches newly mandatory fields at apply time."""
+        # Phase 1: Preview succeeds - metadata has only 1 mandatory field
+        respx.get(METADATA_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {"element": "short_description", "mandatory": "true", "internal_type": "string"},
+                    ]
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        token = json.loads(preview_raw)["data"]["token"]
+
+        # Phase 2: Apply - metadata now returns a NEW mandatory field
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=METADATA_WITH_TWO_MANDATORY))
+
+        raw = await tools["record_apply"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "category" in result["data"]["missing_fields"]
+        assert "Missing mandatory fields" in result["error"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_create_no_mandatory_fields(self, settings, auth_provider):
+        """Proceeds normally when table has no mandatory fields."""
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=METADATA_NO_MANDATORY))
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "result": {
+                        "sys_id": "new002",
+                        "short_description": "Test",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == "new002"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_record_create_metadata_unavailable(self, settings, auth_provider):
+        """Create proceeds when metadata endpoint returns 500 (best-effort)."""
+        respx.get(METADATA_URL).mock(return_value=httpx.Response(500, json={"error": {"message": "Internal error"}}))
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "result": {
+                        "sys_id": "new003",
+                        "short_description": "Test",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == "new003"

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -1,4 +1,4 @@
-"""Tests for developer action tools (dev_toggle, dev_set_property, dev_seed_test_data, dev_cleanup, table_preview_update, table_apply_update)."""
+"""Tests for record CRUD tools (record_create, record_update, record_delete + preview/apply)."""
 
 import json
 
@@ -7,6 +7,7 @@ import pytest
 import respx
 
 from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.policy import DENIED_TABLES
 
 BASE_URL = "https://test.service-now.com"
 
@@ -28,337 +29,44 @@ def _register_and_get_tools(settings, auth_provider):
     return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
 
 
-# ── dev_toggle ────────────────────────────────────────────────────────────
+# -- record_create -------------------------------------------------------------
 
 
-class TestDevToggle:
-    """Tests for the dev_toggle tool."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_toggles_active_field(self, settings, auth_provider):
-        """Toggles the active field and returns old/new values."""
-        # Mock GET to read current record
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "br001",
-                        "name": "My Business Rule",
-                        "active": "true",
-                    }
-                },
-            )
-        )
-        # Mock PATCH to update active field
-        respx.patch(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "br001",
-                        "name": "My Business Rule",
-                        "active": "false",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["old_active"] == "true"
-        assert result["data"]["new_active"] == "false"
+class TestRecordCreate:
+    """Tests for the record_create tool."""
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_blocked_in_prod(self, prod_settings, auth_provider):
-        """Returns error when environment is production."""
-        from mcp.server.fastmcp import FastMCP
-
-        from servicenow_mcp.tools.developer import register_tools
-
-        # Create auth from prod_settings
-        prod_auth = BasicAuthProvider(prod_settings)
-        mcp = FastMCP("test")
-        register_tools(mcp, prod_settings, prod_auth)
-        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-
-        raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_unknown_artifact_type(self, settings, auth_provider):
-        """Returns error for unknown artifact type."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_toggle"](artifact_type="unknown_type", sys_id="br001", active=False)
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_denied_table_returns_error(self, settings, auth_provider):
-        """Returns error when resolved table is denied by policy."""
-        from unittest.mock import patch as mock_patch
-
-        from servicenow_mcp.errors import ForbiddenError
-
-        tools = _register_and_get_tools(settings, auth_provider)
-
-        with mock_patch(
-            "servicenow_mcp.tools.developer.check_table_access",
-            side_effect=ForbiddenError("Access forbidden"),
-        ):
-            raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
-
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "forbidden" in result["error"].lower()
-
-
-# ── dev_set_property ──────────────────────────────────────────────────────
-
-
-class TestDevSetProperty:
-    """Tests for the dev_set_property tool."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_updates_property_value(self, settings, auth_provider):
-        """Updates a system property and returns old value."""
-        # Mock query to find the property
-        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": [
-                        {
-                            "sys_id": "prop001",
-                            "name": "glide.ui.session_timeout",
-                            "value": "30",
-                        }
-                    ]
-                },
-                headers={"X-Total-Count": "1"},
-            )
-        )
-        # Mock PATCH to update value
-        respx.patch(f"{BASE_URL}/api/now/table/sys_properties/prop001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "prop001",
-                        "name": "glide.ui.session_timeout",
-                        "value": "60",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["old_value"] == "30"
-        assert result["data"]["new_value"] == "60"
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_blocked_in_prod(self, prod_settings):
-        """Returns error when environment is production."""
-        from mcp.server.fastmcp import FastMCP
-
-        from servicenow_mcp.tools.developer import register_tools
-
-        prod_auth = BasicAuthProvider(prod_settings)
-        mcp = FastMCP("test")
-        register_tools(mcp, prod_settings, prod_auth)
-        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-
-        raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_property_not_found(self, settings, auth_provider):
-        """Returns error when property doesn't exist."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
-            return_value=httpx.Response(
-                200,
-                json={"result": []},
-                headers={"X-Total-Count": "0"},
-            )
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_set_property"](name="nonexistent.property", value="x")
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-
-
-# ── dev_seed_test_data ────────────────────────────────────────────────────
-
-
-class TestDevSeedTestData:
-    """Tests for the dev_seed_test_data tool."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_inserts_records_and_returns_sys_ids(self, settings, auth_provider):
-        """Creates records and returns the created sys_ids with a seed tag."""
-        # Mock POST for each record creation
-        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
-            side_effect=[
-                httpx.Response(
-                    201,
-                    json={"result": {"sys_id": "new1", "number": "INC0099001"}},
-                ),
-                httpx.Response(
-                    201,
-                    json={"result": {"sys_id": "new2", "number": "INC0099002"}},
-                ),
-            ]
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        records_json = json.dumps(
-            [
-                {"short_description": "Test 1", "urgency": "3"},
-                {"short_description": "Test 2", "urgency": "3"},
-            ]
-        )
-        raw = await tools["dev_seed_test_data"](table="incident", records=records_json)
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["created_count"] == 2
-        assert "new1" in result["data"]["sys_ids"]
-        assert "new2" in result["data"]["sys_ids"]
-        assert "tag" in result["data"]
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_blocked_in_prod(self, prod_settings):
-        """Returns error when environment is production."""
-        from mcp.server.fastmcp import FastMCP
-
-        from servicenow_mcp.tools.developer import register_tools
-
-        prod_auth = BasicAuthProvider(prod_settings)
-        mcp = FastMCP("test")
-        register_tools(mcp, prod_settings, prod_auth)
-        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-
-        raw = await tools["dev_seed_test_data"](
-            table="incident",
-            records=json.dumps([{"short_description": "Test"}]),
-        )
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-
-
-# ── dev_cleanup ───────────────────────────────────────────────────────────
-
-
-class TestDevCleanup:
-    """Tests for the dev_cleanup tool."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_deletes_tracked_records(self, settings, auth_provider):
-        """Deletes records previously seeded and returns summary."""
-        # First seed some records to create the tracking state
+    async def test_creates_record_and_returns_masked(self, settings, auth_provider):
+        """Creates a record and returns it with sensitive fields masked."""
         respx.post(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=httpx.Response(
                 201,
-                json={"result": {"sys_id": "new1", "number": "INC0099001"}},
-            )
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-
-        # Seed first
-        seed_raw = await tools["dev_seed_test_data"](
-            table="incident",
-            records=json.dumps([{"short_description": "To cleanup"}]),
-            tag="cleanup-test-tag",
-        )
-        seed_result = json.loads(seed_raw)
-        assert seed_result["status"] == "success"
-
-        # Now mock DELETE
-        respx.delete(f"{BASE_URL}/api/now/table/incident/new1").mock(return_value=httpx.Response(204))
-
-        # Cleanup
-        raw = await tools["dev_cleanup"](tag="cleanup-test-tag")
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["deleted_count"] == 1
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_unknown_tag_returns_error(self, settings, auth_provider):
-        """Returns error for a tag that was never seeded."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_cleanup"](tag="nonexistent-tag")
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-
-
-# ── table_preview_update ──────────────────────────────────────────────────
-
-
-class TestTablePreviewUpdate:
-    """Tests for the table_preview_update tool."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_returns_diff_and_token(self, settings, auth_provider):
-        """Returns a field-level diff and a preview token."""
-        # Mock GET for current record
-        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
-            return_value=httpx.Response(
-                200,
                 json={
                     "result": {
-                        "sys_id": "inc001",
+                        "sys_id": "new001",
+                        "short_description": "Test incident",
                         "state": "1",
-                        "urgency": "2",
-                        "short_description": "Original",
+                        "password": "s3cret",
                     }
                 },
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        changes_json = json.dumps({"state": "2", "short_description": "Updated"})
-        raw = await tools["table_preview_update"](table="incident", sys_id="inc001", changes=changes_json)
+        raw = await tools["record_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test incident", "state": "1"}),
+        )
         result = json.loads(raw)
 
         assert result["status"] == "success"
-        assert "token" in result["data"]
-        diff = result["data"]["diff"]
-        assert "state" in diff
-        assert diff["state"]["old"] == "1"
-        assert diff["state"]["new"] == "2"
+        assert result["data"]["table"] == "incident"
+        assert result["data"]["sys_id"] == "new001"
+        assert result["data"]["record"]["short_description"] == "Test incident"
+        assert result["data"]["record"]["password"] == "***MASKED***"
 
     @pytest.mark.asyncio
-    @respx.mock
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error when environment is production."""
         from mcp.server.fastmcp import FastMCP
@@ -370,415 +78,61 @@ class TestTablePreviewUpdate:
         register_tools(mcp, prod_settings, prod_auth)
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
 
-        raw = await tools["table_preview_update"](
+        raw = await tools["record_create"](
             table="incident",
-            sys_id="inc001",
-            changes=json.dumps({"state": "2"}),
+            data=json.dumps({"short_description": "Test"}),
         )
         result = json.loads(raw)
 
         assert result["status"] == "error"
-
-
-# ── table_apply_update ────────────────────────────────────────────────────
-
-
-class TestTableApplyUpdate:
-    """Tests for the table_apply_update tool."""
+        assert "production" in result["error"].lower()
 
     @pytest.mark.asyncio
-    @respx.mock
-    async def test_applies_update_with_valid_token(self, settings, auth_provider):
-        """Applies the update using a valid preview token."""
-        # Step 1: Create a preview
-        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "inc001",
-                        "state": "1",
-                    }
-                },
-            )
-        )
-
+    async def test_denied_table_returns_error(self, settings, auth_provider):
+        """Returns error when table is denied by policy."""
+        denied = next(iter(DENIED_TABLES))
         tools = _register_and_get_tools(settings, auth_provider)
-        preview_raw = await tools["table_preview_update"](
-            table="incident",
-            sys_id="inc001",
-            changes=json.dumps({"state": "2"}),
-        )
-        preview_result = json.loads(preview_raw)
-        token = preview_result["data"]["token"]
 
-        # Step 2: Apply with the token
-        respx.patch(f"{BASE_URL}/api/now/table/incident/inc001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "inc001",
-                        "state": "2",
-                    }
-                },
-            )
+        raw = await tools["record_create"](
+            table=denied,
+            data=json.dumps({"value": "test"}),
         )
-
-        raw = await tools["table_apply_update"](preview_token=token)
         result = json.loads(raw)
 
-        assert result["status"] == "success"
-        assert result["data"]["record"]["state"] == "2"
+        assert result["status"] == "error"
+        assert "denied" in result["error"].lower()
 
     @pytest.mark.asyncio
-    @respx.mock
-    async def test_rejects_invalid_token(self, settings, auth_provider):
-        """Returns error for an invalid/unknown token."""
+    async def test_invalid_json_returns_error(self, settings, auth_provider):
+        """Returns error when data is not valid JSON."""
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["table_apply_update"](preview_token="invalid-token")
+        raw = await tools["record_create"](table="incident", data="not valid json")
         result = json.loads(raw)
 
         assert result["status"] == "error"
 
-
-# ── Error handling ────────────────────────────────────────────────────────
-
-
-class TestDeveloperErrorHandling:
-    """Tests for partial-failure handling in seed and cleanup operations."""
-
     @pytest.mark.asyncio
     @respx.mock
-    async def test_seed_partial_failure(self, settings, auth_provider):
-        """One record succeeds, one fails — response reflects partial success."""
+    async def test_acl_denied_returns_clear_error(self, settings, auth_provider):
+        """Returns clear error when ServiceNow ACL denies the operation."""
         respx.post(f"{BASE_URL}/api/now/table/incident").mock(
-            side_effect=[
-                httpx.Response(
-                    201,
-                    json={"result": {"sys_id": "new1", "number": "INC0099001"}},
-                ),
-                httpx.Response(500, json={"error": {"message": "Internal error"}}),
-            ]
+            return_value=httpx.Response(403, json={"error": {"message": "ACL denied"}})
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        records_json = json.dumps(
-            [
-                {"short_description": "Good record"},
-                {"short_description": "Bad record"},
-            ]
-        )
-        raw = await tools["dev_seed_test_data"](table="incident", records=records_json, tag="partial-seed")
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["created_count"] == 1
-        assert result["data"]["failed_count"] == 1
-        assert "new1" in result["data"]["sys_ids"]
-        assert len(result["data"]["sys_ids"]) == 1
-
-        # Verify only the successful record is tracked for cleanup
-        # by attempting a cleanup — the tag should exist with 1 record
-        respx.delete(f"{BASE_URL}/api/now/table/incident/new1").mock(return_value=httpx.Response(204))
-
-        raw = await tools["dev_cleanup"](tag="partial-seed")
-        cleanup_result = json.loads(raw)
-
-        assert cleanup_result["status"] == "success"
-        assert cleanup_result["data"]["deleted_count"] == 1
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_cleanup_partial_failure(self, settings, auth_provider):
-        """One delete succeeds, one fails — tag remains in tracker with failed record."""
-        # Seed two records first
-        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
-            side_effect=[
-                httpx.Response(
-                    201,
-                    json={"result": {"sys_id": "del1", "number": "INC0099010"}},
-                ),
-                httpx.Response(
-                    201,
-                    json={"result": {"sys_id": "del2", "number": "INC0099011"}},
-                ),
-            ]
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        records_json = json.dumps(
-            [
-                {"short_description": "Will delete"},
-                {"short_description": "Will fail delete"},
-            ]
-        )
-        seed_raw = await tools["dev_seed_test_data"](table="incident", records=records_json, tag="partial-cleanup")
-        seed_result = json.loads(seed_raw)
-        assert seed_result["status"] == "success"
-        assert seed_result["data"]["created_count"] == 2
-
-        # Mock deletions: first succeeds, second fails
-        respx.delete(f"{BASE_URL}/api/now/table/incident/del1").mock(return_value=httpx.Response(204))
-        respx.delete(f"{BASE_URL}/api/now/table/incident/del2").mock(return_value=httpx.Response(500))
-
-        raw = await tools["dev_cleanup"](tag="partial-cleanup")
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["deleted_count"] == 1
-        assert result["data"]["failed_count"] == 1
-
-        # Tag should still exist in tracker with the failed record
-        # Attempting cleanup again should find the tag
-        respx.delete(f"{BASE_URL}/api/now/table/incident/del2").mock(return_value=httpx.Response(204))
-
-        retry_raw = await tools["dev_cleanup"](tag="partial-cleanup")
-        retry_result = json.loads(retry_raw)
-        assert retry_result["status"] == "success"
-        assert retry_result["data"]["deleted_count"] == 1
-
-
-# ── Security: write gating & table access ────────────────────────────────
-
-
-class TestDevCleanupWriteGate:
-    """Tests for write-gate enforcement on dev_cleanup."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_dev_cleanup_blocked_in_production(self, prod_settings):
-        """Cleanup returns error when environment is production."""
-        from unittest.mock import patch as mock_patch
-
-        from mcp.server.fastmcp import FastMCP
-
-        from servicenow_mcp.tools.developer import register_tools
-
-        prod_auth = BasicAuthProvider(prod_settings)
-        mcp = FastMCP("test")
-        register_tools(mcp, prod_settings, prod_auth)
-        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-
-        # Patch SeededRecordTracker.get to return a fake entry so the tag lookup succeeds
-        with mock_patch(
-            "servicenow_mcp.state.SeededRecordTracker.get",
-            return_value=[{"table": "incident", "sys_ids": ["rec1"]}],
-        ):
-            raw = await tools["dev_cleanup"](tag="test-tag")
-
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "blocked" in result["error"].lower() or "production" in result["error"].lower()
-
-
-class TestTableApplyUpdateSecurity:
-    """Tests for write-gate and table-access enforcement on table_apply_update."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_table_apply_update_blocked_in_production(self, prod_settings):
-        """Apply returns error when environment is production."""
-        from unittest.mock import patch as mock_patch
-
-        from mcp.server.fastmcp import FastMCP
-
-        from servicenow_mcp.tools.developer import register_tools
-
-        prod_auth = BasicAuthProvider(prod_settings)
-        mcp = FastMCP("test")
-        register_tools(mcp, prod_settings, prod_auth)
-        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-
-        # Patch the preview store to return a valid payload
-        with mock_patch(
-            "servicenow_mcp.state.PreviewTokenStore.consume",
-            return_value={"table": "incident", "sys_id": "inc001", "changes": {"state": "2"}},
-        ):
-            raw = await tools["table_apply_update"](preview_token="fake-token")
-
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "blocked" in result["error"].lower() or "production" in result["error"].lower()
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_table_apply_update_denied_table(self, settings, auth_provider):
-        """Apply returns error when token references a denied table."""
-        from unittest.mock import patch as mock_patch
-
-        tools = _register_and_get_tools(settings, auth_provider)
-
-        # Patch the preview store to return a payload with a denied table
-        with mock_patch(
-            "servicenow_mcp.state.PreviewTokenStore.consume",
-            return_value={"table": "sys_user_has_password", "sys_id": "x", "changes": {"value": "y"}},
-        ):
-            raw = await tools["table_apply_update"](preview_token="fake-token")
-
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
-
-
-class TestTablePreviewUpdateSecurity:
-    """Tests for table-access enforcement on table_preview_update."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_table_preview_update_denied_table(self, settings, auth_provider):
-        """Preview returns error when table is on the deny list."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["table_preview_update"](
-            table="sys_user_has_password",
-            sys_id="x",
-            changes=json.dumps({"value": "y"}),
-        )
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_table_preview_update_invalid_sys_id(self, settings, auth_provider):
-        """Preview returns error when sys_id contains invalid characters."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["table_preview_update"](
+        raw = await tools["record_create"](
             table="incident",
-            sys_id="invalid;id",
-            changes=json.dumps({"state": "2"}),
+            data=json.dumps({"short_description": "Test"}),
         )
         result = json.loads(raw)
+
         assert result["status"] == "error"
-        assert "invalid identifier" in result["error"].lower()
-
-
-class TestDevSeedTestDataSecurity:
-    """Tests for table-access enforcement on dev_seed_test_data."""
+        assert "acl" in result["error"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_dev_seed_test_data_denied_table(self, settings, auth_provider):
-        """Seed returns error when table is on the deny list."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_seed_test_data"](
-            table="sys_user_has_password",
-            records=json.dumps([{"value": "test"}]),
-        )
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
-
-
-# ── Security: sensitive field masking ─────────────────────────────────────
-
-
-class TestSensitiveFieldMasking:
-    """Tests for sensitive field masking in developer tool responses."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_table_apply_update_masks_sensitive_fields(self, settings, auth_provider):
-        """Apply update masks sensitive fields like 'password' in the returned record."""
-        # Step 1: Create a preview
-        respx.get(f"{BASE_URL}/api/now/table/sys_user/u001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "u001",
-                        "user_name": "admin",
-                        "password": "old_secret",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        preview_raw = await tools["table_preview_update"](
-            table="sys_user",
-            sys_id="u001",
-            changes=json.dumps({"user_name": "new_admin"}),
-        )
-        preview_result = json.loads(preview_raw)
-        token = preview_result["data"]["token"]
-
-        # Step 2: Apply — response includes a password field
-        respx.patch(f"{BASE_URL}/api/now/table/sys_user/u001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "u001",
-                        "user_name": "new_admin",
-                        "password": "still_secret",
-                    }
-                },
-            )
-        )
-
-        raw = await tools["table_apply_update"](preview_token=token)
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["record"]["user_name"] == "new_admin"
-        assert result["data"]["record"]["password"] == "***MASKED***"
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_dev_set_property_masks_sensitive_value(self, settings, auth_provider):
-        """Setting a property with a sensitive name masks old/new values in response."""
-        # Mock query to find the property
-        respx.get(f"{BASE_URL}/api/now/table/sys_properties").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": [
-                        {
-                            "sys_id": "prop002",
-                            "name": "my.api_key_token",
-                            "value": "old_secret_key",
-                        }
-                    ]
-                },
-                headers={"X-Total-Count": "1"},
-            )
-        )
-        # Mock PATCH to update value
-        respx.patch(f"{BASE_URL}/api/now/table/sys_properties/prop002").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "prop002",
-                        "name": "my.api_key_token",
-                        "value": "new_secret_key",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_set_property"](name="my.api_key_token", value="new_secret_key")
-        result = json.loads(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["old_value"] == "***MASKED***"
-        assert result["data"]["new_value"] == "***MASKED***"
-        # Name should still be visible
-        assert result["data"]["name"] == "my.api_key_token"
-
-
-# ── Coverage: generic exception handlers ──────────────────────────────────
-
-
-class TestDevToggleGenericException:
-    """Tests for dev_toggle generic exception handler (lines 82-83)."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_unexpected_exception(self, settings, auth_provider):
-        """dev_toggle returns error envelope when an unexpected exception occurs."""
+    async def test_generic_exception(self, settings, auth_provider):
+        """Returns error envelope on unexpected exception."""
         from unittest.mock import AsyncMock, patch
 
         tools = _register_and_get_tools(settings, auth_provider)
@@ -787,132 +141,40 @@ class TestDevToggleGenericException:
             new_callable=AsyncMock,
             side_effect=RuntimeError("connection failed"),
         ):
-            raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
+            raw = await tools["record_create"](
+                table="incident",
+                data=json.dumps({"short_description": "Test"}),
+            )
         result = json.loads(raw)
         assert result["status"] == "error"
         assert "connection failed" in result["error"]
 
 
-class TestDevSetPropertyGenericException:
-    """Tests for dev_set_property generic exception handler (lines 154-155)."""
+# -- record_preview_create -----------------------------------------------------
+
+
+class TestRecordPreviewCreate:
+    """Tests for the record_preview_create tool."""
 
     @pytest.mark.asyncio
-    @respx.mock
-    async def test_unexpected_exception(self, settings, auth_provider):
-        """dev_set_property returns error envelope when an unexpected exception occurs."""
-        from unittest.mock import AsyncMock, patch
-
+    async def test_returns_token_and_data(self, settings, auth_provider):
+        """Returns a preview token and the masked data summary."""
         tools = _register_and_get_tools(settings, auth_provider)
-        with patch(
-            "servicenow_mcp.tools.developer.ServiceNowClient.__aenter__",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("network failure"),
-        ):
-            raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "network failure" in result["error"]
-
-
-class TestDevCleanupGenericException:
-    """Tests for dev_cleanup generic exception handler (lines 322-323)."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_unexpected_exception(self, settings, auth_provider):
-        """dev_cleanup returns error envelope when an unexpected exception occurs."""
-        from unittest.mock import patch
-
-        tools = _register_and_get_tools(settings, auth_provider)
-
-        # Patch SeededRecordTracker.get to raise an unexpected exception
-        with patch(
-            "servicenow_mcp.state.SeededRecordTracker.get",
-            side_effect=RuntimeError("tracker exploded"),
-        ):
-            raw = await tools["dev_cleanup"](tag="test-tag")
-
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "tracker exploded" in result["error"]
-
-
-class TestTablePreviewUpdateSensitiveField:
-    """Tests for table_preview_update with sensitive field (line 368)."""
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_sensitive_field_masked_in_diff(self, settings, auth_provider):
-        """Diff masks both old and new values for sensitive fields like 'password'."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_user/u001").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": "u001",
-                        "user_name": "admin",
-                        "password": "old_secret",
-                    }
-                },
-            )
+        raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test", "password": "s3cret"}),
         )
-
-        tools = _register_and_get_tools(settings, auth_provider)
-        changes_json = json.dumps({"password": "new_secret"})
-        raw = await tools["table_preview_update"](table="sys_user", sys_id="u001", changes=changes_json)
         result = json.loads(raw)
 
         assert result["status"] == "success"
-        diff = result["data"]["diff"]
-        assert "password" in diff
-        assert diff["password"]["old"] == "***MASKED***"
-        assert diff["password"]["new"] == "***MASKED***"
-
-
-# ── Write-gate: denied table vs production ────────────────────────────────
-
-
-class TestWriteBlockedReason:
-    """Tests for _write_blocked_reason() providing accurate error messages."""
+        assert "token" in result["data"]
+        assert result["data"]["table"] == "incident"
+        assert result["data"]["action"] == "create"
+        assert result["data"]["data"]["password"] == "***MASKED***"
 
     @pytest.mark.asyncio
-    @respx.mock
-    async def test_denied_table_non_prod(self, settings, auth_provider):
-        """Write tool returns 'restricted table' error for denied table in non-prod."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["dev_seed_test_data"](
-            table="sys_user_has_password",
-            records=json.dumps([{"value": "test"}]),
-        )
-        result = json.loads(raw)
-
-        assert result["status"] == "error"
-        assert "restricted table" in result["error"] or "denied by policy" in result["error"]
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_dev_cleanup_denied_table(self, settings, auth_provider):
-        """dev_cleanup returns error when tracker contains a denied table."""
-        from unittest.mock import patch as mock_patch
-
-        tools = _register_and_get_tools(settings, auth_provider)
-
-        with mock_patch(
-            "servicenow_mcp.state.SeededRecordTracker.get",
-            return_value=[{"table": "sys_user_token", "sys_ids": ["rec1"]}],
-        ):
-            raw = await tools["dev_cleanup"](tag="denied-table-tag")
-
-        result = json.loads(raw)
-        assert result["status"] == "error"
-        assert "restricted table" in result["error"] or "denied by policy" in result["error"].lower()
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_dev_cleanup_production_block(self, prod_settings):
-        """dev_cleanup returns 'production environments' error in prod."""
-        from unittest.mock import patch as mock_patch
-
+    async def test_blocked_in_prod(self, prod_settings):
+        """Returns error when environment is production."""
         from mcp.server.fastmcp import FastMCP
 
         from servicenow_mcp.tools.developer import register_tools
@@ -922,12 +184,547 @@ class TestWriteBlockedReason:
         register_tools(mcp, prod_settings, prod_auth)
         tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
 
-        with mock_patch(
-            "servicenow_mcp.state.SeededRecordTracker.get",
-            return_value=[{"table": "incident", "sys_ids": ["rec1"]}],
-        ):
-            raw = await tools["dev_cleanup"](tag="prod-tag")
-
+        raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
         result = json.loads(raw)
         assert result["status"] == "error"
-        assert "production environments" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_error(self, settings, auth_provider):
+        """Returns error when data is not valid JSON."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_create"](table="incident", data="{bad json")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+
+# -- record_update -------------------------------------------------------------
+
+
+class TestRecordUpdate:
+    """Tests for the record_update tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_updates_record_and_returns_masked(self, settings, auth_provider):
+        """Updates a record and returns it with sensitive fields masked."""
+        respx.patch(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "inc001",
+                        "state": "2",
+                        "password": "s3cret",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"state": "2"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == "inc001"
+        assert result["data"]["record"]["state"] == "2"
+        assert result["data"]["record"]["password"] == "***MASKED***"
+
+    @pytest.mark.asyncio
+    async def test_blocked_in_prod(self, prod_settings):
+        """Returns error in production."""
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.developer import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        raw = await tools["record_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"state": "2"}),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_denied_table_returns_error(self, settings, auth_provider):
+        """Returns error for denied table."""
+        denied = next(iter(DENIED_TABLES))
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        raw = await tools["record_update"](
+            table=denied,
+            sys_id="abc",
+            changes=json.dumps({"value": "x"}),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_not_found_returns_error(self, settings, auth_provider):
+        """Returns error when record doesn't exist."""
+        respx.patch(f"{BASE_URL}/api/now/table/incident/missing").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_update"](
+            table="incident",
+            sys_id="missing",
+            changes=json.dumps({"state": "2"}),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_acl_denied_returns_clear_error(self, settings, auth_provider):
+        """Returns clear ACL error."""
+        respx.patch(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(403, json={"error": {"message": "ACL denied"}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"state": "2"}),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "acl" in result["error"].lower()
+
+
+# -- record_preview_update -----------------------------------------------------
+
+
+class TestRecordPreviewUpdate:
+    """Tests for the record_preview_update tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_diff_and_token(self, settings, auth_provider):
+        """Fetches current record and returns field-level diff with token."""
+        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "inc001",
+                        "state": "1",
+                        "short_description": "Original",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"state": "2", "short_description": "Updated"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "token" in result["data"]
+        assert result["data"]["diff"]["state"]["old"] == "1"
+        assert result["data"]["diff"]["state"]["new"] == "2"
+        assert result["data"]["diff"]["short_description"]["old"] == "Original"
+        assert result["data"]["diff"]["short_description"]["new"] == "Updated"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_masks_sensitive_fields_in_diff(self, settings, auth_provider):
+        """Sensitive fields in the diff are masked."""
+        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "inc001",
+                        "password": "old_password",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"password": "new_password"}),
+        )
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["diff"]["password"]["old"] == "***MASKED***"
+        assert result["data"]["diff"]["password"]["new"] == "***MASKED***"
+
+    @pytest.mark.asyncio
+    async def test_blocked_in_prod(self, prod_settings):
+        """Returns error in production."""
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.developer import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        raw = await tools["record_preview_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"state": "2"}),
+        )
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+
+# -- record_delete -------------------------------------------------------------
+
+
+class TestRecordDelete:
+    """Tests for the record_delete tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deletes_record(self, settings, auth_provider):
+        """Deletes a record and returns confirmation."""
+        respx.delete(f"{BASE_URL}/api/now/table/incident/inc001").mock(return_value=httpx.Response(204))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_delete"](table="incident", sys_id="inc001")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["table"] == "incident"
+        assert result["data"]["sys_id"] == "inc001"
+        assert result["data"]["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_blocked_in_prod(self, prod_settings):
+        """Returns error in production."""
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.developer import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        raw = await tools["record_delete"](table="incident", sys_id="inc001")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_denied_table_returns_error(self, settings, auth_provider):
+        """Returns error for denied table."""
+        denied = next(iter(DENIED_TABLES))
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        raw = await tools["record_delete"](table=denied, sys_id="abc")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_not_found_returns_error(self, settings, auth_provider):
+        """Returns error when record doesn't exist."""
+        respx.delete(f"{BASE_URL}/api/now/table/incident/missing").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_delete"](table="incident", sys_id="missing")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_acl_denied_returns_clear_error(self, settings, auth_provider):
+        """Returns clear ACL error on 403."""
+        respx.delete(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(403, json={"error": {"message": "ACL denied"}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_delete"](table="incident", sys_id="inc001")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+        assert "acl" in result["error"].lower()
+
+
+# -- record_preview_delete -----------------------------------------------------
+
+
+class TestRecordPreviewDelete:
+    """Tests for the record_preview_delete tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_snapshot_and_token(self, settings, auth_provider):
+        """Fetches record and returns snapshot with preview token."""
+        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "inc001",
+                        "short_description": "Test incident",
+                        "state": "1",
+                        "password": "s3cret",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_delete"](table="incident", sys_id="inc001")
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert "token" in result["data"]
+        assert result["data"]["table"] == "incident"
+        assert result["data"]["sys_id"] == "inc001"
+        assert result["data"]["record_snapshot"]["short_description"] == "Test incident"
+        assert result["data"]["record_snapshot"]["password"] == "***MASKED***"
+
+    @pytest.mark.asyncio
+    async def test_blocked_in_prod(self, prod_settings):
+        """Returns error in production."""
+        from mcp.server.fastmcp import FastMCP
+
+        from servicenow_mcp.tools.developer import register_tools
+
+        prod_auth = BasicAuthProvider(prod_settings)
+        mcp = FastMCP("test")
+        register_tools(mcp, prod_settings, prod_auth)
+        tools = {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+        raw = await tools["record_preview_delete"](table="incident", sys_id="inc001")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_not_found_returns_error(self, settings, auth_provider):
+        """Returns error when record doesn't exist."""
+        respx.get(f"{BASE_URL}/api/now/table/incident/missing").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_preview_delete"](table="incident", sys_id="missing")
+        result = json.loads(raw)
+        assert result["status"] == "error"
+
+
+# -- record_apply --------------------------------------------------------------
+
+
+class TestRecordApply:
+    """Tests for the record_apply tool (applies any previewed action)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apply_create(self, settings, auth_provider):
+        """Applies a previewed create action."""
+        # Phase 1: Preview
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test", "state": "1"}),
+        )
+        token = json.loads(preview_raw)["data"]["token"]
+
+        # Phase 2: Apply
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "result": {
+                        "sys_id": "new001",
+                        "short_description": "Test",
+                        "state": "1",
+                    }
+                },
+            )
+        )
+
+        raw = await tools["record_apply"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["action"] == "create"
+        assert result["data"]["sys_id"] == "new001"
+        assert result["data"]["record"]["short_description"] == "Test"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apply_update(self, settings, auth_provider):
+        """Applies a previewed update action."""
+        # Phase 1: Preview (needs GET mock for current record)
+        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": "inc001", "state": "1"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_update"](
+            table="incident",
+            sys_id="inc001",
+            changes=json.dumps({"state": "2"}),
+        )
+        token = json.loads(preview_raw)["data"]["token"]
+
+        # Phase 2: Apply
+        respx.patch(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": "inc001", "state": "2"}},
+            )
+        )
+
+        raw = await tools["record_apply"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["action"] == "update"
+        assert result["data"]["record"]["state"] == "2"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apply_delete(self, settings, auth_provider):
+        """Applies a previewed delete action."""
+        # Phase 1: Preview (needs GET mock)
+        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "inc001",
+                        "short_description": "To be deleted",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_delete"](table="incident", sys_id="inc001")
+        token = json.loads(preview_raw)["data"]["token"]
+
+        # Phase 2: Apply
+        respx.delete(f"{BASE_URL}/api/now/table/incident/inc001").mock(return_value=httpx.Response(204))
+
+        raw = await tools["record_apply"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["action"] == "delete"
+        assert result["data"]["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_error(self, settings, auth_provider):
+        """Returns error for an invalid/unknown token."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["record_apply"](preview_token="nonexistent-token")
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "invalid" in result["error"].lower() or "expired" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_token_consumed_only_once(self, settings, auth_provider):
+        """Token is single-use - second apply with same token fails."""
+        # Preview a create
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        token = json.loads(preview_raw)["data"]["token"]
+
+        # First apply succeeds
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                201,
+                json={"result": {"sys_id": "new001", "short_description": "Test"}},
+            )
+        )
+        raw1 = await tools["record_apply"](preview_token=token)
+        result1 = json.loads(raw1)
+        assert result1["status"] == "success"
+
+        # Second apply with same token fails
+        raw2 = await tools["record_apply"](preview_token=token)
+        result2 = json.loads(raw2)
+        assert result2["status"] == "error"
+        assert "invalid" in result2["error"].lower() or "expired" in result2["error"].lower()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apply_masks_sensitive_fields(self, settings, auth_provider):
+        """Applied create masks sensitive fields in the returned record."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        token = json.loads(preview_raw)["data"]["token"]
+
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "result": {
+                        "sys_id": "new001",
+                        "short_description": "Test",
+                        "password": "s3cret",
+                    }
+                },
+            )
+        )
+
+        raw = await tools["record_apply"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["record"]["password"] == "***MASKED***"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_apply_acl_denied(self, settings, auth_provider):
+        """Returns clear ACL error when ServiceNow denies the apply operation."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["record_preview_create"](
+            table="incident",
+            data=json.dumps({"short_description": "Test"}),
+        )
+        token = json.loads(preview_raw)["data"]["token"]
+
+        respx.post(f"{BASE_URL}/api/now/table/incident").mock(
+            return_value=httpx.Response(403, json={"error": {"message": "ACL denied"}})
+        )
+
+        raw = await tools["record_apply"](preview_token=token)
+        result = json.loads(raw)
+
+        assert result["status"] == "error"
+        assert "acl" in result["error"].lower()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -325,7 +325,7 @@ class TestWriteGating:
         with caplog.at_level(logging.WARNING, logger="servicenow_mcp.policy"):
             can_write("sys_user_has_password", settings)
 
-        assert any("deny list" in record.message for record in caplog.records)
+        assert any("restricted table" in record.message for record in caplog.records)
 
     def test_write_blocked_in_prod_logs_warning(self, prod_settings, caplog):
         """Write blocked in production logs a warning."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,10 +1,10 @@
-"""Tests for in-memory state management (PreviewTokenStore, SeededRecordTracker)."""
+"""Tests for in-memory state management (PreviewTokenStore)."""
 
 from unittest.mock import patch
 
 import pytest
 
-from servicenow_mcp.state import PreviewTokenStore, SeededRecordTracker
+from servicenow_mcp.state import PreviewTokenStore
 
 
 class TestPreviewTokenStore:
@@ -141,38 +141,3 @@ class TestPreviewTokenStore:
             store._sweep_expired()
 
         assert len(store._store) == 0
-
-
-class TestSeededRecordTracker:
-    """Tests for SeededRecordTracker."""
-
-    def test_track_and_get(self):
-        """track() stores records, get() retrieves them."""
-        tracker = SeededRecordTracker()
-        tracker.track("tag1", "incident", ["sys1", "sys2"])
-        result = tracker.get("tag1")
-        assert result is not None
-        assert len(result) == 1
-        assert result[0]["table"] == "incident"
-        assert result[0]["sys_ids"] == ["sys1", "sys2"]
-
-    def test_track_multiple_tables(self):
-        """track() accumulates records across multiple tables for the same tag."""
-        tracker = SeededRecordTracker()
-        tracker.track("tag1", "incident", ["sys1"])
-        tracker.track("tag1", "problem", ["sys2", "sys3"])
-        result = tracker.get("tag1")
-        assert result is not None
-        assert len(result) == 2
-
-    def test_get_unknown_tag_returns_none(self):
-        """get() returns None for a tag that was never tracked."""
-        tracker = SeededRecordTracker()
-        assert tracker.get("unknown") is None
-
-    def test_remove(self):
-        """remove() deletes all tracked records for a tag."""
-        tracker = SeededRecordTracker()
-        tracker.track("tag1", "incident", ["sys1"])
-        tracker.remove("tag1")
-        assert tracker.get("tag1") is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,13 @@
 """Tests for utility functions."""
 
+import json
 import uuid
 import warnings
 
 import pytest
+
+from servicenow_mcp.errors import ForbiddenError
+from servicenow_mcp.utils import safe_tool_call
 
 
 class TestCorrelationId:
@@ -556,3 +560,41 @@ class TestServiceNowQueryInList:
 
         result = ServiceNowQuery().in_list("state", []).build()
         assert result == "stateIN"
+
+
+class TestSafeToolCall:
+    """Tests for the safe_tool_call error-handling wrapper."""
+
+    async def test_success_passthrough(self):
+        """Successful fn return passes through unchanged."""
+
+        async def fn() -> str:
+            return '{"status": "ok"}'
+
+        result = await safe_tool_call(fn, "test-corr-id")
+        assert result == '{"status": "ok"}'
+
+    async def test_forbidden_error_returns_acl_envelope(self):
+        """ForbiddenError is caught and formatted as ACL denial."""
+
+        async def fn() -> str:
+            raise ForbiddenError("no access to incident")
+
+        result = await safe_tool_call(fn, "test-corr-id")
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"
+        assert "Access denied by ServiceNow ACL" in parsed["error"]
+        assert "no access to incident" in parsed["error"]
+        assert parsed["correlation_id"] == "test-corr-id"
+
+    async def test_generic_exception_returns_error_envelope(self):
+        """Generic exceptions are caught and formatted as error envelope."""
+
+        async def fn() -> str:
+            raise ValueError("something broke")
+
+        result = await safe_tool_call(fn, "test-corr-id")
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"
+        assert "something broke" in parsed["error"]
+        assert parsed["correlation_id"] == "test-corr-id"


### PR DESCRIPTION
## Summary

### Record CRUD Tools
- 7 new tools: `record_create`, `record_preview_create`, `record_update`, `record_preview_update`, `record_delete`, `record_preview_delete`, `record_apply`
- Both direct and preview-then-apply patterns for all operations
- Replaces old `dev_seed_test_data`/`dev_cleanup` tools

### Shared Error Handling
- Added `safe_tool_call()` helper to `utils.py`
- Migrated 35 of 36 tools to use it (all async tools)
- Consistent `ForbiddenError` (ACL) handling across all tools
- ~176 lines of duplicated boilerplate removed

### Mandatory Field Validation
- `record_create`, `record_preview_create`, and `record_apply` (create path) pre-flight check mandatory fields via `sys_dictionary`
- Returns clear error listing missing fields before API call
- Best-effort: proceeds if metadata unavailable

### Code Review Fixes
- Renamed `_is_sensitive_field` to `is_sensitive_field` (public cross-module API)
- DRYed `can_write()` to delegate to `write_blocked_reason()`
- Moved `dev_toggle`/`dev_set_property` to `dev_utils` module

### Developer Utilities
- New `tools/dev_utils.py` module for `dev_toggle` and `dev_set_property`
- Removed `SeededRecordTracker` from state.py

### Tests
- 474 tests passing (up from ~430)
- 10 new tests for dev_utils
- 3 new tests for safe_tool_call
- 7 new tests for mandatory field validation
- 32 tests for record CRUD tools

### Docs
- Updated README with new tool names, counts, safety section
- Updated banner SVG (33 -> 36 tools)
- Updated agent prompt