### PR TITLE
feat: add Service Catalog API domain tools

### DIFF
--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -513,6 +513,204 @@ class ServiceNowClient:
         self._raise_for_status(response)
         return self._extract_result(response.json())
 
+    # ── Service Catalog API ──────────────────────────────────────────────
+
+    def _sc_url(self, *segments: str) -> str:
+        """Build the Service Catalog REST API URL.
+
+        Examples:
+            _sc_url("catalogs")            -> .../api/sn_sc/servicecatalog/catalogs
+            _sc_url("items", sys_id)       -> .../api/sn_sc/servicecatalog/items/{sys_id}
+        """
+        path = "/".join(segments)
+        return f"{self._settings.servicenow_instance_url}/api/sn_sc/servicecatalog/{path}"
+
+    async def sc_get_catalogs(
+        self,
+        limit: int | None = None,
+        text: str = "",
+    ) -> Any:
+        """Retrieve list of catalogs the user has access to."""
+        http = self._ensure_client()
+        params: dict[str, str] = {"sysparm_text": text}
+        if limit is not None:
+            params["sysparm_limit"] = str(limit)
+
+        response = await http.get(
+            self._sc_url("catalogs"),
+            headers=await self._headers(),
+            params=params,
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_catalog(self, sys_id: str) -> Any:
+        """Retrieve details of a specific catalog."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._sc_url("catalogs", sys_id),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_catalog_categories(
+        self,
+        catalog_sys_id: str,
+        limit: int | None = None,
+        offset: int | None = None,
+        top_level_only: bool = False,
+    ) -> Any:
+        """Retrieve categories for a specific catalog."""
+        http = self._ensure_client()
+        params: dict[str, str] = {}
+        if limit is not None:
+            params["sysparm_limit"] = str(limit)
+        if offset is not None:
+            params["sysparm_offset"] = str(offset)
+        if top_level_only:
+            params["sysparm_top_level_only"] = "true"
+
+        response = await http.get(
+            self._sc_url("catalogs", catalog_sys_id, "categories"),
+            headers=await self._headers(),
+            params=params,
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_category(self, sys_id: str) -> Any:
+        """Retrieve details of a specific category."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._sc_url("categories", sys_id),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_items(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        text: str = "",
+        catalog: str = "",
+        category: str = "",
+    ) -> Any:
+        """Retrieve list of catalog items."""
+        http = self._ensure_client()
+        params: dict[str, str] = {"sysparm_text": text}
+        if limit is not None:
+            params["sysparm_limit"] = str(limit)
+        if offset is not None:
+            params["sysparm_offset"] = str(offset)
+        if catalog:
+            params["sysparm_catalog"] = catalog
+        if category:
+            params["sysparm_category"] = category
+
+        response = await http.get(
+            self._sc_url("items"),
+            headers=await self._headers(),
+            params=params,
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_item(self, sys_id: str) -> Any:
+        """Retrieve details of a specific catalog item."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._sc_url("items", sys_id),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_item_variables(self, sys_id: str) -> Any:
+        """Retrieve variables for a specific catalog item."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._sc_url("items", sys_id, "variables"),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_order_now(self, item_sys_id: str, variables: dict[str, Any] | None = None) -> Any:
+        """Order a catalog item immediately (skip cart).
+
+        Args:
+            item_sys_id: The sys_id of the catalog item.
+            variables: Variable name-value pairs for the item.
+        """
+        http = self._ensure_client()
+        body: dict[str, Any] = {}
+        if variables:
+            body["sysparm_quantity"] = "1"
+            body["variables"] = variables
+
+        response = await http.post(
+            self._sc_url("items", item_sys_id, "order_now"),
+            headers=await self._headers(),
+            json=body,
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_add_to_cart(self, item_sys_id: str, variables: dict[str, Any] | None = None) -> Any:
+        """Add a catalog item to the cart.
+
+        Args:
+            item_sys_id: The sys_id of the catalog item.
+            variables: Variable name-value pairs for the item.
+        """
+        http = self._ensure_client()
+        body: dict[str, Any] = {}
+        if variables:
+            body["sysparm_quantity"] = "1"
+            body["variables"] = variables
+
+        response = await http.post(
+            self._sc_url("items", item_sys_id, "add_to_cart"),
+            headers=await self._headers(),
+            json=body,
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_get_cart(self) -> Any:
+        """Retrieve the current user's cart."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._sc_url("cart"),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_submit_order(self) -> Any:
+        """Submit the current cart as an order."""
+        http = self._ensure_client()
+        response = await http.post(
+            self._sc_url("cart", "submit_order"),
+            headers=await self._headers(),
+            json={},
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def sc_checkout(self) -> Any:
+        """Checkout the current cart (two-step ordering)."""
+        http = self._ensure_client()
+        response = await http.post(
+            self._sc_url("cart", "checkout"),
+            headers=await self._headers(),
+            json={},
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
     # ── ATF Cloud Runner API ───────────────────────────────────────────
 
     def _atf_cloud_runner_url(self, endpoint: str) -> str:

--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -18,6 +18,7 @@ _TOOL_GROUP_MODULES: dict[str, str] = {
     "domain_problem": "servicenow_mcp.tools.domains.problem",
     "domain_request": "servicenow_mcp.tools.domains.request",
     "domain_knowledge": "servicenow_mcp.tools.domains.knowledge",
+    "domain_service_catalog": "servicenow_mcp.tools.domains.service_catalog",
 }
 
 # Registry mapping package names to lists of tool group names.
@@ -47,6 +48,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "domain_problem",
         "domain_request",
         "domain_knowledge",
+        "domain_service_catalog",
     ],
     "none": [],
     "itil": [
@@ -125,6 +127,11 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "introspection",
         "utility",
         "domain_knowledge",
+    ],
+    "service_catalog": [
+        "introspection",
+        "utility",
+        "domain_service_catalog",
     ],
 }
 

--- a/src/servicenow_mcp/tools/domains/service_catalog.py
+++ b/src/servicenow_mcp/tools/domains/service_catalog.py
@@ -1,0 +1,257 @@
+"""Service Catalog domain tools."""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.choices import ChoiceRegistry
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.config import Settings
+from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.policy import write_gate
+from servicenow_mcp.utils import format_response
+
+
+def register_tools(
+    mcp: FastMCP,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    choices: ChoiceRegistry | None = None,
+) -> None:
+    """Register Service Catalog tools with MCP server.
+
+    Args:
+        mcp: FastMCP instance for tool registration
+        settings: Server configuration settings
+        auth_provider: Authentication provider for ServiceNow API
+        choices: Optional choice registry for resolving field values
+    """
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_catalogs_list(
+        limit: int = 20,
+        text: str = "",
+        *,
+        correlation_id: str,
+    ) -> str:
+        """List service catalogs the user has access to.
+
+        Args:
+            limit: Maximum number of catalogs to return (default 20)
+            text: Search text to filter catalogs
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_catalogs(limit=limit, text=text)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_catalog_get(
+        sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Fetch details of a specific service catalog.
+
+        Args:
+            sys_id: The sys_id of the catalog
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_catalog(sys_id)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_categories_list(
+        catalog_sys_id: str,
+        limit: int = 20,
+        offset: int = 0,
+        top_level_only: bool = False,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """List categories for a specific service catalog.
+
+        Args:
+            catalog_sys_id: The sys_id of the catalog
+            limit: Maximum number of categories to return (default 20)
+            offset: Number of records to skip for pagination
+            top_level_only: If true, return only top-level categories
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_catalog_categories(
+                catalog_sys_id=catalog_sys_id,
+                limit=limit,
+                offset=offset,
+                top_level_only=top_level_only,
+            )
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_category_get(
+        sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Fetch details of a specific service catalog category.
+
+        Args:
+            sys_id: The sys_id of the category
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_category(sys_id)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_items_list(
+        limit: int = 20,
+        offset: int = 0,
+        text: str = "",
+        catalog: str = "",
+        category: str = "",
+        *,
+        correlation_id: str,
+    ) -> str:
+        """List catalog items with optional filters.
+
+        Args:
+            limit: Maximum number of items to return (default 20)
+            offset: Number of records to skip for pagination
+            text: Search text to filter items
+            catalog: Filter by catalog sys_id
+            category: Filter by category sys_id
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_items(
+                limit=limit,
+                offset=offset,
+                text=text,
+                catalog=catalog,
+                category=category,
+            )
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_item_get(
+        sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Fetch details of a specific catalog item.
+
+        Args:
+            sys_id: The sys_id of the catalog item
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_item(sys_id)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_item_variables(
+        sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Fetch variables (form fields) for a specific catalog item.
+
+        Args:
+            sys_id: The sys_id of the catalog item
+        """
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_item_variables(sys_id)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_order_now(
+        item_sys_id: str,
+        variables: str = "",
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Order a catalog item immediately, bypassing the cart.
+
+        Args:
+            item_sys_id: The sys_id of the catalog item to order
+            variables: JSON string of variable name-value pairs (e.g. '{"urgency": "1"}')
+        """
+        blocked = write_gate("sc_req_item", settings, correlation_id)
+        if blocked:
+            return blocked
+
+        parsed_vars = json.loads(variables) if variables else None
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_order_now(item_sys_id, variables=parsed_vars)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_add_to_cart(
+        item_sys_id: str,
+        variables: str = "",
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Add a catalog item to the shopping cart.
+
+        Args:
+            item_sys_id: The sys_id of the catalog item to add
+            variables: JSON string of variable name-value pairs (e.g. '{"urgency": "1"}')
+        """
+        blocked = write_gate("sc_cart_item", settings, correlation_id)
+        if blocked:
+            return blocked
+
+        parsed_vars = json.loads(variables) if variables else None
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_add_to_cart(item_sys_id, variables=parsed_vars)
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_cart_get(
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Retrieve the current user's shopping cart contents."""
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_get_cart()
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_cart_submit(
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Submit the current shopping cart as an order request."""
+        blocked = write_gate("sc_request", settings, correlation_id)
+        if blocked:
+            return blocked
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_submit_order()
+            return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def sc_cart_checkout(
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Checkout the current shopping cart (two-step ordering)."""
+        blocked = write_gate("sc_request", settings, correlation_id)
+        if blocked:
+            return blocked
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.sc_checkout()
+            return format_response(data=result, correlation_id=correlation_id)

--- a/tests/domains/test_service_catalog.py
+++ b/tests/domains/test_service_catalog.py
@@ -1,0 +1,568 @@
+"""Tests for Service Catalog domain tools."""
+
+from unittest.mock import patch
+
+import pytest
+import respx
+from httpx import Response
+from toon_format import decode as toon_decode
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.config import Settings
+
+BASE_URL = "https://test.service-now.com"
+SC_BASE = f"{BASE_URL}/api/sn_sc/servicecatalog"
+
+
+def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider) -> dict:
+    """Helper to register service catalog tools and extract callables."""
+    from mcp.server.fastmcp import FastMCP
+
+    from servicenow_mcp.choices import ChoiceRegistry
+    from servicenow_mcp.tools.domains.service_catalog import register_tools
+
+    mcp = FastMCP("test")
+    choices = ChoiceRegistry(settings, auth_provider)
+    choices._fetched = True
+    choices._cache = {k: dict(v) for k, v in ChoiceRegistry._DEFAULTS.items()}
+    register_tools(mcp, settings, auth_provider, choices=choices)
+    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+
+# ── Catalog List ─────────────────────────────────────────────────────────
+
+
+class TestScCatalogsList:
+    """Tests for sc_catalogs_list tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_defaults(self, settings, auth_provider):
+        """Should list catalogs with default parameters."""
+        respx.get(f"{SC_BASE}/catalogs").mock(
+            return_value=Response(
+                200,
+                json={
+                    "result": [
+                        {"sys_id": "cat1", "title": "Service Catalog"},
+                        {"sys_id": "cat2", "title": "Technical Catalog"},
+                    ]
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_catalogs_list"]()
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert len(data["data"]) == 2
+        assert data["data"][0]["title"] == "Service Catalog"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_with_text_filter(self, settings, auth_provider):
+        """Should pass text search parameter."""
+        respx.get(f"{SC_BASE}/catalogs").mock(return_value=Response(200, json={"result": []}))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        await tools["sc_catalogs_list"](text="hardware")
+
+        request = respx.calls.last.request
+        assert "sysparm_text=hardware" in str(request.url)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_with_limit(self, settings, auth_provider):
+        """Should pass limit parameter."""
+        respx.get(f"{SC_BASE}/catalogs").mock(return_value=Response(200, json={"result": []}))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        await tools["sc_catalogs_list"](limit=5)
+
+        request = respx.calls.last.request
+        assert "sysparm_limit=5" in str(request.url)
+
+
+# ── Catalog Get ──────────────────────────────────────────────────────────
+
+
+class TestScCatalogGet:
+    """Tests for sc_catalog_get tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_catalog(self, settings, auth_provider):
+        """Should fetch a specific catalog by sys_id."""
+        respx.get(f"{SC_BASE}/catalogs/cat123").mock(
+            return_value=Response(
+                200,
+                json={"result": {"sys_id": "cat123", "title": "Service Catalog"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_catalog_get"](sys_id="cat123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["sys_id"] == "cat123"
+        assert data["data"]["title"] == "Service Catalog"
+
+
+# ── Categories List ──────────────────────────────────────────────────────
+
+
+class TestScCategoriesList:
+    """Tests for sc_categories_list tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_categories(self, settings, auth_provider):
+        """Should list categories for a catalog."""
+        respx.get(f"{SC_BASE}/catalogs/cat123/categories").mock(
+            return_value=Response(
+                200,
+                json={
+                    "result": [
+                        {"sys_id": "categ1", "title": "Hardware"},
+                        {"sys_id": "categ2", "title": "Software"},
+                    ]
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_categories_list"](catalog_sys_id="cat123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert len(data["data"]) == 2
+        assert data["data"][0]["title"] == "Hardware"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_categories_with_pagination(self, settings, auth_provider):
+        """Should pass limit and offset parameters."""
+        respx.get(f"{SC_BASE}/catalogs/cat123/categories").mock(return_value=Response(200, json={"result": []}))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        await tools["sc_categories_list"](catalog_sys_id="cat123", limit=10, offset=5)
+
+        request = respx.calls.last.request
+        url = str(request.url)
+        assert "sysparm_limit=10" in url
+        assert "sysparm_offset=5" in url
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_categories_top_level_only(self, settings, auth_provider):
+        """Should pass top_level_only parameter."""
+        respx.get(f"{SC_BASE}/catalogs/cat123/categories").mock(return_value=Response(200, json={"result": []}))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        await tools["sc_categories_list"](catalog_sys_id="cat123", top_level_only=True)
+
+        request = respx.calls.last.request
+        assert "sysparm_top_level_only=true" in str(request.url)
+
+
+# ── Category Get ─────────────────────────────────────────────────────────
+
+
+class TestScCategoryGet:
+    """Tests for sc_category_get tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_category(self, settings, auth_provider):
+        """Should fetch a specific category by sys_id."""
+        respx.get(f"{SC_BASE}/categories/categ123").mock(
+            return_value=Response(
+                200,
+                json={"result": {"sys_id": "categ123", "title": "Hardware"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_category_get"](sys_id="categ123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["sys_id"] == "categ123"
+        assert data["data"]["title"] == "Hardware"
+
+
+# ── Items List ───────────────────────────────────────────────────────────
+
+
+class TestScItemsList:
+    """Tests for sc_items_list tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_items_defaults(self, settings, auth_provider):
+        """Should list catalog items with default parameters."""
+        respx.get(f"{SC_BASE}/items").mock(
+            return_value=Response(
+                200,
+                json={
+                    "result": [
+                        {"sys_id": "item1", "name": "Laptop"},
+                        {"sys_id": "item2", "name": "Monitor"},
+                    ]
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_items_list"]()
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert len(data["data"]) == 2
+        assert data["data"][0]["name"] == "Laptop"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_items_with_filters(self, settings, auth_provider):
+        """Should pass text, catalog, and category filters."""
+        respx.get(f"{SC_BASE}/items").mock(return_value=Response(200, json={"result": []}))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        await tools["sc_items_list"](
+            text="laptop",
+            catalog="cat123",
+            category="categ456",
+            limit=10,
+            offset=5,
+        )
+
+        request = respx.calls.last.request
+        url = str(request.url)
+        assert "sysparm_text=laptop" in url
+        assert "sysparm_catalog=cat123" in url
+        assert "sysparm_category=categ456" in url
+        assert "sysparm_limit=10" in url
+        assert "sysparm_offset=5" in url
+
+
+# ── Item Get ─────────────────────────────────────────────────────────────
+
+
+class TestScItemGet:
+    """Tests for sc_item_get tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_item(self, settings, auth_provider):
+        """Should fetch a specific catalog item by sys_id."""
+        respx.get(f"{SC_BASE}/items/item123").mock(
+            return_value=Response(
+                200,
+                json={"result": {"sys_id": "item123", "name": "Laptop", "price": "$1200"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_item_get"](sys_id="item123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["sys_id"] == "item123"
+        assert data["data"]["name"] == "Laptop"
+
+
+# ── Item Variables ───────────────────────────────────────────────────────
+
+
+class TestScItemVariables:
+    """Tests for sc_item_variables tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_variables(self, settings, auth_provider):
+        """Should fetch variables for a catalog item."""
+        respx.get(f"{SC_BASE}/items/item123/variables").mock(
+            return_value=Response(
+                200,
+                json={
+                    "result": [
+                        {"name": "urgency", "type": "choice", "mandatory": True},
+                        {"name": "description", "type": "text", "mandatory": False},
+                    ]
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_item_variables"](sys_id="item123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert len(data["data"]) == 2
+        assert data["data"][0]["name"] == "urgency"
+
+
+# ── Order Now ────────────────────────────────────────────────────────────
+
+
+class TestScOrderNow:
+    """Tests for sc_order_now tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("servicenow_mcp.policy.write_gate", return_value=None)
+    async def test_order_now_no_variables(self, mock_write_gate, settings, auth_provider):
+        """Should order an item without variables."""
+        respx.post(f"{SC_BASE}/items/item123/order_now").mock(
+            return_value=Response(
+                200,
+                json={"result": {"sys_id": "req123", "number": "REQ0010001"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_order_now"](item_sys_id="item123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["number"] == "REQ0010001"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("servicenow_mcp.policy.write_gate", return_value=None)
+    async def test_order_now_with_variables(self, mock_write_gate, settings, auth_provider):
+        """Should order an item with variables JSON."""
+        respx.post(f"{SC_BASE}/items/item123/order_now").mock(
+            return_value=Response(
+                200,
+                json={"result": {"sys_id": "req123", "number": "REQ0010001"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_order_now"](
+            item_sys_id="item123",
+            variables='{"urgency": "1"}',
+        )
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["number"] == "REQ0010001"
+
+    @pytest.mark.asyncio
+    async def test_order_now_blocked_in_prod(self):
+        """Should block ordering in production."""
+        prod_env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "password",
+            "MCP_TOOL_PACKAGE": "full",
+            "SERVICENOW_ENV": "prod",
+        }
+        with patch.dict("os.environ", prod_env, clear=True):
+            prod_settings = Settings(_env_file=None)
+            prod_auth = BasicAuthProvider(prod_settings)
+
+            tools = _register_and_get_tools(prod_settings, prod_auth)
+            result = await tools["sc_order_now"](item_sys_id="item123")
+            data = toon_decode(result)
+
+            assert data["status"] == "error"
+            assert "production" in data["error"].lower()
+
+
+# ── Add to Cart ──────────────────────────────────────────────────────────
+
+
+class TestScAddToCart:
+    """Tests for sc_add_to_cart tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("servicenow_mcp.policy.write_gate", return_value=None)
+    async def test_add_to_cart_no_variables(self, mock_write_gate, settings, auth_provider):
+        """Should add item to cart without variables."""
+        respx.post(f"{SC_BASE}/items/item123/add_to_cart").mock(
+            return_value=Response(
+                200,
+                json={"result": {"cart_item_id": "ci123", "item_id": "item123"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_add_to_cart"](item_sys_id="item123")
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["cart_item_id"] == "ci123"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("servicenow_mcp.policy.write_gate", return_value=None)
+    async def test_add_to_cart_with_variables(self, mock_write_gate, settings, auth_provider):
+        """Should add item to cart with variables JSON."""
+        respx.post(f"{SC_BASE}/items/item123/add_to_cart").mock(
+            return_value=Response(
+                200,
+                json={"result": {"cart_item_id": "ci123", "item_id": "item123"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_add_to_cart"](
+            item_sys_id="item123",
+            variables='{"quantity": "2"}',
+        )
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["cart_item_id"] == "ci123"
+
+    @pytest.mark.asyncio
+    async def test_add_to_cart_blocked_in_prod(self):
+        """Should block add-to-cart in production."""
+        prod_env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "password",
+            "MCP_TOOL_PACKAGE": "full",
+            "SERVICENOW_ENV": "prod",
+        }
+        with patch.dict("os.environ", prod_env, clear=True):
+            prod_settings = Settings(_env_file=None)
+            prod_auth = BasicAuthProvider(prod_settings)
+
+            tools = _register_and_get_tools(prod_settings, prod_auth)
+            result = await tools["sc_add_to_cart"](item_sys_id="item123")
+            data = toon_decode(result)
+
+            assert data["status"] == "error"
+            assert "production" in data["error"].lower()
+
+
+# ── Cart Get ─────────────────────────────────────────────────────────────
+
+
+class TestScCartGet:
+    """Tests for sc_cart_get tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_cart(self, settings, auth_provider):
+        """Should retrieve the current user's cart."""
+        respx.get(f"{SC_BASE}/cart").mock(
+            return_value=Response(
+                200,
+                json={
+                    "result": {
+                        "items": [
+                            {"cart_item_id": "ci1", "name": "Laptop"},
+                        ],
+                        "subtotal": "$1200",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_cart_get"]()
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["subtotal"] == "$1200"
+
+
+# ── Cart Submit ──────────────────────────────────────────────────────────
+
+
+class TestScCartSubmit:
+    """Tests for sc_cart_submit tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("servicenow_mcp.policy.write_gate", return_value=None)
+    async def test_submit_cart(self, mock_write_gate, settings, auth_provider):
+        """Should submit the cart as an order."""
+        respx.post(f"{SC_BASE}/cart/submit_order").mock(
+            return_value=Response(
+                200,
+                json={"result": {"request_number": "REQ0010001", "request_id": "req123"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_cart_submit"]()
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["request_number"] == "REQ0010001"
+
+    @pytest.mark.asyncio
+    async def test_submit_cart_blocked_in_prod(self):
+        """Should block cart submission in production."""
+        prod_env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "password",
+            "MCP_TOOL_PACKAGE": "full",
+            "SERVICENOW_ENV": "prod",
+        }
+        with patch.dict("os.environ", prod_env, clear=True):
+            prod_settings = Settings(_env_file=None)
+            prod_auth = BasicAuthProvider(prod_settings)
+
+            tools = _register_and_get_tools(prod_settings, prod_auth)
+            result = await tools["sc_cart_submit"]()
+            data = toon_decode(result)
+
+            assert data["status"] == "error"
+            assert "production" in data["error"].lower()
+
+
+# ── Cart Checkout ────────────────────────────────────────────────────────
+
+
+class TestScCartCheckout:
+    """Tests for sc_cart_checkout tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("servicenow_mcp.policy.write_gate", return_value=None)
+    async def test_checkout_cart(self, mock_write_gate, settings, auth_provider):
+        """Should checkout the cart."""
+        respx.post(f"{SC_BASE}/cart/checkout").mock(
+            return_value=Response(
+                200,
+                json={"result": {"request_number": "REQ0010002", "request_id": "req456"}},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        result = await tools["sc_cart_checkout"]()
+        data = toon_decode(result)
+
+        assert data["status"] == "success"
+        assert data["data"]["request_number"] == "REQ0010002"
+
+    @pytest.mark.asyncio
+    async def test_checkout_blocked_in_prod(self):
+        """Should block checkout in production."""
+        prod_env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "password",
+            "MCP_TOOL_PACKAGE": "full",
+            "SERVICENOW_ENV": "prod",
+        }
+        with patch.dict("os.environ", prod_env, clear=True):
+            prod_settings = Settings(_env_file=None)
+            prod_auth = BasicAuthProvider(prod_settings)
+
+            tools = _register_and_get_tools(prod_settings, prod_auth)
+            result = await tools["sc_cart_checkout"]()
+            data = toon_decode(result)
+
+            assert data["status"] == "error"
+            assert "production" in data["error"].lower()

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -220,7 +220,7 @@ class TestPackageRegistry:
         assert "documentation" in groups
         assert "utility" in groups
         assert "testing" not in groups
-        assert len(groups) == 16
+        assert len(groups) == 17
 
 
 class TestCommaSeparatedGroups:
@@ -401,18 +401,19 @@ class TestDomainPackages:
         assert len(groups) == 3
 
     def test_full_package_includes_all_domain_groups(self):
-        """full package includes exactly 6 domain groups."""
+        """full package includes exactly 7 domain groups."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("full")
         domain_groups = [g for g in groups if g.startswith("domain_")]
-        assert len(domain_groups) == 6
+        assert len(domain_groups) == 7
         assert "domain_incident" in domain_groups
         assert "domain_change" in domain_groups
         assert "domain_cmdb" in domain_groups
         assert "domain_problem" in domain_groups
         assert "domain_request" in domain_groups
         assert "domain_knowledge" in domain_groups
+        assert "domain_service_catalog" in domain_groups
 
     def test_itil_package_includes_four_domain_groups(self):
         """itil package includes 4 domain groups (incident, change, problem, request)."""
@@ -427,7 +428,7 @@ class TestDomainPackages:
         assert "domain_request" in domain_groups
 
     def test_list_packages_includes_all_domain_packages(self):
-        """list_packages includes all 6 domain-specific packages."""
+        """list_packages includes all 7 domain-specific packages."""
         from servicenow_mcp.packages import list_packages
 
         packages = list_packages()
@@ -437,6 +438,7 @@ class TestDomainPackages:
         assert "problem_management" in packages
         assert "request_management" in packages
         assert "knowledge_management" in packages
+        assert "service_catalog" in packages
 
     def test_comma_syntax_with_domain_groups(self):
         """get_package accepts comma-separated syntax with domain groups."""
@@ -453,11 +455,11 @@ class TestDomainPackages:
         assert groups == ["domain_incident", "domain_change", "utility"]
 
     def test_backward_compatibility_full_package_count(self):
-        """full package has 16 total groups (10 original + 6 domain)."""
+        """full package has 17 total groups (10 original + 7 domain)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("full")
-        assert len(groups) == 16
+        assert len(groups) == 17
 
     def test_backward_compatibility_itil_package_count(self):
         """itil package has 11 total groups (7 original + 4 domain)."""


### PR DESCRIPTION
## Summary

- Add support for the ServiceNow Service Catalog scoped API (`sn_sc/servicecatalog`) as a new domain tool module
- Implements 12 MCP tools covering catalog browsing, item ordering, and cart management
- Follows existing domain tool patterns (request.py as template)

## Changes

### Client (`client.py`)
- `_sc_url(*segments)` helper for Service Catalog scoped API endpoints
- 11 async methods: `sc_get_catalogs`, `sc_get_catalog`, `sc_get_catalog_categories`, `sc_get_category`, `sc_get_items`, `sc_get_item`, `sc_get_item_variables`, `sc_order_now`, `sc_add_to_cart`, `sc_get_cart`, `sc_submit_order`, `sc_checkout`

### Domain Tools (`service_catalog.py`)
- **Read tools**: `sc_catalogs_list`, `sc_catalog_get`, `sc_categories_list`, `sc_category_get`, `sc_items_list`, `sc_item_get`, `sc_item_variables`
- **Write tools**: `sc_order_now`, `sc_add_to_cart`, `sc_cart_get`, `sc_cart_submit`, `sc_cart_checkout`
- Write tools use `write_gate()` with proxy table names for production gating
- Read tools skip `check_table_access()` since they use scoped API, not Table API

### Package Registration (`packages.py`)
- Added `domain_service_catalog` to `_TOOL_GROUP_MODULES`
- Added to `full` package
- Created standalone `service_catalog` package

### Tests
- 23 new tests in `tests/domains/test_service_catalog.py`
- Covers all 12 tools: reads, writes, parameter forwarding, production write blocking
- Updated `tests/test_packages.py` count assertions (16->17 full groups, 6->7 domain groups)

## Test Results

All 914 tests passing, ruff lint and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Service Catalog API integration with support for browsing catalogs, searching and filtering items, managing categories, and handling ordering operations.
  * Added cart management and order submission capabilities with variable support for catalog items.

* **Tests**
  * Added extensive test coverage for Service Catalog functionality.

* **Chores**
  * Registered new Service Catalog domain package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->