### PR TITLE
chore: disable ATF tools from full package

### DIFF
--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -32,7 +32,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "full": [
         "introspection",
         "relationships",
-        "testing",
+        # "testing",  # ATF - disabled
         "metadata",
         "changes",
         "debug",

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -219,7 +219,8 @@ class TestPackageRegistry:
         assert "investigations" in groups
         assert "documentation" in groups
         assert "utility" in groups
-        assert len(groups) == 17
+        assert "testing" not in groups
+        assert len(groups) == 16
 
 
 class TestCommaSeparatedGroups:
@@ -452,11 +453,11 @@ class TestDomainPackages:
         assert groups == ["domain_incident", "domain_change", "utility"]
 
     def test_backward_compatibility_full_package_count(self):
-        """full package has 17 total groups (11 original + 6 domain)."""
+        """full package has 16 total groups (10 original + 6 domain)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("full")
-        assert len(groups) == 17
+        assert len(groups) == 16
 
     def test_backward_compatibility_itil_package_count(self):
         """itil package has 11 total groups (7 original + 4 domain)."""


### PR DESCRIPTION
## Summary

- ATF testing tools are commented out in the `full` package registry so they are no longer exposed via the MCP server.
- They can be re-enabled by uncommenting the `"testing"` line in `PACKAGE_REGISTRY`.
- No code was deleted -- the testing tool group and all ATF functionality remain intact.

## Changes

- `src/servicenow_mcp/packages.py`: Commented out `"testing"` in the `full` package group list.
- `tests/test_packages.py`: Updated assertions to reflect 16 groups instead of 17, and added an explicit check that `"testing"` is not in the full package groups.