### PR TITLE
feat: structured error format and workflow hardening

### DIFF
--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -44,9 +44,6 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         if table:
             validate_identifier(table)
 
-        # Clamp limit to 1-100
-        safe_limit = max(1, min(limit, 100))
-
         legacy_query = (
             ServiceNowQuery()
             .equals("id", record_sys_id)
@@ -56,8 +53,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         )
         flow_query = ServiceNowQuery().equals("source_record", record_sys_id).build()
 
-        enforce_query_safety("wf_context", legacy_query, safe_limit, settings)
-        enforce_query_safety("sys_flow_context", flow_query, safe_limit, settings)
+        legacy_safety = enforce_query_safety("wf_context", legacy_query, limit, settings)
+        flow_safety = enforce_query_safety("sys_flow_context", flow_query, limit, settings)
+        effective_limit = min(legacy_safety["limit"], flow_safety["limit"])
 
         async with ServiceNowClient(settings, auth_provider) as client:
             legacy_result, flow_result = await asyncio.gather(
@@ -76,7 +74,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "running_duration",
                         "active",
                     ],
-                    limit=safe_limit,
+                    limit=effective_limit,
                     display_values=True,
                 ),
                 client.query_records(
@@ -92,7 +90,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "source_table",
                         "source_record",
                     ],
-                    limit=safe_limit,
+                    limit=effective_limit,
                     display_values=True,
                 ),
             )
@@ -129,8 +127,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         activity_query = ServiceNowQuery().equals("workflow_version", workflow_version_sys_id).order_by("x").build()
         transition_query = ServiceNowQuery().equals("from.workflow_version", workflow_version_sys_id).build()
 
-        enforce_query_safety("wf_activity", activity_query, 100, settings)
-        enforce_query_safety("wf_transition", transition_query, 200, settings)
+        act_safety = enforce_query_safety("wf_activity", activity_query, 100, settings)
+        trans_safety = enforce_query_safety("wf_transition", transition_query, 200, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             version_record, activity_result, transition_result = await asyncio.gather(
@@ -152,7 +150,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "is_parent",
                         "stage",
                     ],
-                    limit=100,
+                    limit=act_safety["limit"],
                     display_values=True,
                 ),
                 client.query_records(
@@ -166,7 +164,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "to.name",
                         "condition",
                     ],
-                    limit=200,
+                    limit=trans_safety["limit"],
                     display_values=True,
                 ),
             )
@@ -182,12 +180,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     .in_list("document_key", activity_sys_ids)
                     .build()
                 )
-                enforce_query_safety("sys_variable_value", vars_query, 500, settings)
+                vars_safety = enforce_query_safety("sys_variable_value", vars_query, 500, settings)
                 vars_result = await client.query_records(
                     "sys_variable_value",
                     vars_query,
                     fields=["sys_id", "variable", "value", "document_key"],
-                    limit=500,
+                    limit=vars_safety["limit"],
                     display_values=False,
                 )
                 vars_by_activity: dict[str, list[dict[str, Any]]] = {}
@@ -233,8 +231,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         executing_query = ServiceNowQuery().equals("context", context_sys_id).order_by("started").build()
         history_query = ServiceNowQuery().equals("context", context_sys_id).order_by("started").build()
 
-        enforce_query_safety("wf_executing", executing_query, 50, settings)
-        enforce_query_safety("wf_history", history_query, 50, settings)
+        exec_safety = enforce_query_safety("wf_executing", executing_query, 50, settings)
+        hist_safety = enforce_query_safety("wf_history", history_query, 50, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             context_record, executing_result, history_result = await asyncio.gather(
@@ -254,7 +252,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "fault_description",
                         "activity_index",
                     ],
-                    limit=50,
+                    limit=exec_safety["limit"],
                     display_values=True,
                 ),
                 client.query_records(
@@ -272,7 +270,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "fault_description",
                         "activity_index",
                     ],
-                    limit=50,
+                    limit=hist_safety["limit"],
                     display_values=True,
                 ),
             )
@@ -308,7 +306,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         variables_query = (
             ServiceNowQuery().equals("document", "wf_activity").equals("document_key", activity_sys_id).build()
         )
-        enforce_query_safety("sys_variable_value", variables_query, 50, settings)
+        vars_safety = enforce_query_safety("sys_variable_value", variables_query, 50, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # Phase 1: raw activity to extract the activity_definition sys_id
@@ -323,7 +321,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "sys_variable_value",
                         variables_query,
                         fields=["sys_id", "variable", "value", "document_key"],
-                        limit=50,
+                        limit=vars_safety["limit"],
                         display_values=True,
                     ),
                 )
@@ -337,7 +335,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "sys_variable_value",
                         variables_query,
                         fields=["sys_id", "variable", "value", "document_key"],
-                        limit=50,
+                        limit=vars_safety["limit"],
                         display_values=True,
                     ),
                 )
@@ -370,11 +368,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         validate_identifier(table)
         check_table_access("wf_workflow_version")
 
-        # Clamp limit to 1-100
-        safe_limit = max(1, min(limit, 100))
-
         query = ServiceNowQuery().equals("table", table).equals_if("active", "true", active_only).build()
