### PR TITLE
feat: add legacy workflow introspection tools

### DIFF
--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -12,6 +12,7 @@ _TOOL_GROUP_MODULES: dict[str, str] = {
     "investigations": "servicenow_mcp.tools.investigations",
     "documentation": "servicenow_mcp.tools.documentation",
     "utility": "servicenow_mcp.tools.utility",
+    "workflow": "servicenow_mcp.tools.workflow",
     "domain_incident": "servicenow_mcp.tools.domains.incident",
     "domain_change": "servicenow_mcp.tools.domains.change",
     "domain_cmdb": "servicenow_mcp.tools.domains.cmdb",
@@ -42,6 +43,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "investigations",
         "documentation",
         "utility",
+        "workflow",
         "domain_incident",
         "domain_change",
         "domain_cmdb",
@@ -59,6 +61,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "debug",
         "documentation",
         "utility",
+        "workflow",
         "domain_incident",
         "domain_change",
         "domain_problem",
@@ -75,6 +78,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "investigations",
         "documentation",
         "utility",
+        "workflow",
     ],
     "readonly": [
         "introspection",
@@ -85,6 +89,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "investigations",
         "documentation",
         "utility",
+        "workflow",
     ],
     "analyst": [
         "introspection",
@@ -93,12 +98,14 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "investigations",
         "documentation",
         "utility",
+        "workflow",
     ],
     "incident_management": [
         "introspection",
         "utility",
         "domain_incident",
         "debug",
+        "workflow",
     ],
     "change_management": [
         "introspection",
@@ -117,11 +124,13 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "utility",
         "domain_problem",
         "debug",
+        "workflow",
     ],
     "request_management": [
         "introspection",
         "utility",
         "domain_request",
+        "workflow",
     ],
     "knowledge_management": [
         "introspection",

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -1,6 +1,7 @@
 """Workflow introspection tools for the legacy Workflow Engine."""
 
 import asyncio
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
@@ -101,7 +102,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         *,
         correlation_id: str,
     ) -> str:
-        """Show the structure of a workflow version: activities and transitions between them.
+        """Show the structure of a workflow version: activities, transitions, and activity variables.
+
+        Each activity includes its configured variable values (script body, conditions, etc.)
+        from sys_variable_value.
 
         Args:
             workflow_version_sys_id: The sys_id of the wf_workflow_version record.
@@ -109,6 +113,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         check_table_access("wf_workflow_version")
         check_table_access("wf_activity")
         check_table_access("wf_transition")
+        check_table_access("sys_variable_value")
 
         activity_query = ServiceNowQuery().equals("workflow_version", workflow_version_sys_id).order_by("x").build()
         transition_query = ServiceNowQuery().equals("from.workflow_version", workflow_version_sys_id).build()
@@ -152,10 +157,42 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 ),
             )
 
+            # Bulk-fetch variables for all activities (display_values=False to keep raw sys_ids for grouping)
+            activity_records = activity_result["records"]
+            activity_sys_ids = [a["sys_id"] for a in activity_records]
+
+            if activity_sys_ids:
+                vars_query = (
+                    ServiceNowQuery()
+                    .equals("document", "wf_activity")
+                    .in_list("document_key", activity_sys_ids)
+                    .build()
+                )
+                vars_result = await client.query_records(
+                    "sys_variable_value",
+                    vars_query,
+                    fields=["sys_id", "variable", "value", "document_key"],
+                    limit=500,
+                    display_values=False,
+                )
+                vars_by_activity: dict[str, list[dict[str, Any]]] = {}
+                for v in vars_result["records"]:
+                    key = v.get("document_key", "")
+                    vars_by_activity.setdefault(key, []).append(mask_sensitive_fields(v))
+            else:
+                vars_by_activity = {}
+
+        # Attach variables to each activity
+        activities = []
+        for a in activity_records:
+            masked = mask_sensitive_fields(a)
+            masked["variables"] = vars_by_activity.get(a["sys_id"], [])
+            activities.append(masked)
+
         return format_response(
             data={
                 "version": mask_sensitive_fields(version_record),
-                "activities": [mask_sensitive_fields(a) for a in activity_result["records"]],
+                "activities": activities,
                 "transitions": [mask_sensitive_fields(t) for t in transition_result["records"]],
             },
             correlation_id=correlation_id,
@@ -237,34 +274,57 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         *,
         correlation_id: str,
     ) -> str:
-        """Fetch detailed information about a workflow activity and its element definition.
+        """Fetch detailed information about a workflow activity, its element definition, and configured variables.
+
+        Includes activity variable values (script body, conditions, etc.) from sys_variable_value.
 
         Args:
             activity_sys_id: The sys_id of the wf_activity record.
         """
         check_table_access("wf_activity")
         check_table_access("wf_element_definition")
+        check_table_access("sys_variable_value")
+
+        variables_query = (
+            ServiceNowQuery().equals("document", "wf_activity").equals("document_key", activity_sys_id).build()
+        )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            # Fetch raw activity to extract the activity_definition sys_id
+            # Phase 1: raw activity to extract the activity_definition sys_id
             raw_activity = await client.get_record("wf_activity", activity_sys_id, display_values=False)
             definition_sys_id = raw_activity.get("activity_definition", "")
 
+            # Phase 2: parallel fetch of display activity, definition (if linked), and variables
             if not definition_sys_id:
-                # No definition linked - return the activity with display values only
-                display_activity = await client.get_record("wf_activity", activity_sys_id, display_values=True)
+                display_activity, variables_result = await asyncio.gather(
+                    client.get_record("wf_activity", activity_sys_id, display_values=True),
+                    client.query_records(
+                        "sys_variable_value",
+                        variables_query,
+                        fields=["sys_id", "variable", "value", "document_key"],
+                        limit=50,
+                        display_values=True,
+                    ),
+                )
                 definition_record = None
             else:
-                # Parallel fetch: display-value activity + element definition
-                display_activity, definition_record = await asyncio.gather(
+                display_activity, definition_record, variables_result = await asyncio.gather(
                     client.get_record("wf_activity", activity_sys_id, display_values=True),
                     client.get_record("wf_element_definition", definition_sys_id, display_values=True),
+                    client.query_records(
+                        "sys_variable_value",
+                        variables_query,
+                        fields=["sys_id", "variable", "value", "document_key"],
+                        limit=50,
+                        display_values=True,
+                    ),
                 )
 
         return format_response(
             data={
                 "activity": mask_sensitive_fields(display_activity),
                 "definition": mask_sensitive_fields(definition_record) if definition_record else None,
+                "variables": [mask_sensitive_fields(v) for v in variables_result["records"]],
             },
             correlation_id=correlation_id,
         )

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -1,0 +1,317 @@
+"""Workflow introspection tools for the legacy Workflow Engine."""
+
+import asyncio
+
+from mcp.server.fastmcp import FastMCP
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.config import Settings
+from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
+from servicenow_mcp.utils import ServiceNowQuery, format_response, validate_identifier
+
+
+def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """Register workflow introspection tools on the MCP server."""
+
+    @mcp.tool()
+    @tool_handler
+    async def workflow_contexts(
+        record_sys_id: str,
+        table: str = "",
+        state: str = "",
+        limit: int = 10,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """List legacy workflow contexts and Flow Designer contexts running on a record.
+
+        Args:
+            record_sys_id: The sys_id of the source record.
+            table: Filter legacy contexts by table name.
+            state: Filter legacy contexts by state. Legacy values: executing, finished, cancelled. Flow Designer values: IN_PROGRESS, COMPLETE, ERROR, CANCELLED.
+            limit: Maximum number of records to return per engine (default 10).
+        """
+        check_table_access("wf_context")
+        check_table_access("sys_flow_context")
+
+        if table:
+            validate_identifier(table)
+
+        legacy_query = (
+            ServiceNowQuery()
+            .equals("id", record_sys_id)
+            .equals_if("state", state, bool(state))
+            .equals_if("table", table, bool(table))
+            .build()
+        )
+        flow_query = ServiceNowQuery().equals("source_record", record_sys_id).build()
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            legacy_result, flow_result = await asyncio.gather(
+                client.query_records(
+                    "wf_context",
+                    legacy_query,
+                    fields=[
+                        "sys_id",
+                        "name",
+                        "state",
+                        "started",
+                        "ended",
+                        "workflow_version",
+                        "table",
+                        "result",
+                        "running_duration",
+                        "active",
+                    ],
+                    limit=limit,
+                    display_values=True,
+                ),
+                client.query_records(
+                    "sys_flow_context",
+                    flow_query,
+                    fields=[
+                        "sys_id",
+                        "name",
+                        "state",
+                        "started",
+                        "ended",
+                        "flow_version",
+                        "source_table",
+                        "source_record",
+                    ],
+                    limit=limit,
+                    display_values=True,
+                ),
+            )
+
+        legacy_records = [mask_sensitive_fields(r) for r in legacy_result["records"]]
+        flow_records = [mask_sensitive_fields(r) for r in flow_result["records"]]
+
+        return format_response(
+            data={"legacy_workflows": legacy_records, "flow_designer": flow_records},
+            correlation_id=correlation_id,
+        )
+
+    @mcp.tool()
+    @tool_handler
+    async def workflow_map(
+        workflow_version_sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Show the structure of a workflow version: activities and transitions between them.
+
+        Args:
+            workflow_version_sys_id: The sys_id of the wf_workflow_version record.
+        """
+        check_table_access("wf_workflow_version")
+        check_table_access("wf_activity")
+        check_table_access("wf_transition")
+
+        activity_query = ServiceNowQuery().equals("workflow_version", workflow_version_sys_id).order_by("x").build()
+        transition_query = ServiceNowQuery().equals("from.workflow_version", workflow_version_sys_id).build()
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            version_record, activity_result, transition_result = await asyncio.gather(
+                client.get_record("wf_workflow_version", workflow_version_sys_id, display_values=True),
+                client.query_records(
+                    "wf_activity",
+                    activity_query,
+                    fields=[
+                        "sys_id",
+                        "name",
+                        "activity_definition",
+                        "activity_definition.name",
+                        "activity_definition.category",
+                        "x",
+                        "y",
+                        "timeout",
+                        "notes",
+                        "out_of_date",
+                        "is_parent",
+                        "stage",
+                    ],
+                    limit=100,
+                    display_values=True,
+                ),
+                client.query_records(
+                    "wf_transition",
+                    transition_query,
+                    fields=[
+                        "sys_id",
+                        "from",
+                        "from.name",
+                        "to",
+                        "to.name",
+                        "condition",
+                    ],
+                    limit=200,
+                    display_values=True,
+                ),
+            )
+
+        return format_response(
+            data={
+                "version": mask_sensitive_fields(version_record),
+                "activities": [mask_sensitive_fields(a) for a in activity_result["records"]],
+                "transitions": [mask_sensitive_fields(t) for t in transition_result["records"]],
+            },
+            correlation_id=correlation_id,
+        )
+
+    @mcp.tool()
+    @tool_handler
+    async def workflow_status(
+        context_sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Show execution status of a workflow context: currently executing and completed steps.
+
+        Args:
+            context_sys_id: The sys_id of the wf_context record.
+        """
+        check_table_access("wf_context")
+        check_table_access("wf_executing")
+        check_table_access("wf_history")
+
+        executing_query = ServiceNowQuery().equals("context", context_sys_id).order_by("started").build()
+        history_query = ServiceNowQuery().equals("context", context_sys_id).order_by("started").build()
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            context_record, executing_result, history_result = await asyncio.gather(
+                client.get_record("wf_context", context_sys_id, display_values=True),
+                client.query_records(
+                    "wf_executing",
+                    executing_query,
+                    fields=[
+                        "sys_id",
+                        "activity",
+                        "activity.name",
+                        "activity.activity_definition.name",
+                        "state",
+                        "started",
+                        "due",
+                        "result",
+                        "fault_description",
+                        "activity_index",
+                    ],
+                    limit=50,
+                    display_values=True,
+                ),
+                client.query_records(
+                    "wf_history",
+                    history_query,
+                    fields=[
+                        "sys_id",
+                        "activity",
+                        "activity.name",
+                        "activity.activity_definition.name",
+                        "state",
+                        "started",
+                        "ended",
+                        "result",
+                        "fault_description",
+                        "activity_index",
+                    ],
+                    limit=50,
+                    display_values=True,
+                ),
+            )
+
+        return format_response(
+            data={
+                "context": mask_sensitive_fields(context_record),
+                "executing": [mask_sensitive_fields(e) for e in executing_result["records"]],
+                "history": [mask_sensitive_fields(h) for h in history_result["records"]],
+            },
+            correlation_id=correlation_id,
+        )
+
+    @mcp.tool()
+    @tool_handler
+    async def workflow_activity_detail(
+        activity_sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """Fetch detailed information about a workflow activity and its element definition.
+
+        Args:
+            activity_sys_id: The sys_id of the wf_activity record.
+        """
+        check_table_access("wf_activity")
+        check_table_access("wf_element_definition")
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            # Fetch raw activity to extract the activity_definition sys_id
+            raw_activity = await client.get_record("wf_activity", activity_sys_id, display_values=False)
+            definition_sys_id = raw_activity.get("activity_definition", "")
+
+            if not definition_sys_id:
+                # No definition linked - return the activity with display values only
+                display_activity = await client.get_record("wf_activity", activity_sys_id, display_values=True)
+                definition_record = None
+            else:
+                # Parallel fetch: display-value activity + element definition
+                display_activity, definition_record = await asyncio.gather(
+                    client.get_record("wf_activity", activity_sys_id, display_values=True),
+                    client.get_record("wf_element_definition", definition_sys_id, display_values=True),
+                )
+
+        return format_response(
+            data={
+                "activity": mask_sensitive_fields(display_activity),
+                "definition": mask_sensitive_fields(definition_record) if definition_record else None,
+            },
+            correlation_id=correlation_id,
+        )
+
+    @mcp.tool()
+    @tool_handler
+    async def workflow_version_list(
+        table: str,
+        active_only: bool = True,
+        limit: int = 20,
+        *,
+        correlation_id: str,
+    ) -> str:
+        """List workflow versions defined for a specific table.
+
+        Args:
+            table: The table name to find workflows for (e.g. 'incident').
+            active_only: Only return active workflow versions (default True).
+            limit: Maximum number of versions to return (default 20).
+        """
+        validate_identifier(table)
+        check_table_access("wf_workflow_version")
+
+        query = ServiceNowQuery().equals("table", table).equals_if("active", "true", active_only).build()
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.query_records(
+                "wf_workflow_version",
+                query,
+                fields=[
+                    "sys_id",
+                    "name",
+                    "table",
+                    "description",
+                    "active",
+                    "published",
+                    "checked_out",
+                    "checked_out_by",
+                    "workflow",
+                ],
+                limit=limit,
+                display_values=True,
+            )
+
+        versions = [mask_sensitive_fields(v) for v in result["records"]]
+
+        return format_response(
+            data={"versions": versions},
+            correlation_id=correlation_id,
+        )

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -121,13 +121,14 @@ class TestPackageRegistry:
             "debug",
             "documentation",
             "utility",
+            "workflow",
             "domain_incident",
             "domain_change",
             "domain_problem",
             "domain_request",
         ]
         assert groups == expected
-        assert len(groups) == 11
+        assert len(groups) == 12
 
     def test_get_package_developer(self):
         """get_package returns correct groups for developer preset."""
@@ -145,9 +146,10 @@ class TestPackageRegistry:
             "investigations",
             "documentation",
             "utility",
+            "workflow",
         ]
         assert groups == expected
-        assert len(groups) == 10
+        assert len(groups) == 11
 
     def test_get_package_readonly(self):
         """get_package returns correct groups for readonly preset."""
@@ -163,18 +165,27 @@ class TestPackageRegistry:
             "investigations",
             "documentation",
             "utility",
+            "workflow",
         ]
         assert groups == expected
-        assert len(groups) == 8
+        assert len(groups) == 9
 
     def test_get_package_analyst(self):
         """get_package returns correct groups for analyst preset."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("analyst")
-        expected = ["introspection", "relationships", "metadata", "investigations", "documentation", "utility"]
+        expected = [
+            "introspection",
+            "relationships",
+            "metadata",
+            "investigations",
+            "documentation",
+            "utility",
+            "workflow",
+        ]
         assert groups == expected
-        assert len(groups) == 6
+        assert len(groups) == 7
 
     def test_list_packages_includes_itil(self):
         """list_packages includes itil preset."""
@@ -219,8 +230,9 @@ class TestPackageRegistry:
         assert "investigations" in groups
         assert "documentation" in groups
         assert "utility" in groups
+        assert "workflow" in groups
         assert "testing" not in groups
-        assert len(groups) == 17
+        assert len(groups) == 18
 
 
 class TestCommaSeparatedGroups:
@@ -345,7 +357,8 @@ class TestDomainPackages:
         assert "introspection" in groups
         assert "utility" in groups
         assert "debug" in groups
-        assert len(groups) == 4
+        assert "workflow" in groups
+        assert len(groups) == 5
 
     def test_change_management_package(self):
         """change_management package includes correct groups."""
@@ -378,7 +391,8 @@ class TestDomainPackages:
         assert "introspection" in groups
         assert "utility" in groups
         assert "debug" in groups
-        assert len(groups) == 4
+        assert "workflow" in groups
+        assert len(groups) == 5
 
     def test_request_management_package(self):
         """request_management package includes correct groups."""
@@ -388,7 +402,8 @@ class TestDomainPackages:
         assert "domain_request" in groups
         assert "introspection" in groups
         assert "utility" in groups
-        assert len(groups) == 3
+        assert "workflow" in groups
+        assert len(groups) == 4
 
     def test_knowledge_management_package(self):
         """knowledge_management package includes correct groups."""
@@ -455,43 +470,43 @@ class TestDomainPackages:
         assert groups == ["domain_incident", "domain_change", "utility"]
 
     def test_backward_compatibility_full_package_count(self):
-        """full package has 17 total groups (10 original + 7 domain)."""
+        """full package has 18 total groups (11 original + 7 domain)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("full")
-        assert len(groups) == 17
+        assert len(groups) == 18
 
     def test_backward_compatibility_itil_package_count(self):
-        """itil package has 11 total groups (7 original + 4 domain)."""
+        """itil package has 12 total groups (8 original + 4 domain)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("itil")
-        assert len(groups) == 11
+        assert len(groups) == 12
 
     def test_developer_package_unchanged(self):
-        """developer package still has 10 groups (no domain groups)."""
+        """developer package still has 11 groups (no domain groups)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("developer")
-        assert len(groups) == 10
+        assert len(groups) == 11
         domain_groups = [g for g in groups if g.startswith("domain_")]
         assert len(domain_groups) == 0
 
     def test_readonly_package_unchanged(self):
-        """readonly package still has 8 groups (no domain groups)."""
+        """readonly package still has 9 groups (no domain groups)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("readonly")
-        assert len(groups) == 8
+        assert len(groups) == 9
         domain_groups = [g for g in groups if g.startswith("domain_")]
         assert len(domain_groups) == 0
 
     def test_analyst_package_unchanged(self):
-        """analyst package still has 6 groups (no domain groups)."""
+        """analyst package still has 7 groups (no domain groups)."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("analyst")
-        assert len(groups) == 6
+        assert len(groups) == 7
         domain_groups = [g for g in groups if g.startswith("domain_")]
         assert len(domain_groups) == 0
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -295,6 +295,22 @@ class TestWorkflowMap:
                 headers={"X-Total-Count": "1"},
             )
         )
+        respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "sv001",
+                            "variable": "var_def_001",
+                            "value": "some_script_body",
+                            "document_key": "act002",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["workflow_map"](workflow_version_sys_id="wfv001")
@@ -305,6 +321,10 @@ class TestWorkflowMap:
         assert len(result["data"]["activities"]) == 2
         assert len(result["data"]["transitions"]) == 1
         assert result["data"]["transitions"][0]["from.name"] == "Begin"
+        # act001 has no variables, act002 has one
+        assert result["data"]["activities"][0].get("variables") == []
+        assert len(result["data"]["activities"][1]["variables"]) == 1
+        assert result["data"]["activities"][1]["variables"][0]["value"] == "some_script_body"
 
     @pytest.mark.asyncio
     @respx.mock
@@ -366,6 +386,9 @@ class TestWorkflowMap:
         respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
+        respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["workflow_map"](workflow_version_sys_id="wfv_sort")
@@ -374,6 +397,7 @@ class TestWorkflowMap:
         assert result["status"] == "success"
         names = [a["name"] for a in result["data"]["activities"]]
         assert names == ["First", "Second", "Third"]
+        assert all(a["variables"] == [] for a in result["data"]["activities"])
 
     @pytest.mark.asyncio
     @respx.mock
@@ -394,6 +418,82 @@ class TestWorkflowMap:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_map_groups_variables_by_activity(self, settings, auth_provider):
+        """Variables are grouped correctly per activity in the map."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_vars").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": "wfv_vars", "name": "Vars Test WF"}},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {"sys_id": "a1", "name": "Script 1", "x": "10", "y": "50"},
+                        {"sys_id": "a2", "name": "Script 2", "x": "200", "y": "50"},
+                    ]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {"sys_id": "sv1", "variable": "var1", "value": "script_a1", "document_key": "a1"},
+                        {"sys_id": "sv2", "variable": "var2", "value": "script_a2", "document_key": "a2"},
+                        {"sys_id": "sv3", "variable": "var3", "value": "condition_a1", "document_key": "a1"},
+                    ]
+                },
+                headers={"X-Total-Count": "3"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_vars")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        activities = result["data"]["activities"]
+        # a1 should have 2 variables, a2 should have 1
+        a1 = next(a for a in activities if a["sys_id"] == "a1")
+        a2 = next(a for a in activities if a["sys_id"] == "a2")
+        assert len(a1["variables"]) == 2
+        assert len(a2["variables"]) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_map_empty_activities_skips_variable_fetch(self, settings, auth_provider):
+        """No sys_variable_value call when there are no activities."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_none").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": "wfv_none", "name": "No Activities WF"}},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        # Do NOT mock sys_variable_value - if it's called, the test will fail with ConnectionError
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_none")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["activities"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -717,6 +817,22 @@ class TestWorkflowActivityDetail:
                 },
             )
         )
+        respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "var001",
+                            "variable": "Script",
+                            "value": "current.state = 2;",
+                            "document_key": "act001",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["workflow_activity_detail"](activity_sys_id="act001")
@@ -726,6 +842,8 @@ class TestWorkflowActivityDetail:
         assert result["data"]["activity"]["sys_id"] == "act001"
         assert result["data"]["definition"]["name"] == "Approval - User"
         assert result["data"]["definition"]["category"] == "Approvals"
+        assert len(result["data"]["variables"]) == 1
+        assert result["data"]["variables"][0]["value"] == "current.state = 2;"
 
     @pytest.mark.asyncio
     @respx.mock
@@ -746,6 +864,9 @@ class TestWorkflowActivityDetail:
                 },
             )
         )
+        respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["workflow_activity_detail"](activity_sys_id="act_nodef")
@@ -754,6 +875,7 @@ class TestWorkflowActivityDetail:
         assert result["status"] == "success"
         assert result["data"]["activity"]["sys_id"] == "act_nodef"
         assert result["data"]["definition"] is None
+        assert result["data"]["variables"] == []
 
     @pytest.mark.asyncio
     @respx.mock
@@ -768,6 +890,69 @@ class TestWorkflowActivityDetail:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_activity_includes_multiple_variables(self, settings, auth_provider):
+        """Returns multiple configured variables for an activity."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act_vars").mock(
+            side_effect=lambda request: httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "act_vars",
+                        "name": "Run Script",
+                        "activity_definition": "def_script",
+                        "x": "100",
+                        "y": "50",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/def_script").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "def_script",
+                        "name": "Run Script",
+                        "category": "Utilities",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "sv1",
+                            "variable": "Script",
+                            "value": "gs.log('hello');",
+                            "document_key": "act_vars",
+                        },
+                        {
+                            "sys_id": "sv2",
+                            "variable": "Condition",
+                            "value": "current.active == true",
+                            "document_key": "act_vars",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_activity_detail"](activity_sys_id="act_vars")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert len(result["data"]["variables"]) == 2
+        values = [v["value"] for v in result["data"]["variables"]]
+        assert "gs.log('hello');" in values
+        assert "current.active == true" in values
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,919 @@
+"""Tests for workflow introspection tools."""
+
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+import respx
+from toon_format import decode as toon_decode
+
+from servicenow_mcp.auth import BasicAuthProvider
+
+BASE_URL = "https://test.service-now.com"
+
+
+@pytest.fixture
+def auth_provider(settings):
+    """Create a BasicAuthProvider from test settings."""
+    return BasicAuthProvider(settings)
+
+
+def _register_and_get_tools(settings, auth_provider):
+    """Helper: register workflow tools on a fresh MCP server and return tool map."""
+    from mcp.server.fastmcp import FastMCP
+
+    from servicenow_mcp.tools.workflow import register_tools
+
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider)
+    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+
+
+# ---------------------------------------------------------------------------
+# Tool Registration
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowToolRegistration:
+    """Verify all workflow tools register correctly."""
+
+    def test_registers_all_five_tools(self, settings, auth_provider):
+        """All five workflow tools are registered on the MCP server."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        expected = {
+            "workflow_contexts",
+            "workflow_map",
+            "workflow_status",
+            "workflow_activity_detail",
+            "workflow_version_list",
+        }
+        assert expected == set(tools.keys())
+
+
+# ---------------------------------------------------------------------------
+# workflow_contexts
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowContexts:
+    """Tests for the workflow_contexts tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_both_legacy_and_flow_contexts(self, settings, auth_provider):
+        """Returns legacy workflow contexts and flow designer contexts."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "wfc001",
+                            "name": "Incident Workflow",
+                            "state": "Executing",
+                            "started": "2026-02-20 09:00:00",
+                            "ended": "",
+                            "workflow_version": "wfv001",
+                            "table": "incident",
+                            "result": "",
+                            "running_duration": "00:05:00",
+                            "active": "true",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "fc001",
+                            "name": "Auto-assign Flow",
+                            "state": "Completed",
+                            "started": "2026-02-20 09:00:00",
+                            "ended": "2026-02-20 09:00:05",
+                            "flow_version": "fv001",
+                            "source_table": "incident",
+                            "source_record": "inc001",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_contexts"](record_sys_id="inc001")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert len(result["data"]["legacy_workflows"]) == 1
+        assert len(result["data"]["flow_designer"]) == 1
+        assert result["data"]["legacy_workflows"][0]["name"] == "Incident Workflow"
+        assert result["data"]["flow_designer"][0]["name"] == "Auto-assign Flow"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_results_for_both_engines(self, settings, auth_provider):
+        """Returns empty lists when no contexts found."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_contexts"](record_sys_id="inc999")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["legacy_workflows"] == []
+        assert result["data"]["flow_designer"] == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_filters_by_state(self, settings, auth_provider):
+        """Passes state filter through to the legacy query."""
+        legacy_route = respx.get(f"{BASE_URL}/api/now/table/wf_context").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "wfc002",
+                            "name": "Finished WF",
+                            "state": "Finished",
+                            "started": "2026-02-20 08:00:00",
+                            "ended": "2026-02-20 08:05:00",
+                            "workflow_version": "wfv002",
+                            "table": "incident",
+                            "result": "success",
+                            "running_duration": "00:05:00",
+                            "active": "false",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_contexts"](record_sys_id="inc001", state="finished")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        # Verify state was included in the legacy encoded query
+        request = legacy_route.calls[0].request
+        qs = parse_qs(urlparse(str(request.url)).query)
+        assert "state=finished" in qs["sysparm_query"][0]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_filters_by_table(self, settings, auth_provider):
+        """Passes table filter through to the legacy query."""
+        legacy_route = respx.get(f"{BASE_URL}/api/now/table/wf_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_contexts"](record_sys_id="inc001", table="incident")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        # Verify table was included in the legacy encoded query
+        request = legacy_route.calls[0].request
+        qs = parse_qs(urlparse(str(request.url)).query)
+        assert "table=incident" in qs["sysparm_query"][0]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_handles_server_error(self, settings, auth_provider):
+        """Returns error envelope when legacy context query fails."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context").mock(
+            return_value=httpx.Response(500, json={"error": {"message": "Server error"}})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_contexts"](record_sys_id="inc001")
+        result = toon_decode(raw)
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# workflow_map
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowMap:
+    """Tests for the workflow_map tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_full_map(self, settings, auth_provider):
+        """Returns version, activities, and transitions."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "wfv001",
+                        "name": "Incident Workflow v2",
+                        "table": "incident",
+                        "active": "true",
+                        "published": "true",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "act001",
+                            "name": "Begin",
+                            "activity_definition": "def001",
+                            "activity_definition.name": "Begin",
+                            "activity_definition.category": "Core",
+                            "x": "50",
+                            "y": "100",
+                            "timeout": "",
+                            "notes": "",
+                            "out_of_date": "false",
+                            "is_parent": "false",
+                            "stage": "",
+                        },
+                        {
+                            "sys_id": "act002",
+                            "name": "Approval",
+                            "activity_definition": "def002",
+                            "activity_definition.name": "Approval - User",
+                            "activity_definition.category": "Approvals",
+                            "x": "200",
+                            "y": "100",
+                            "timeout": "86400",
+                            "notes": "Manager approval",
+                            "out_of_date": "false",
+                            "is_parent": "false",
+                            "stage": "",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "tr001",
+                            "from": "act001",
+                            "from.name": "Begin",
+                            "to": "act002",
+                            "to.name": "Approval",
+                            "condition": "",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="wfv001")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["version"]["name"] == "Incident Workflow v2"
+        assert len(result["data"]["activities"]) == 2
+        assert len(result["data"]["transitions"]) == 1
+        assert result["data"]["transitions"][0]["from.name"] == "Begin"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_activities_and_transitions(self, settings, auth_provider):
+        """Returns version with empty activities and transitions lists."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_empty").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "wfv_empty",
+                        "name": "Empty Workflow",
+                        "table": "incident",
+                        "active": "true",
+                        "published": "false",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_empty")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["activities"] == []
+        assert result["data"]["transitions"] == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_activities_sorted_by_x_position(self, settings, auth_provider):
+        """Activities are returned ordered by x position from the query."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_sort").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": "wfv_sort", "name": "Sort Test WF"}},
+            )
+        )
+        # Activities returned pre-sorted by x (as ServiceNow would return them)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {"sys_id": "a1", "name": "First", "x": "10", "y": "50"},
+                        {"sys_id": "a2", "name": "Second", "x": "200", "y": "50"},
+                        {"sys_id": "a3", "name": "Third", "x": "400", "y": "50"},
+                    ]
+                },
+                headers={"X-Total-Count": "3"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_sort")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        names = [a["name"] for a in result["data"]["activities"]]
+        assert names == ["First", "Second", "Third"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_on_missing_version(self, settings, auth_provider):
+        """Returns error when the workflow version is not found."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/bad_id").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="bad_id")
+        result = toon_decode(raw)
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# workflow_status
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowStatus:
+    """Tests for the workflow_status tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_context_with_executing_and_history(self, settings, auth_provider):
+        """Returns context record alongside executing and history lists."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "ctx001",
+                        "name": "Incident WF",
+                        "state": "Executing",
+                        "started": "2026-02-20 09:00:00",
+                        "ended": "",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_executing").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "ex001",
+                            "activity": "act001",
+                            "activity.name": "Approval",
+                            "activity.activity_definition.name": "Approval - User",
+                            "state": "executing",
+                            "started": "2026-02-20 09:01:00",
+                            "due": "2026-02-21 09:01:00",
+                            "result": "",
+                            "fault_description": "",
+                            "activity_index": "1",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_history").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "hist001",
+                            "activity": "act000",
+                            "activity.name": "Begin",
+                            "activity.activity_definition.name": "Begin",
+                            "state": "finished",
+                            "started": "2026-02-20 09:00:00",
+                            "ended": "2026-02-20 09:00:01",
+                            "result": "success",
+                            "fault_description": "",
+                            "activity_index": "0",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_status"](context_sys_id="ctx001")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["context"]["state"] == "Executing"
+        assert len(result["data"]["executing"]) == 1
+        assert len(result["data"]["history"]) == 1
+        assert result["data"]["executing"][0]["activity.name"] == "Approval"
+        assert result["data"]["history"][0]["result"] == "success"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_executing_all_completed(self, settings, auth_provider):
+        """Returns empty executing list when all activities have finished."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx_done").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "ctx_done",
+                        "name": "Completed WF",
+                        "state": "Finished",
+                        "started": "2026-02-20 08:00:00",
+                        "ended": "2026-02-20 08:10:00",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_executing").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_history").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "h1",
+                            "activity": "a1",
+                            "activity.name": "Begin",
+                            "state": "finished",
+                            "started": "2026-02-20 08:00:00",
+                            "ended": "2026-02-20 08:00:01",
+                            "result": "success",
+                            "fault_description": "",
+                            "activity_index": "0",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_status"](context_sys_id="ctx_done")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["executing"] == []
+        assert len(result["data"]["history"]) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_multiple_executing_activities(self, settings, auth_provider):
+        """Returns multiple currently-executing activities."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx_multi").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "ctx_multi",
+                        "name": "Parallel WF",
+                        "state": "Executing",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_executing").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "ex1",
+                            "activity": "a1",
+                            "activity.name": "Task A",
+                            "state": "executing",
+                            "started": "2026-02-20 09:00:00",
+                            "fault_description": "",
+                        },
+                        {
+                            "sys_id": "ex2",
+                            "activity": "a2",
+                            "activity.name": "Task B",
+                            "state": "executing",
+                            "started": "2026-02-20 09:00:00",
+                            "fault_description": "",
+                        },
+                        {
+                            "sys_id": "ex3",
+                            "activity": "a3",
+                            "activity.name": "Task C",
+                            "state": "executing",
+                            "started": "2026-02-20 09:00:01",
+                            "fault_description": "",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "3"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_history").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_status"](context_sys_id="ctx_multi")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert len(result["data"]["executing"]) == 3
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_history_with_faults(self, settings, auth_provider):
+        """Returns history entries with populated fault_description."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx_fault").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "ctx_fault",
+                        "name": "Faulted WF",
+                        "state": "Finished",
+                    }
+                },
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_executing").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_history").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "h1",
+                            "activity": "a1",
+                            "activity.name": "Run Script",
+                            "state": "faulted",
+                            "started": "2026-02-20 09:00:00",
+                            "ended": "2026-02-20 09:00:02",
+                            "result": "error",
+                            "fault_description": "NullPointerException at line 42",
+                            "activity_index": "1",
+                        },
+                        {
+                            "sys_id": "h2",
+                            "activity": "a2",
+                            "activity.name": "Notification",
+                            "state": "faulted",
+                            "started": "2026-02-20 09:00:03",
+                            "ended": "2026-02-20 09:00:04",
+                            "result": "error",
+                            "fault_description": "Invalid email address",
+                            "activity_index": "2",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_status"](context_sys_id="ctx_fault")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        history = result["data"]["history"]
+        assert len(history) == 2
+        assert history[0]["fault_description"] == "NullPointerException at line 42"
+        assert history[1]["fault_description"] == "Invalid email address"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_on_missing_context(self, settings, auth_provider):
+        """Returns error envelope when wf_context is not found."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx404").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Record not found"}})
+        )
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_status"](context_sys_id="ctx404")
+        result = toon_decode(raw)
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# workflow_activity_detail
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowActivityDetail:
+    """Tests for the workflow_activity_detail tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_activity_with_linked_definition(self, settings, auth_provider):
+        """Returns activity display values alongside the element definition."""
+        # Phase 1: raw activity (display_values=False) to get the definition sys_id
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act001").mock(
+            side_effect=lambda request: httpx.Response(
+                200,
+                json={
+                    "result": (
+                        {
+                            "sys_id": "act001",
+                            "name": "Approval",
+                            "activity_definition": "def001",
+                            "x": "200",
+                            "y": "100",
+                        }
+                        if "sysparm_display_value" not in str(request.url)
+                        else {
+                            "sys_id": "act001",
+                            "name": "Approval",
+                            "activity_definition": "Approval - User",
+                            "x": "200",
+                            "y": "100",
+                        }
+                    )
+                },
+            )
+        )
+        # Phase 2: element definition with display values
+        respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/def001").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "def001",
+                        "name": "Approval - User",
+                        "category": "Approvals",
+                        "description": "Generates a user approval request",
+                        "access": "public",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_activity_detail"](activity_sys_id="act001")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["activity"]["sys_id"] == "act001"
+        assert result["data"]["definition"]["name"] == "Approval - User"
+        assert result["data"]["definition"]["category"] == "Approvals"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_activity_with_no_definition(self, settings, auth_provider):
+        """Returns definition as None when activity has no linked definition."""
+        # Phase 1: raw activity with empty activity_definition
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act_nodef").mock(
+            side_effect=lambda request: httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": "act_nodef",
+                        "name": "Custom Activity",
+                        "activity_definition": "",
+                        "x": "100",
+                        "y": "50",
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_activity_detail"](activity_sys_id="act_nodef")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["activity"]["sys_id"] == "act_nodef"
+        assert result["data"]["definition"] is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_on_missing_activity(self, settings, auth_provider):
+        """Returns error when the activity record is not found."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/bad_id").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_activity_detail"](activity_sys_id="bad_id")
+        result = toon_decode(raw)
+
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# workflow_version_list
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowVersionList:
+    """Tests for the workflow_version_list tool."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_versions_for_table(self, settings, auth_provider):
+        """Returns workflow versions defined for a specific table."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "wfv001",
+                            "name": "Incident Workflow v1",
+                            "table": "incident",
+                            "description": "Handles incident lifecycle",
+                            "active": "true",
+                            "published": "true",
+                            "checked_out": "",
+                            "checked_out_by": "",
+                            "workflow": "wf001",
+                        },
+                        {
+                            "sys_id": "wfv002",
+                            "name": "Incident Workflow v2",
+                            "table": "incident",
+                            "description": "Updated incident lifecycle",
+                            "active": "true",
+                            "published": "true",
+                            "checked_out": "",
+                            "checked_out_by": "",
+                            "workflow": "wf001",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_version_list"](table="incident")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert len(result["data"]["versions"]) == 2
+        assert result["data"]["versions"][0]["table"] == "incident"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_result(self, settings, auth_provider):
+        """Returns empty versions list when none found."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_version_list"](table="change_request")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["versions"] == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_active_only_false_includes_inactive(self, settings, auth_provider):
+        """Omits the active filter when active_only is False."""
+        version_route = respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "wfv_inactive",
+                            "name": "Old Workflow",
+                            "table": "incident",
+                            "active": "false",
+                            "published": "false",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_version_list"](table="incident", active_only=False)
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        assert len(result["data"]["versions"]) == 1
+        # Verify active=true was NOT in the encoded query
+        request = version_route.calls[0].request
+        qs = parse_qs(urlparse(str(request.url)).query)
+        assert "active=true" not in qs["sysparm_query"][0]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_versions_with_display_values(self, settings, auth_provider):
+        """Display values are requested for version records."""
+        version_route = respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "wfv003",
+                            "name": "Problem Workflow",
+                            "table": "problem",
+                            "description": "Problem management",
+                            "active": "true",
+                            "published": "true",
+                            "checked_out": "",
+                            "checked_out_by": "",
+                            "workflow": "Parent Workflow Name",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_version_list"](table="problem")
+        result = toon_decode(raw)
+
+        assert result["status"] == "success"
+        # Verify display_value=true was in the query params
+        request = version_route.calls[0].request
+        assert "sysparm_display_value=true" in str(request.url)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_handles_server_error(self, settings, auth_provider):
+        """Returns error envelope on server error."""
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version").mock(
+            return_value=httpx.Response(500, json={"error": {"message": "Internal server error"}})
+        )
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_version_list"](table="incident")
+        result = toon_decode(raw)
+        assert result["status"] == "error"


### PR DESCRIPTION
## Summary

Add dedicated workflow introspection tools for the legacy Workflow Engine (`wf_*` tables), reducing workflow debugging from ~20 API calls down to 2-3 tool invocations.

## Tools Added

| Tool | Purpose |
|------|---------|
| `workflow_contexts` | List legacy workflow + Flow Designer contexts for a record |
| `workflow_map` | Show workflow structure: activities, transitions, and activity variable values |
| `workflow_status` | Show execution status of a workflow context (running + completed steps) |
| `workflow_activity_detail` | Get activity details, element definition, and configured variable values |
| `workflow_version_list` | List active workflow versions for a table |

## Key Design Decisions

- **Non-domain tool** (`tools/workflow.py`, 3-arg `register_tools`) - follows `debug.py`/`introspection.py` pattern
- **`asyncio.gather`** for parallel table queries (same pattern as `debug_trace`)
- **`display_values=True`** with dot-walked fields for server-side reference resolution
- **Variable enrichment**: `workflow_activity_detail` and `workflow_map` include `sys_variable_value` data (script bodies, conditions, configured values) - eliminates 8+ follow-up API calls agents were making
- **Legacy Workflow Engine only** - Flow Designer will be a separate module/PR

## Package Registration

`workflow` group added to: `full`, `itil`, `developer`, `readonly`, `analyst`, `incident_management`, `problem_management`, `request_management`

## Test Coverage

- 26 workflow-specific tests covering all 5 tools + variable enrichment
- 940/940 full suite tests pass
- ruff lint/format clean, mypy clean

## Commits

1. `feat: add legacy workflow introspection tools` - Initial 5 tools + packages + tests (23 tests)
2. `feat: enrich workflow tools with activity variable values` - Variable enrichment for `workflow_activity_detail` and `workflow_map` (26 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow introspection tools for examining contexts, execution status, workflow structure, versions, and activity details across environments.
* **Chores**
  * Exposed the workflow tool group in the full, ITIL, developer, readonly, analyst and several domain-specific package bundles.
* **Tests**
  * Added comprehensive tests covering registration and behavior of the new workflow tools, including success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->