-        enforce_query_safety("wf_workflow_version", query, safe_limit, settings)
+        safety = enforce_query_safety("wf_workflow_version", query, limit, settings)
+        effective_limit = safety["limit"]
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -391,7 +387,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     "checked_out_by",
                     "workflow",
                 ],
-                limit=safe_limit,
+                limit=effective_limit,
                 display_values=True,
             )
 

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -1,6 +1,7 @@
 """Workflow introspection tools for the legacy Workflow Engine."""
 
 import asyncio
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -9,8 +10,10 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import check_table_access, enforce_query_safety, mask_sensitive_fields
 from servicenow_mcp.utils import ServiceNowQuery, format_response, validate_identifier
+
+logger = logging.getLogger(__name__)
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -34,11 +37,15 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             state: Filter legacy contexts by state. Legacy values: executing, finished, cancelled. Flow Designer values: IN_PROGRESS, COMPLETE, ERROR, CANCELLED.
             limit: Maximum number of records to return per engine (default 10).
         """
+        validate_identifier(record_sys_id)
         check_table_access("wf_context")
         check_table_access("sys_flow_context")
 
         if table:
             validate_identifier(table)
+
+        # Clamp limit to 1-100
+        safe_limit = max(1, min(limit, 100))
 
         legacy_query = (
             ServiceNowQuery()
@@ -48,6 +55,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             .build()
         )
         flow_query = ServiceNowQuery().equals("source_record", record_sys_id).build()
+
+        enforce_query_safety("wf_context", legacy_query, safe_limit, settings)
+        enforce_query_safety("sys_flow_context", flow_query, safe_limit, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             legacy_result, flow_result = await asyncio.gather(
@@ -66,7 +76,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "running_duration",
                         "active",
                     ],
-                    limit=limit,
+                    limit=safe_limit,
                     display_values=True,
                 ),
                 client.query_records(
@@ -82,7 +92,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         "source_table",
                         "source_record",
                     ],
-                    limit=limit,
+                    limit=safe_limit,
                     display_values=True,
                 ),
             )
@@ -110,6 +120,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             workflow_version_sys_id: The sys_id of the wf_workflow_version record.
         """
+        validate_identifier(workflow_version_sys_id)
         check_table_access("wf_workflow_version")
         check_table_access("wf_activity")
         check_table_access("wf_transition")
@@ -117,6 +128,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         activity_query = ServiceNowQuery().equals("workflow_version", workflow_version_sys_id).order_by("x").build()
         transition_query = ServiceNowQuery().equals("from.workflow_version", workflow_version_sys_id).build()
+
+        enforce_query_safety("wf_activity", activity_query, 100, settings)
+        enforce_query_safety("wf_transition", transition_query, 200, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             version_record, activity_result, transition_result = await asyncio.gather(
@@ -168,6 +182,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     .in_list("document_key", activity_sys_ids)
                     .build()
                 )
+                enforce_query_safety("sys_variable_value", vars_query, 500, settings)
                 vars_result = await client.query_records(
                     "sys_variable_value",
                     vars_query,
@@ -210,12 +225,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             context_sys_id: The sys_id of the wf_context record.
         """
+        validate_identifier(context_sys_id)
         check_table_access("wf_context")
         check_table_access("wf_executing")
         check_table_access("wf_history")
 
         executing_query = ServiceNowQuery().equals("context", context_sys_id).order_by("started").build()
         history_query = ServiceNowQuery().equals("context", context_sys_id).order_by("started").build()
+
+        enforce_query_safety("wf_executing", executing_query, 50, settings)
+        enforce_query_safety("wf_history", history_query, 50, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             context_record, executing_result, history_result = await asyncio.gather(
@@ -281,6 +300,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             activity_sys_id: The sys_id of the wf_activity record.
         """
+        validate_identifier(activity_sys_id)
         check_table_access("wf_activity")
         check_table_access("wf_element_definition")
         check_table_access("sys_variable_value")
@@ -288,6 +308,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         variables_query = (
             ServiceNowQuery().equals("document", "wf_activity").equals("document_key", activity_sys_id).build()
         )
+        enforce_query_safety("sys_variable_value", variables_query, 50, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # Phase 1: raw activity to extract the activity_definition sys_id
@@ -308,6 +329,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 )
                 definition_record = None
             else:
+                validate_identifier(definition_sys_id)
                 display_activity, definition_record, variables_result = await asyncio.gather(
                     client.get_record("wf_activity", activity_sys_id, display_values=True),
                     client.get_record("wf_element_definition", definition_sys_id, display_values=True),
@@ -348,7 +370,11 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         validate_identifier(table)
         check_table_access("wf_workflow_version")
 
+        # Clamp limit to 1-100
+        safe_limit = max(1, min(limit, 100))
+
         query = ServiceNowQuery().equals("table", table).equals_if("active", "true", active_only).build()
+        enforce_query_safety("wf_workflow_version", query, safe_limit, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -365,7 +391,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     "checked_out_by",
                     "workflow",
                 ],
-                limit=limit,
+                limit=safe_limit,
                 display_values=True,
             )
 

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -105,18 +105,21 @@ def format_response(
     data: Any,
     correlation_id: str,
     status: str = "success",
-    error: str | None = None,
+    error: str | dict[str, str] | None = None,
     pagination: dict[str, int] | None = None,
     warnings: list[str] | None = None,
 ) -> str:
-    """Build and serialize a standardized response envelope."""
+    """Build and serialize a standardized response envelope.
+
+    The *error* field accepts a plain string (for backward compatibility)
+    or a structured dict (preferred: ``{"message": "..."}``)."""
     response: dict[str, Any] = {
         "correlation_id": correlation_id,
         "status": status,
         "data": data,
     }
     if error is not None:
-        response["error"] = error
+        response["error"] = {"message": error} if isinstance(error, str) else error
     if pagination is not None:
         response["pagination"] = pagination
     if warnings is not None:

--- a/tests/domains/test_change.py
+++ b/tests/domains/test_change.py
@@ -112,7 +112,7 @@ class TestChangeGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "CHG" in data["error"]
+        assert "CHG" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -125,7 +125,7 @@ class TestChangeGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
 
 class TestChangeCreate:
@@ -227,7 +227,7 @@ class TestChangeCreate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_missing_short_description(self, settings, auth_provider):
@@ -237,7 +237,7 @@ class TestChangeCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "short_description" in data["error"].lower()
+        assert "short_description" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_type(self, settings, auth_provider):
@@ -247,7 +247,7 @@ class TestChangeCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "type" in data["error"].lower()
+        assert "type" in data["error"]["message"].lower()
 
 
 class TestChangeUpdate:
@@ -294,7 +294,7 @@ class TestChangeUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "CHG" in data["error"]
+        assert "CHG" in data["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_update_blocked_in_prod(self):
@@ -318,7 +318,7 @@ class TestChangeUpdate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -334,7 +334,7 @@ class TestChangeUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -398,7 +398,7 @@ class TestChangeUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "no fields" in data["error"].lower()
+        assert "no fields" in data["error"]["message"].lower()
 
 
 class TestChangeTasks:
@@ -436,7 +436,7 @@ class TestChangeTasks:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "CHG" in data["error"]
+        assert "CHG" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -536,7 +536,7 @@ class TestChangeAddComment:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "comment" in data["error"].lower() or "work_note" in data["error"].lower()
+        assert "comment" in data["error"]["message"].lower() or "work_note" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_add_comment_blocked_in_prod(self):
@@ -560,7 +560,7 @@ class TestChangeAddComment:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_add_comment_invalid_prefix(self, settings, auth_provider):
@@ -573,7 +573,7 @@ class TestChangeAddComment:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "CHG" in data["error"]
+        assert "CHG" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -589,4 +589,4 @@ class TestChangeAddComment:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -180,7 +180,7 @@ class TestCmdbGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
 
 class TestCmdbRelationships:
@@ -294,7 +294,7 @@ class TestCmdbRelationships:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -336,7 +336,7 @@ class TestCmdbRelationships:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "invalid direction" in data["error"].lower()
+        assert "invalid direction" in data["error"]["message"].lower()
 
 
 class TestCmdbClasses:
@@ -464,7 +464,7 @@ class TestErrorHandling:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "denied" in data["error"].lower() or "forbidden" in data["error"].lower()
+        assert "denied" in data["error"]["message"].lower() or "forbidden" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/domains/test_incident.py
+++ b/tests/domains/test_incident.py
@@ -112,7 +112,7 @@ class TestIncidentGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "INC" in data["error"]
+        assert "INC" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -125,7 +125,7 @@ class TestIncidentGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
 
 class TestIncidentCreate:
@@ -168,7 +168,7 @@ class TestIncidentCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "short_description" in data["error"].lower()
+        assert "short_description" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_urgency(self, settings, auth_provider):
@@ -179,13 +179,13 @@ class TestIncidentCreate:
         result = await tools["incident_create"](short_description="Test", urgency=0)
         data = toon_decode(result)
         assert data["status"] == "error"
-        assert "urgency" in data["error"].lower()
+        assert "urgency" in data["error"]["message"].lower()
 
         # Test urgency=5
         result = await tools["incident_create"](short_description="Test", urgency=5)
         data = toon_decode(result)
         assert data["status"] == "error"
-        assert "urgency" in data["error"].lower()
+        assert "urgency" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_impact(self, settings, auth_provider):
@@ -195,12 +195,12 @@ class TestIncidentCreate:
         result = await tools["incident_create"](short_description="Test", impact=0)
         data = toon_decode(result)
         assert data["status"] == "error"
-        assert "impact" in data["error"].lower()
+        assert "impact" in data["error"]["message"].lower()
 
         result = await tools["incident_create"](short_description="Test", impact=5)
         data = toon_decode(result)
         assert data["status"] == "error"
-        assert "impact" in data["error"].lower()
+        assert "impact" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_blocked_in_prod(self):
@@ -221,7 +221,7 @@ class TestIncidentCreate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -309,7 +309,7 @@ class TestIncidentUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "INC" in data["error"]
+        assert "INC" in data["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_update_blocked_in_prod(self):
@@ -333,7 +333,7 @@ class TestIncidentUpdate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -346,7 +346,7 @@ class TestIncidentUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -364,7 +364,7 @@ class TestIncidentUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "no fields" in data["error"].lower()
+        assert "no fields" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -471,7 +471,7 @@ class TestIncidentResolve:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "close_code" in data["error"].lower()
+        assert "close_code" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_resolve_missing_close_notes(self, settings, auth_provider):
@@ -485,7 +485,7 @@ class TestIncidentResolve:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "close_notes" in data["error"].lower()
+        assert "close_notes" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_resolve_blocked_in_prod(self):
@@ -510,7 +510,7 @@ class TestIncidentResolve:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_resolve_invalid_number(self, settings, auth_provider):
@@ -524,7 +524,7 @@ class TestIncidentResolve:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "INC" in data["error"]
+        assert "INC" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -541,7 +541,7 @@ class TestIncidentResolve:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
 
 class TestIncidentAddComment:
@@ -623,7 +623,7 @@ class TestIncidentAddComment:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "comment" in data["error"].lower() or "work_note" in data["error"].lower()
+        assert "comment" in data["error"]["message"].lower() or "work_note" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_add_comment_blocked_in_prod(self):
@@ -647,7 +647,7 @@ class TestIncidentAddComment:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_add_comment_invalid_number(self, settings, auth_provider):
@@ -660,7 +660,7 @@ class TestIncidentAddComment:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "INC" in data["error"]
+        assert "INC" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -676,4 +676,4 @@ class TestIncidentAddComment:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()

--- a/tests/domains/test_knowledge.py
+++ b/tests/domains/test_knowledge.py
@@ -143,7 +143,7 @@ class TestKnowledgeGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
 
 class TestKnowledgeCreate:
@@ -185,7 +185,7 @@ class TestKnowledgeCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "short_description" in data["error"].lower()
+        assert "short_description" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -196,7 +196,7 @@ class TestKnowledgeCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "text" in data["error"].lower()
+        assert "text" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -258,7 +258,7 @@ class TestKnowledgeCreate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
 
 class TestKnowledgeUpdate:
@@ -333,7 +333,7 @@ class TestKnowledgeUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -348,7 +348,7 @@ class TestKnowledgeUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "no fields" in data["error"].lower()
+        assert "no fields" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_update_production_blocked(self):
@@ -369,7 +369,7 @@ class TestKnowledgeUpdate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -501,7 +501,7 @@ class TestKnowledgeFeedback:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "rating or comment" in data["error"].lower()
+        assert "rating or comment" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -512,7 +512,7 @@ class TestKnowledgeFeedback:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "between 1 and 5" in data["error"].lower()
+        assert "between 1 and 5" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -523,7 +523,7 @@ class TestKnowledgeFeedback:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "between 1 and 5" in data["error"].lower()
+        assert "between 1 and 5" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_feedback_production_blocked(self):
@@ -544,7 +544,7 @@ class TestKnowledgeFeedback:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -595,4 +595,4 @@ class TestKnowledgeFeedback:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()

--- a/tests/domains/test_problem.py
+++ b/tests/domains/test_problem.py
@@ -148,7 +148,7 @@ class TestProblemGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "PRB" in data["error"]
+        assert "PRB" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -161,7 +161,7 @@ class TestProblemGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -262,7 +262,7 @@ class TestProblemCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "short_description" in data["error"].lower()
+        assert "short_description" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_whitespace_short_description(self, settings, auth_provider):
@@ -272,7 +272,7 @@ class TestProblemCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "short_description" in data["error"].lower()
+        assert "short_description" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_urgency_too_high(self, settings, auth_provider):
@@ -282,7 +282,7 @@ class TestProblemCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "urgency" in data["error"].lower()
+        assert "urgency" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_urgency_too_low(self, settings, auth_provider):
@@ -292,7 +292,7 @@ class TestProblemCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "urgency" in data["error"].lower()
+        assert "urgency" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_impact_too_high(self, settings, auth_provider):
@@ -302,7 +302,7 @@ class TestProblemCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "impact" in data["error"].lower()
+        assert "impact" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_invalid_impact_too_low(self, settings, auth_provider):
@@ -312,7 +312,7 @@ class TestProblemCreate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "impact" in data["error"].lower()
+        assert "impact" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_create_blocked_in_prod(self):
@@ -333,7 +333,7 @@ class TestProblemCreate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
 
 class TestProblemUpdate:
@@ -380,7 +380,7 @@ class TestProblemUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "PRB" in data["error"]
+        assert "PRB" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -393,7 +393,7 @@ class TestProblemUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -411,7 +411,7 @@ class TestProblemUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "no fields" in data["error"].lower()
+        assert "no fields" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -522,7 +522,7 @@ class TestProblemUpdate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
 
 class TestProblemRootCause:
@@ -608,7 +608,7 @@ class TestProblemRootCause:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "PRB" in data["error"]
+        assert "PRB" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -624,7 +624,7 @@ class TestProblemRootCause:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_root_cause_empty_cause_notes(self, settings, auth_provider):
@@ -637,7 +637,7 @@ class TestProblemRootCause:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "cause_notes" in data["error"].lower()
+        assert "cause_notes" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_root_cause_whitespace_cause_notes(self, settings, auth_provider):
@@ -650,7 +650,7 @@ class TestProblemRootCause:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "cause_notes" in data["error"].lower()
+        assert "cause_notes" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_root_cause_blocked_in_prod(self):
@@ -674,4 +674,4 @@ class TestProblemRootCause:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()

--- a/tests/domains/test_request.py
+++ b/tests/domains/test_request.py
@@ -129,7 +129,7 @@ class TestRequestGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "REQ" in data["error"]
+        assert "REQ" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -142,7 +142,7 @@ class TestRequestGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -208,7 +208,7 @@ class TestRequestItems:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "REQ" in data["error"]
+        assert "REQ" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -258,7 +258,7 @@ class TestRequestItemGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "RITM" in data["error"]
+        assert "RITM" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -271,7 +271,7 @@ class TestRequestItemGet:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
 
 class TestRequestItemUpdate:
@@ -354,7 +354,7 @@ class TestRequestItemUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "RITM" in data["error"]
+        assert "RITM" in data["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -368,7 +368,7 @@ class TestRequestItemUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "not found" in data["error"].lower()
+        assert "not found" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -387,7 +387,7 @@ class TestRequestItemUpdate:
         data = toon_decode(result)
 
         assert data["status"] == "error"
-        assert "no fields" in data["error"].lower()
+        assert "no fields" in data["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_update_blocked_in_prod(self):
@@ -411,4 +411,4 @@ class TestRequestItemUpdate:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()

--- a/tests/domains/test_service_catalog.py
+++ b/tests/domains/test_service_catalog.py
@@ -370,7 +370,7 @@ class TestScOrderNow:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
 
 # ── Add to Cart ──────────────────────────────────────────────────────────
@@ -439,7 +439,7 @@ class TestScAddToCart:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
 
 # ── Cart Get ─────────────────────────────────────────────────────────────
@@ -518,7 +518,7 @@ class TestScCartSubmit:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()
 
 
 # ── Cart Checkout ────────────────────────────────────────────────────────
@@ -565,4 +565,4 @@ class TestScCartCheckout:
             data = toon_decode(result)
 
             assert data["status"] == "error"
-            assert "production" in data["error"].lower()
+            assert "production" in data["error"]["message"].lower()

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -179,7 +179,7 @@ class TestChangesUpdatesetInspect:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "invalid identifier" in result["error"].lower()
+        assert "invalid identifier" in result["error"]["message"].lower()
 
 
 class TestChangesDiffArtifact:
@@ -541,4 +541,4 @@ class TestChangesReleaseNotes:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "invalid identifier" in result["error"].lower()
+        assert "invalid identifier" in result["error"]["message"].lower()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -84,7 +84,7 @@ class TestToolHandler:
         result = await my_tool()
         parsed = toon_decode(result)
         assert parsed["status"] == "error"
-        assert "something broke" in parsed["error"]
+        assert "something broke" in parsed["error"]["message"]
 
     async def test_catches_forbidden_error(self) -> None:
         """ForbiddenError is caught and returned as an ACL denial error envelope."""
@@ -96,7 +96,7 @@ class TestToolHandler:
         result = await my_tool()
         parsed = toon_decode(result)
         assert parsed["status"] == "error"
-        assert "Access denied" in parsed["error"] or "ACL" in parsed["error"]
+        assert "Access denied" in parsed["error"]["message"] or "ACL" in parsed["error"]["message"]
 
     async def test_passes_args_and_kwargs(self) -> None:
         """Positional and keyword arguments are forwarded correctly."""

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -116,7 +116,7 @@ class TestDevToggle:
 
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "acl" in result["error"].lower() or "forbidden" in result["error"].lower()
+        assert "acl" in result["error"]["message"].lower() or "forbidden" in result["error"]["message"].lower()
 
 
 # -- dev_set_property ----------------------------------------------------------
@@ -271,7 +271,7 @@ class TestDevToggleGenericException:
             raw = await tools["dev_toggle"](artifact_type="business_rule", sys_id="br001", active=False)
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "connection failed" in result["error"]
+        assert "connection failed" in result["error"]["message"]
 
 
 class TestDevSetPropertyGenericException:
@@ -292,4 +292,4 @@ class TestDevSetPropertyGenericException:
             raw = await tools["dev_set_property"](name="glide.ui.session_timeout", value="60")
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "network failure" in result["error"]
+        assert "network failure" in result["error"]["message"]

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -86,7 +86,7 @@ class TestRecordCreate:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "production" in result["error"].lower()
+        assert "production" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_denied_table_returns_error(self, settings, auth_provider):
@@ -101,7 +101,7 @@ class TestRecordCreate:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_invalid_json_returns_error(self, settings, auth_provider):
@@ -128,7 +128,7 @@ class TestRecordCreate:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "acl" in result["error"].lower()
+        assert "acl" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -148,7 +148,7 @@ class TestRecordCreate:
             )
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "connection failed" in result["error"]
+        assert "connection failed" in result["error"]["message"]
 
 
 # -- record_preview_create -----------------------------------------------------
@@ -304,7 +304,7 @@ class TestRecordUpdate:
         )
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "acl" in result["error"].lower()
+        assert "acl" in result["error"]["message"].lower()
 
 
 # -- record_preview_update -----------------------------------------------------
@@ -466,7 +466,7 @@ class TestRecordDelete:
         raw = await tools["record_delete"](table="incident", sys_id="inc001")
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "acl" in result["error"].lower()
+        assert "acl" in result["error"]["message"].lower()
 
 
 # -- record_preview_delete -----------------------------------------------------
@@ -648,7 +648,7 @@ class TestRecordApply:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "invalid" in result["error"].lower() or "expired" in result["error"].lower()
+        assert "invalid" in result["error"]["message"].lower() or "expired" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -677,7 +677,7 @@ class TestRecordApply:
         raw2 = await tools["record_apply"](preview_token=token)
         result2 = toon_decode(raw2)
         assert result2["status"] == "error"
-        assert "invalid" in result2["error"].lower() or "expired" in result2["error"].lower()
+        assert "invalid" in result2["error"]["message"].lower() or "expired" in result2["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -728,7 +728,7 @@ class TestRecordApply:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "acl" in result["error"].lower()
+        assert "acl" in result["error"]["message"].lower()
 
 
 # -- mandatory field validation ------------------------------------------------
@@ -770,7 +770,7 @@ class TestMandatoryFieldValidation:
         assert result["status"] == "error"
         assert "missing_fields" in result["data"]
         assert "category" in result["data"]["missing_fields"]
-        assert "Missing mandatory fields" in result["error"]
+        assert "Missing mandatory fields" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -815,7 +815,7 @@ class TestMandatoryFieldValidation:
 
         assert result["status"] == "error"
         assert "category" in result["data"]["missing_fields"]
-        assert "Missing mandatory fields" in result["error"]
+        assert "Missing mandatory fields" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -865,7 +865,7 @@ class TestMandatoryFieldValidation:
 
         assert result["status"] == "error"
         assert "category" in result["data"]["missing_fields"]
-        assert "Missing mandatory fields" in result["error"]
+        assert "Missing mandatory fields" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -288,8 +288,8 @@ class TestDocsArtifactSummary:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "bogus_type" in result["error"]
-        assert "Valid:" in result["error"]
+        assert "bogus_type" in result["error"]["message"]
+        assert "Valid:" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -458,8 +458,8 @@ class TestDocsTestScenarios:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "bogus_type" in result["error"]
-        assert "Valid:" in result["error"]
+        assert "bogus_type" in result["error"]["message"]
+        assert "Valid:" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -663,8 +663,8 @@ class TestDocsReviewNotes:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "bogus_type" in result["error"]
-        assert "Valid:" in result["error"]
+        assert "bogus_type" in result["error"]["message"]
+        assert "Valid:" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -85,7 +85,7 @@ class TestTableDescribe:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -175,7 +175,7 @@ class TestTableGet:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 class TestTableQuery:
@@ -240,7 +240,7 @@ class TestTableQuery:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "date" in result["error"].lower()
+        assert "date" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_denied_table_returns_error(self, settings, auth_provider):
@@ -252,7 +252,7 @@ class TestTableQuery:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -316,7 +316,7 @@ class TestTableAggregate:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 # ── Error propagation tests ──────────────────────────────────────────────
@@ -342,7 +342,7 @@ class TestErrorPropagation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "not authenticated" in result["error"].lower()
+        assert "not authenticated" in result["error"]["message"].lower()
         assert "correlation_id" in result
 
     @pytest.mark.asyncio
@@ -361,7 +361,7 @@ class TestErrorPropagation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "insufficient" in result["error"].lower() or "forbidden" in result["error"].lower()
+        assert "insufficient" in result["error"]["message"].lower() or "forbidden" in result["error"]["message"].lower()
         assert "correlation_id" in result
 
     @pytest.mark.asyncio
@@ -380,7 +380,7 @@ class TestErrorPropagation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "not found" in result["error"].lower()
+        assert "not found" in result["error"]["message"].lower()
         assert "correlation_id" in result
 
     @pytest.mark.asyncio
@@ -399,7 +399,10 @@ class TestErrorPropagation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "internal server error" in result["error"].lower() or "server error" in result["error"].lower()
+        assert (
+            "internal server error" in result["error"]["message"].lower()
+            or "server error" in result["error"]["message"].lower()
+        )
         assert "correlation_id" in result
 
     @pytest.mark.asyncio
@@ -419,7 +422,10 @@ class TestErrorPropagation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "session expired" in result["error"].lower() or "authentication" in result["error"].lower()
+        assert (
+            "session expired" in result["error"]["message"].lower()
+            or "authentication" in result["error"]["message"].lower()
+        )
         assert "correlation_id" in result
 
     @pytest.mark.asyncio
@@ -439,7 +445,7 @@ class TestErrorPropagation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert result["error"]  # Error message is non-empty
+        assert result["error"]["message"]  # Error message is non-empty
         assert "correlation_id" in result
 
 
@@ -454,7 +460,7 @@ class TestQueryTokenValidation:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "build_query" in result["error"].lower()
+        assert "build_query" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -390,7 +390,7 @@ class TestTableHealth:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "Invalid identifier" in result["error"]
+        assert "Invalid identifier" in result["error"]["message"]
 
 
 # ── acl_conflicts ─────────────────────────────────────────────────────────
@@ -1018,7 +1018,7 @@ class TestExplainPerformanceBottlenecks:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "Invalid identifier" in result["error"]
+        assert "Invalid identifier" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_explain_denied_table(self, settings, auth_provider):
@@ -1031,7 +1031,7 @@ class TestExplainPerformanceBottlenecks:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -1211,7 +1211,7 @@ class TestExplainSecurityRestrictions:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "Invalid identifier" in result["error"]
+        assert "Invalid identifier" in result["error"]["message"]
 
 
 # ── WP5: element_id split guard tests ────────────────────────────────────
@@ -1414,7 +1414,7 @@ class TestErrorAnalysisCheckTableAccess:
             result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 # ── WP5: validate_identifier + check_table_access for perf bottlenecks ───
@@ -1434,7 +1434,7 @@ class TestPerformanceBottlenecksElseBranch:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "Invalid identifier" in result["error"]
+        assert "Invalid identifier" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_explain_special_chars_table(self, settings, auth_provider):
@@ -1447,7 +1447,7 @@ class TestPerformanceBottlenecksElseBranch:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "Invalid identifier" in result["error"]
+        assert "Invalid identifier" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_explain_denied_table_else_branch(self, settings, auth_provider):
@@ -1460,7 +1460,7 @@ class TestPerformanceBottlenecksElseBranch:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 # ── Direct module tests for coverage gaps ─────────────────────────────────
@@ -1934,7 +1934,7 @@ class TestPerformanceBottlenecksCheckTableAccess:
             result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 class TestSlowTransactionsCheckTableAccess:
@@ -1961,7 +1961,7 @@ class TestSlowTransactionsCheckTableAccess:
             result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 class TestStaleAutomationsCheckTableAccess:
@@ -1988,7 +1988,7 @@ class TestStaleAutomationsCheckTableAccess:
             result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 class TestTableHealthExplainCheckTableAccess:
@@ -2014,7 +2014,7 @@ class TestTableHealthExplainCheckTableAccess:
             result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 # ── Clamping: hours/stale_days minimum 1 ──────────────────────────────────

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -129,7 +129,7 @@ class TestMetaListArtifacts:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "unknown" in result["error"].lower() or "type" in result["error"].lower()
+        assert "unknown" in result["error"]["message"].lower() or "type" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -106,7 +106,7 @@ class TestRelReferencesTo:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -478,7 +478,7 @@ class TestRelReferencesFrom:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "denied" in result["error"].lower()
+        assert "denied" in result["error"]["message"].lower()
 
 
 class TestRelReferencesToBoundedConcurrency:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -403,7 +403,7 @@ class TestAtfGetResults:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "not both" in result["error"].lower()
+        assert "not both" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_get_results_missing_both_ids(self, settings, auth_provider):
@@ -413,7 +413,7 @@ class TestAtfGetResults:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "exactly one" in result["error"].lower()
+        assert "exactly one" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -506,7 +506,7 @@ class TestAtfRunTest:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "production" in result["error"].lower() or "blocked" in result["error"].lower()
+        assert "production" in result["error"]["message"].lower() or "blocked" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -524,7 +524,7 @@ class TestAtfRunTest:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "no execution id" in result["error"].lower()
+        assert "no execution id" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -646,7 +646,7 @@ class TestAtfRunSuite:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "production" in result["error"].lower() or "blocked" in result["error"].lower()
+        assert "production" in result["error"]["message"].lower() or "blocked" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -664,7 +664,7 @@ class TestAtfRunSuite:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "no execution id" in result["error"].lower()
+        assert "no execution id" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -841,7 +841,7 @@ class TestAtfTestHealth:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "exactly one" in result["error"].lower()
+        assert "exactly one" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_health_both_ids_provided(self, settings, auth_provider):
@@ -851,7 +851,7 @@ class TestAtfTestHealth:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "exactly one" in result["error"].lower() and "not both" in result["error"].lower()
+        assert "exactly one" in result["error"]["message"].lower() and "not both" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -90,7 +90,7 @@ class TestBuildQuery:
         raw = tools["build_query"](conditions='[{"operator": "INVALID", "field": "active", "value": "true"}]')
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "Unknown operator" in result["error"]
+        assert "Unknown operator" in result["error"]["message"]
 
     def test_invalid_json_returns_error(self, settings, auth_provider):
         """Malformed JSON returns an error response."""
@@ -98,7 +98,7 @@ class TestBuildQuery:
         raw = tools["build_query"](conditions="not valid json")
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "Invalid JSON" in result["error"]
+        assert "Invalid JSON" in result["error"]["message"]
 
     def test_missing_field_returns_error(self, settings, auth_provider):
         """Missing required 'field' key returns an error."""
@@ -106,7 +106,7 @@ class TestBuildQuery:
         raw = tools["build_query"](conditions='[{"operator": "equals", "value": "true"}]')
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "requires a 'field'" in result["error"]
+        assert "requires a 'field'" in result["error"]["message"]
 
     def test_missing_value_for_binary_operator_returns_error(self, settings, auth_provider):
         """Binary operators require a value."""
@@ -114,7 +114,7 @@ class TestBuildQuery:
         raw = tools["build_query"](conditions='[{"operator": "equals", "field": "active"}]')
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "requires a 'value'" in result["error"]
+        assert "requires a 'value'" in result["error"]["message"]
 
     def test_not_array_returns_error(self, settings, auth_provider):
         """Non-array JSON returns an error."""
@@ -122,7 +122,7 @@ class TestBuildQuery:
         raw = tools["build_query"](conditions='{"operator": "equals"}')
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "must be a JSON array" in result["error"]
+        assert "must be a JSON array" in result["error"]["message"]
 
     def test_empty_array_returns_empty_query(self, settings, auth_provider):
         """Empty array returns empty query string."""
@@ -220,7 +220,7 @@ class TestBuildQuery:
         raw = tools["build_query"](conditions=conditions)
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "list of strings" in result["error"]
+        assert "list of strings" in result["error"]["message"]
 
     def test_order_by_ascending(self, settings, auth_provider):
         """Test order_by operator (ascending by default)."""
@@ -275,7 +275,7 @@ class TestBuildQuery:
         )
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "requires an integer 'value'" in result["error"]
+        assert "requires an integer 'value'" in result["error"]["message"]
 
     def test_unexpected_exception_returns_error(self, settings, auth_provider):
         """Unexpected exception in ServiceNowQuery triggers generic handler (lines 155-156)."""
@@ -286,7 +286,7 @@ class TestBuildQuery:
             raw = tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
         result = toon_decode(raw)
         assert result["status"] == "error"
-        assert "boom" in result["error"]
+        assert "boom" in result["error"]["message"]
 
     def test_query_token_is_resolvable(self, settings):
         """build_query returns a token that resolves back to the built query."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,7 +59,7 @@ class TestFormatResponse:
         resp = toon_decode(raw)
 
         assert resp["status"] == "error"
-        assert resp["error"] == "Something went wrong"
+        assert resp["error"] == {"message": "Something went wrong"}
 
     def test_pagination_included(self):
         from servicenow_mcp.utils import format_response
@@ -959,8 +959,9 @@ class TestSafeToolCall:
         result = await safe_tool_call(fn, "test-corr-id")
         parsed = toon_decode(result)
         assert parsed["status"] == "error"
-        assert "Access denied by ServiceNow ACL" in parsed["error"]
-        assert "no access to incident" in parsed["error"]
+        assert isinstance(parsed["error"], dict)
+        assert "Access denied by ServiceNow ACL" in parsed["error"]["message"]
+        assert "no access to incident" in parsed["error"]["message"]
         assert parsed["correlation_id"] == "test-corr-id"
 
     async def test_generic_exception_returns_error_envelope(self):
@@ -972,5 +973,6 @@ class TestSafeToolCall:
         result = await safe_tool_call(fn, "test-corr-id")
         parsed = toon_decode(result)
         assert parsed["status"] == "error"
-        assert "something broke" in parsed["error"]
+        assert isinstance(parsed["error"], dict)
+        assert "something broke" in parsed["error"]["message"]
         assert parsed["correlation_id"] == "test-corr-id"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -211,6 +211,8 @@ class TestWorkflowContexts:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
+        assert isinstance(result["error"], dict)
+        assert "Server error" in result["error"]["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +420,8 @@ class TestWorkflowMap:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
+        assert isinstance(result["error"], dict)
+        assert "Not found" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -762,7 +766,10 @@ class TestWorkflowStatus:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["workflow_status"](context_sys_id="ctx404")
         result = toon_decode(raw)
+
         assert result["status"] == "error"
+        assert isinstance(result["error"], dict)
+        assert "Record not found" in result["error"]["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -890,6 +897,8 @@ class TestWorkflowActivityDetail:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
+        assert isinstance(result["error"], dict)
+        assert "Not found" in result["error"]["message"]
 
     @pytest.mark.asyncio
     @respx.mock
@@ -1101,4 +1110,7 @@ class TestWorkflowVersionList:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["workflow_version_list"](table="incident")
         result = toon_decode(raw)
+
         assert result["status"] == "error"
+        assert isinstance(result["error"], dict)
+        assert "Internal server error" in result["error"]["message"]


### PR DESCRIPTION
## Summary

Two related improvements to error handling consistency and workflow tool security.

### 1. Structured error format in `format_response()`

`error` parameter now wraps plain strings as `{"message": error}` instead of passing raw strings. This gives consumers a consistent structured object to work with.

**Before:** `{"error": "Something went wrong"}`
**After:** `{"error": {"message": "Something went wrong"}}`

- `src/servicenow_mcp/utils.py` - Updated `format_response()` signature and wrapping logic
- 20 test files updated to assert on `data["error"]["message"]` instead of `data["error"]`

### 2. Workflow tool hardening

Added input validation and query safety to all workflow tools:

- `validate_identifier()` on all sys_id parameters (`record_sys_id`, `workflow_version_sys_id`, `context_sys_id`, `activity_sys_id`, `definition_sys_id`)
- `enforce_query_safety()` before all `query_records` API calls
- Limit clamping (`max(1, min(limit, 100))`) in `workflow_contexts` and `workflow_version_list`