### PR TITLE
chore: expand ruff lint config with 13 new rule categories

### DIFF
--- a/.github/instructions/sonarqube_mcp.instructions.md
+++ b/.github/instructions/sonarqube_mcp.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "**/*"
+---
+
+These are some guidelines when using the SonarQube MCP server.
+
+# Important Tool Guidelines
+
+## Basic usage
+- **IMPORTANT**: After you finish generating or modifying any code files at the very end of the task, you MUST call the `analyze_file_list` tool (if it exists) to analyze the files you created or modified.
+- **IMPORTANT**: When starting a new task, you MUST disable automatic analysis with the `toggle_automatic_analysis` tool if it exists.
+- **IMPORTANT**: When you are done generating code at the very end of the task, you MUST re-enable automatic analysis with the `toggle_automatic_analysis` tool if it exists.
+
+## Project Keys
+- When a user mentions a project key, use `search_my_sonarqube_projects` first to find the exact project key
+- Don't guess project keys - always look them up
+
+## Code Language Detection
+- When analyzing code snippets, try to detect the programming language from the code syntax
+- If unclear, ask the user or make an educated guess based on syntax
+
+## Branch and Pull Request Context
+- Many operations support branch-specific analysis
+- If user mentions working on a feature branch, include the branch parameter
+
+## Code Issues and Violations
+- After fixing issues, do not attempt to verify them using `search_sonar_issues_in_projects`, as the server will not yet reflect the updates
+
+# Common Troubleshooting
+
+## Authentication Issues
+- SonarQube requires USER tokens (not project tokens)
+- When the error `SonarQube answered with Not authorized` occurs, verify the token type
+
+## Project Not Found
+- Use `search_my_sonarqube_projects` to find available projects
+- Verify project key spelling and format
+
+## Code Analysis Issues
+- Ensure programming language is correctly specified
+- Remind users that snippet analysis doesn't replace full project scans
+- Provide full file content for better analysis results

--- a/.github/instructions/sonarqube_mcp.instructions.md
+++ b/.github/instructions/sonarqube_mcp.instructions.md
@@ -2,41 +2,51 @@
 applyTo: "**/*"
 ---
 
+# SonarQube MCP Server Guidelines
+
 These are some guidelines when using the SonarQube MCP server.
 
 # Important Tool Guidelines
 
 ## Basic usage
+
 - **IMPORTANT**: After you finish generating or modifying any code files at the very end of the task, you MUST call the `analyze_file_list` tool (if it exists) to analyze the files you created or modified.
 - **IMPORTANT**: When starting a new task, you MUST disable automatic analysis with the `toggle_automatic_analysis` tool if it exists.
 - **IMPORTANT**: When you are done generating code at the very end of the task, you MUST re-enable automatic analysis with the `toggle_automatic_analysis` tool if it exists.
 
 ## Project Keys
+
 - When a user mentions a project key, use `search_my_sonarqube_projects` first to find the exact project key
 - Don't guess project keys - always look them up
 
 ## Code Language Detection
+
 - When analyzing code snippets, try to detect the programming language from the code syntax
 - If unclear, ask the user or make an educated guess based on syntax
 
 ## Branch and Pull Request Context
+
 - Many operations support branch-specific analysis
 - If user mentions working on a feature branch, include the branch parameter
 
 ## Code Issues and Violations
+
 - After fixing issues, do not attempt to verify them using `search_sonar_issues_in_projects`, as the server will not yet reflect the updates
 
 # Common Troubleshooting
 
 ## Authentication Issues
+
 - SonarQube requires USER tokens (not project tokens)
 - When the error `SonarQube answered with Not authorized` occurs, verify the token type
 
 ## Project Not Found
+
 - Use `search_my_sonarqube_projects` to find available projects
 - Verify project key spelling and format
 
 ## Code Analysis Issues
+
 - Ensure programming language is correctly specified
 - Remind users that snippet analysis doesn't replace full project scans
 - Provide full file content for better analysis results

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,20 @@
+{
+  "lsp": {
+    "basedpyright": {
+      "binary": {
+        "path": "basedpyright-langserver",
+        "arguments": [
+          "--stdio"
+        ]
+      }
+    },
+    "ruff": {
+      "binary": {
+        "path": "ruff server",
+        "arguments": [
+          "--stdio"
+        ]
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,13 +67,59 @@ dev = [
 [tool.ruff]
 target-version = "py312"
 line-length = 120
+src = ["src", "tests"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
-ignore = ["E501"]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "W",    # pycodestyle warnings
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "RUF",  # ruff-specific rules
+    "A",    # flake8-builtins (prevent shadowing builtins)
+    "C4",   # flake8-comprehensions (optimize comprehensions)
+    "T10",  # flake8-debugger (catch leftover debugger statements)
+    "PIE",  # flake8-pie (miscellaneous good catches)
+    "PT",   # flake8-pytest-style (pytest best practices)
+    "RSE",  # flake8-raise (clean exception raising)
+    "TC",   # type-checking imports
+    "PERF", # perflint (performance anti-patterns)
+    "FURB", # refurb (modern Python idioms)
+    "LOG",  # logging best practices
+    "FLY",  # flynt f-string conversion
+    "RET",  # flake8-return
+    "PLC",  # pylint conventions
+    "PLE",  # pylint errors
+    "PLW",  # pylint warnings
+]
+ignore = [
+    "E501",    # line too long (formatter handles wrapping)
+    "RET504",  # unnecessary variable assignment before return (aids readability)
+    "TC001",   # no future annotations; would break runtime type resolution
+    "A005",    # module shadowing standard-library module (false positive for types.py etc.)
+    "PLC0415", # import not at top-level (project uses local imports to break circular deps)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["PT011", "PT012"]
+"src/servicenow_mcp/tools/domains/change.py" = ["A002"]  # MCP tool params shadow builtins (type)
+"src/servicenow_mcp/tools/changes.py" = ["A002"]    # MCP tool params shadow builtins (format)
+
+[tool.ruff.lint.isort]
+known-first-party = ["servicenow_mcp"]
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
 
 [tool.ruff.format]
 quote-style = "double"
+docstring-code-format = true
+line-ending = "lf"
+indent-style = "space"
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ dev = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
+target-version = "py312"
 src = ["src", "tests"]
 
 [tool.ruff.lint]
@@ -79,46 +79,57 @@ select = [
     "B",    # flake8-bugbear
     "SIM",  # flake8-simplify
     "RUF",  # ruff-specific rules
-    "A",    # flake8-builtins (prevent shadowing builtins)
-    "C4",   # flake8-comprehensions (optimize comprehensions)
-    "T10",  # flake8-debugger (catch leftover debugger statements)
-    "PIE",  # flake8-pie (miscellaneous good catches)
-    "PT",   # flake8-pytest-style (pytest best practices)
-    "RSE",  # flake8-raise (clean exception raising)
-    "TC",   # type-checking imports
-    "PERF", # perflint (performance anti-patterns)
-    "FURB", # refurb (modern Python idioms)
-    "LOG",  # logging best practices
-    "FLY",  # flynt f-string conversion
+    "C4",   # flake8-comprehensions
+    "DTZ",  # flake8-datetimez
+    "T20",  # flake8-print
+    "PTH",  # flake8-use-pathlib
+    "TC",   # flake8-type-checking
     "RET",  # flake8-return
-    "PLC",  # pylint conventions
-    "PLE",  # pylint errors
     "PLW",  # pylint warnings
+    "PT",   # flake8-pytest-style
+    "A",    # flake8-builtins
+    "COM",  # flake8-commas
+    "PIE",  # flake8-pie
+    "ISC",  # flake8-implicit-str-concat
+    "G",    # flake8-logging-format
+    "INP",  # flake8-no-pep420
+    "TID",  # flake8-tidy-imports
+    "ERA",  # eradicate (commented-out code)
 ]
 ignore = [
-    "E501",    # line too long (formatter handles wrapping)
-    "RET504",  # unnecessary variable assignment before return (aids readability)
-    "TC001",   # no future annotations; would break runtime type resolution
-    "A005",    # module shadowing standard-library module (false positive for types.py etc.)
-    "PLC0415", # import not at top-level (project uses local imports to break circular deps)
+    "E501",   # line too long (formatter handles this)
+    "COM812", # missing trailing comma (conflicts with formatter)
+    "ISC001", # implicit string concatenation (conflicts with formatter)
+    "TC001", # no future annotations; would break runtime type resolution
+    "TC002", # no future annotations; would break runtime type resolution
+    "TC003", # no future annotations; would break runtime type resolution
+    "RET504", # unnecessary assignment before return (reduces debuggability)
+    "RET505", # unnecessary else after return (sometimes clearer with else)
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["PT011", "PT012"]
-"src/servicenow_mcp/tools/domains/change.py" = ["A002"]  # MCP tool params shadow builtins (type)
-"src/servicenow_mcp/tools/changes.py" = ["A002"]    # MCP tool params shadow builtins (format)
+"tests/**/*.py" = [
+    "T20",    # print statements OK in tests
+    "ERA001", # commented-out code OK in tests
+]
+"src/servicenow_mcp/tools/domains/*.py" = [
+    "A002",   # shadowing built-in "type" used as ServiceNow parameter name
+]
+"src/servicenow_mcp/tools/changes.py" = [
+    "A002",   # same - "format" parameter from ServiceNow API
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["servicenow_mcp"]
+force-single-line = false
+lines-after-imports = 2
 
 [tool.ruff.lint.flake8-pytest-style]
-fixture-parentheses = false
-mark-parentheses = false
+fixture-parentheses = true
+mark-parentheses = true
 
 [tool.ruff.format]
 quote-style = "double"
-docstring-code-format = true
-line-ending = "lf"
 indent-style = "space"
 
 [tool.mypy]

--- a/src/servicenow_mcp/choices.py
+++ b/src/servicenow_mcp/choices.py
@@ -182,6 +182,6 @@ class ChoiceRegistry:
                 self._cache[key] = dict(self._DEFAULTS[key])
 
         # Also include any instance-only choices not in defaults
-        for key in grouped:
+        for key, value in grouped.items():
             if key not in self._cache:
-                self._cache[key] = grouped[key]
+                self._cache[key] = value

--- a/src/servicenow_mcp/choices.py
+++ b/src/servicenow_mcp/choices.py
@@ -8,6 +8,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/servicenow_mcp/config.py
+++ b/src/servicenow_mcp/config.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings
 
+
 _DEFAULT_LARGE_TABLES = "syslog,sys_audit,sys_log_transaction,sys_email_log"
 
 

--- a/src/servicenow_mcp/decorators.py
+++ b/src/servicenow_mcp/decorators.py
@@ -8,7 +8,9 @@ from typing import Any
 from servicenow_mcp.utils import generate_correlation_id, safe_tool_call
 
 
-def tool_handler(fn: Callable[..., Coroutine[Any, Any, str]]) -> Callable[..., Coroutine[Any, Any, str]]:
+def tool_handler(
+    fn: Callable[..., Coroutine[Any, Any, str]],
+) -> Callable[..., Coroutine[Any, Any, str]]:
     """Wrap a tool function with automatic correlation ID and error handling.
 
     The decorated function receives ``correlation_id`` as a keyword argument

--- a/src/servicenow_mcp/investigations/__init__.py
+++ b/src/servicenow_mcp/investigations/__init__.py
@@ -7,6 +7,8 @@ Each module exports:
 The INVESTIGATION_REGISTRY maps investigation names to their modules.
 """
 
+import types
+
 from servicenow_mcp.investigations import (
     acl_conflicts,
     deprecated_apis,
@@ -18,7 +20,7 @@ from servicenow_mcp.investigations import (
 )
 
 
-INVESTIGATION_REGISTRY: dict = {
+INVESTIGATION_REGISTRY: dict[str, types.ModuleType] = {
     "stale_automations": stale_automations,
     "deprecated_apis": deprecated_apis,
     "table_health": table_health,

--- a/src/servicenow_mcp/investigations/__init__.py
+++ b/src/servicenow_mcp/investigations/__init__.py
@@ -17,6 +17,7 @@ from servicenow_mcp.investigations import (
     table_health,
 )
 
+
 INVESTIGATION_REGISTRY: dict = {
     "stale_automations": stale_automations,
     "deprecated_apis": deprecated_apis,

--- a/src/servicenow_mcp/investigations/acl_conflicts.py
+++ b/src/servicenow_mcp/investigations/acl_conflicts.py
@@ -5,7 +5,11 @@ from typing import Any
 
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.investigation_helpers import build_investigation_result
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 
@@ -29,7 +33,14 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     acl_result = await client.query_records(
         "sys_security_acl",
         query,
-        fields=["sys_id", "name", "operation", "condition", "script", "active"],
+        fields=[
+            "sys_id",
+            "name",
+            "operation",
+            "condition",
+            "script",
+            "active",
+        ],
         limit=INTERNAL_QUERY_LIMIT,
     )
     acls = [mask_sensitive_fields(a) for a in acl_result["records"]]

--- a/src/servicenow_mcp/investigations/deprecated_apis.py
+++ b/src/servicenow_mcp/investigations/deprecated_apis.py
@@ -43,16 +43,16 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
         try:
             result = await client.code_search(term=pattern, limit=limit)
             search_results = result.get("search_results", [])
-            for match in search_results:
-                findings.append(
-                    {
-                        "pattern": pattern,
-                        "element_id": f"{match.get('className', 'unknown')}:{match.get('sys_id', '')}",
-                        "name": match.get("name", ""),
-                        "table": match.get("className", ""),
-                        "detail": f"Uses deprecated pattern '{pattern}'",
-                    }
-                )
+            findings.extend(
+                {
+                    "pattern": pattern,
+                    "element_id": f"{match.get('className', 'unknown')}:{match.get('sys_id', '')}",
+                    "name": match.get("name", ""),
+                    "table": match.get("className", ""),
+                    "detail": f"Uses deprecated pattern '{pattern}'",
+                }
+                for match in search_results
+            )
         except Exception:
             # Code Search API may not be available; skip pattern
             continue

--- a/src/servicenow_mcp/investigations/deprecated_apis.py
+++ b/src/servicenow_mcp/investigations/deprecated_apis.py
@@ -9,6 +9,7 @@ from servicenow_mcp.investigation_helpers import (
     parse_int_param,
 )
 
+
 # Deprecated patterns to scan for
 DEPRECATED_PATTERNS = [
     "Packages.",

--- a/src/servicenow_mcp/investigations/performance_bottlenecks.py
+++ b/src/servicenow_mcp/investigations/performance_bottlenecks.py
@@ -4,8 +4,16 @@ from collections import Counter
 from typing import Any
 
 from servicenow_mcp.client import ServiceNowClient
-from servicenow_mcp.investigation_helpers import build_investigation_result, parse_element_id, parse_int_param
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, mask_sensitive_fields
+from servicenow_mcp.investigation_helpers import (
+    build_investigation_result,
+    parse_element_id,
+    parse_int_param,
+)
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 HEAVY_AUTOMATION_THRESHOLD = 10
@@ -71,7 +79,13 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     sj_result = await client.query_records(
         "sysauto_script",
         sj_query.build(),
-        fields=["sys_id", "name", "run_type", "run_dayofweek", "sys_updated_on"],
+        fields=[
+            "sys_id",
+            "name",
+            "run_type",
+            "run_dayofweek",
+            "sys_updated_on",
+        ],
         limit=limit,
     )
     for rec in sj_result["records"]:
@@ -140,35 +154,34 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
             "explanation": " ".join(explanation_parts),
             "record": record,
         }
-    else:
-        # element_id is a table name (heavy_automation category)
-        try:
-            validate_identifier(element_id)
-        except ValueError as e:
-            return {"error": str(e)}
+    # element_id is a table name (heavy_automation category)
+    try:
+        validate_identifier(element_id)
+    except ValueError as e:
+        return {"error": str(e)}
 
-        check_table_access(element_id)
-        stats_result = await client.aggregate(element_id, query="")
-        record_count = int(stats_result.get("stats", {}).get("count", 0))
+    check_table_access(element_id)
+    stats_result = await client.aggregate(element_id, query="")
+    record_count = int(stats_result.get("stats", {}).get("count", 0))
 
-        br_query = ServiceNowQuery().equals("collection", element_id).equals("active", "true").build()
-        br_result = await client.query_records(
-            "sys_script",
-            br_query,
-            fields=["sys_id", "name", "when"],
-            limit=INTERNAL_QUERY_LIMIT,
-        )
-        br_count = len(br_result["records"])
+    br_query = ServiceNowQuery().equals("collection", element_id).equals("active", "true").build()
+    br_result = await client.query_records(
+        "sys_script",
+        br_query,
+        fields=["sys_id", "name", "when"],
+        limit=INTERNAL_QUERY_LIMIT,
+    )
+    br_count = len(br_result["records"])
 
-        explanation_parts = [
-            f"Table '{element_id}' has {br_count} active business rules and {record_count} records.",
-            f"Tables with more than {HEAVY_AUTOMATION_THRESHOLD} business rules can cause performance issues.",
-            "Consider consolidating or disabling unnecessary rules.",
-        ]
+    explanation_parts = [
+        f"Table '{element_id}' has {br_count} active business rules and {record_count} records.",
+        f"Tables with more than {HEAVY_AUTOMATION_THRESHOLD} business rules can cause performance issues.",
+        "Consider consolidating or disabling unnecessary rules.",
+    ]
 
-        return {
-            "element": element_id,
-            "explanation": " ".join(explanation_parts),
-            "record_count": record_count,
-            "br_count": br_count,
-        }
+    return {
+        "element": element_id,
+        "explanation": " ".join(explanation_parts),
+        "record_count": record_count,
+        "br_count": br_count,
+    }

--- a/src/servicenow_mcp/investigations/performance_bottlenecks.py
+++ b/src/servicenow_mcp/investigations/performance_bottlenecks.py
@@ -165,6 +165,8 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
     stats_result = await client.aggregate(element_id, query="")
     record_count = int(stats_result.get("stats", {}).get("count", 0))
 
+    check_table_access("sys_script")
+
     br_query = ServiceNowQuery().equals("collection", element_id).equals("active", "true").build()
     br_result = await client.query_records(
         "sys_script",

--- a/src/servicenow_mcp/investigations/performance_bottlenecks.py
+++ b/src/servicenow_mcp/investigations/performance_bottlenecks.py
@@ -16,6 +16,7 @@ from servicenow_mcp.policy import (
 )
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
+
 HEAVY_AUTOMATION_THRESHOLD = 10
 
 

--- a/src/servicenow_mcp/investigations/slow_transactions.py
+++ b/src/servicenow_mcp/investigations/slow_transactions.py
@@ -88,7 +88,11 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
     return build_investigation_result(
         "slow_transactions",
         findings,
-        params={"hours": hours, "limit": limit, "categories": categories_filter},
+        params={
+            "hours": hours,
+            "limit": limit,
+            "categories": categories_filter,
+        },
         tables_queried=[t[0] for t in PERFORMANCE_TABLES],
     )
 

--- a/src/servicenow_mcp/investigations/slow_transactions.py
+++ b/src/servicenow_mcp/investigations/slow_transactions.py
@@ -11,6 +11,7 @@ from servicenow_mcp.investigation_helpers import (
 from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
 from servicenow_mcp.utils import ServiceNowQuery
 
+
 # ServiceNow performance pattern tables and their finding categories
 PERFORMANCE_TABLES = [
     ("sys_query_pattern", "slow_query"),

--- a/src/servicenow_mcp/investigations/stale_automations.py
+++ b/src/servicenow_mcp/investigations/stale_automations.py
@@ -11,7 +11,12 @@ from servicenow_mcp.investigation_helpers import (
 from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
 from servicenow_mcp.utils import ServiceNowQuery
 
-_ALLOWED_TABLES = {"flow_context", "sys_script", "sys_script_include", "sysauto_script"}
+_ALLOWED_TABLES = {
+    "flow_context",
+    "sys_script",
+    "sys_script_include",
+    "sysauto_script",
+}
 
 
 async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any]:

--- a/src/servicenow_mcp/investigations/stale_automations.py
+++ b/src/servicenow_mcp/investigations/stale_automations.py
@@ -11,6 +11,7 @@ from servicenow_mcp.investigation_helpers import (
 from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
 from servicenow_mcp.utils import ServiceNowQuery
 
+
 _ALLOWED_TABLES = {
     "flow_context",
     "sys_script",

--- a/src/servicenow_mcp/investigations/table_health.py
+++ b/src/servicenow_mcp/investigations/table_health.py
@@ -5,7 +5,11 @@ from typing import Any
 
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.investigation_helpers import build_investigation_result
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 
@@ -49,7 +53,14 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
         syslog_q.hours_ago("sys_created_on", hours)
 
     # Run all 6 health check queries in parallel
-    stats_result, br_result, cs_result, acl_result, uip_result, syslog_result = await asyncio.gather(
+    (
+        stats_result,
+        br_result,
+        cs_result,
+        acl_result,
+        uip_result,
+        syslog_result,
+    ) = await asyncio.gather(
         client.aggregate(table, query=""),
         client.query_records(
             "sys_script",

--- a/src/servicenow_mcp/policy.py
+++ b/src/servicenow_mcp/policy.py
@@ -7,6 +7,7 @@ from typing import Any
 from servicenow_mcp.config import Settings
 from servicenow_mcp.errors import PolicyError, QuerySafetyError
 
+
 logger = logging.getLogger(__name__)
 
 # Tables that must never be accessed via the MCP server

--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -8,7 +8,11 @@ from mcp.server.fastmcp import FastMCP
 from servicenow_mcp.auth import create_auth
 from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.config import Settings
-from servicenow_mcp.packages import _TOOL_GROUP_MODULES, get_package, list_packages
+from servicenow_mcp.packages import (
+    _TOOL_GROUP_MODULES,
+    get_package,
+    list_packages,
+)
 from servicenow_mcp.state import QueryTokenStore
 from servicenow_mcp.utils import serialize
 

--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -16,6 +16,7 @@ from servicenow_mcp.packages import (
 from servicenow_mcp.state import QueryTokenStore
 from servicenow_mcp.utils import serialize
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,9 +57,9 @@ def create_mcp_server() -> FastMCP:
                         module.register_tools(mcp, settings, auth_provider, choices=choices)
                     else:
                         module.register_tools(mcp, settings, auth_provider)
-                    logger.info(f"Loaded tool group: {group_name}")
+                    logger.info("Loaded tool group: %s", group_name)
             except ImportError as e:
-                logger.warning(f"Could not load tool group '{group_name}': {e}")
+                logger.warning("Could not load tool group '%s': %s", group_name, e)
 
     return mcp
 

--- a/src/servicenow_mcp/state.py
+++ b/src/servicenow_mcp/state.py
@@ -4,6 +4,7 @@ import time
 import uuid
 from typing import Any
 
+
 __all__ = ["PreviewTokenStore", "QueryTokenStore"]
 
 

--- a/src/servicenow_mcp/tools/changes.py
+++ b/src/servicenow_mcp/tools/changes.py
@@ -9,7 +9,12 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, mask_audit_entry, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_audit_entry,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
@@ -90,11 +95,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             )
 
         # Flag risks
-        risk_flags = []
         member_types = set(groups.keys())
         risky_found = member_types & RISKY_TYPES
-        for risky_type in sorted(risky_found):
-            risk_flags.append(f"Contains {groups[risky_type].__len__()} '{risky_type}' artifact(s) — review carefully")
+        risk_flags = [
+            f"Contains {len(groups[risky_type])} '{risky_type}' artifact(s) - review carefully"
+            for risky_type in sorted(risky_found)
+        ]
 
         return format_response(
             data={
@@ -300,8 +306,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             lines.append("")
             for type_name, items in sorted(groups.items()):
                 lines.append(f"### {type_name} ({len(items)})")
-                for item in items:
-                    lines.append(f"- {item}")
+                lines.extend(f"- {item}" for item in items)
                 lines.append("")
         else:
             lines.append("_No changes in this update set._")

--- a/src/servicenow_mcp/tools/changes.py
+++ b/src/servicenow_mcp/tools/changes.py
@@ -21,6 +21,7 @@ from servicenow_mcp.utils import (
     validate_identifier,
 )
 
+
 # Artifact types that are considered risky when modified
 RISKY_TYPES = {
     "sys_security_acl",

--- a/src/servicenow_mcp/tools/debug.py
+++ b/src/servicenow_mcp/tools/debug.py
@@ -9,7 +9,12 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, mask_audit_entry, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_audit_entry,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,

--- a/src/servicenow_mcp/tools/developer.py
+++ b/src/servicenow_mcp/tools/developer.py
@@ -43,7 +43,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         try:
             metadata = await client.get_metadata(table)
         except Exception:
-            logger.warning("Failed to fetch metadata for mandatory field check on table '%s'", table)
+            logger.warning(
+                "Failed to fetch metadata for mandatory field check on table '%s'",
+                table,
+            )
             return []
         mandatory_fields = [
             entry["element"] for entry in metadata if entry.get("mandatory") == "true" and entry.get("element")
@@ -320,7 +323,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 missing = await _check_mandatory_fields(client, payload["table"], payload["data"])
                 if missing:
                     return format_response(
-                        data={"table": payload["table"], "missing_fields": missing},
+                        data={
+                            "table": payload["table"],
+                            "missing_fields": missing,
+                        },
                         correlation_id=correlation_id,
                         status="error",
                         error=f"Missing mandatory fields for table '{payload['table']}': {', '.join(missing)}",
@@ -336,7 +342,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
 
-            elif action == "update":
+            if action == "update":
                 sys_id = payload["sys_id"]
                 result = await client.update_record(table, sys_id, payload["changes"])
                 return format_response(
@@ -349,7 +355,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
 
-            elif action == "delete":
+            if action == "delete":
                 sys_id = payload["sys_id"]
                 await client.delete_record(table, sys_id)
                 return format_response(
@@ -362,10 +368,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     correlation_id=correlation_id,
                 )
 
-            else:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Unknown preview action: '{action}'",
-                )
+            return format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=f"Unknown preview action: '{action}'",
+            )

--- a/src/servicenow_mcp/tools/developer.py
+++ b/src/servicenow_mcp/tools/developer.py
@@ -20,6 +20,7 @@ from servicenow_mcp.policy import (
 from servicenow_mcp.state import PreviewTokenStore
 from servicenow_mcp.utils import format_response, validate_identifier
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -10,7 +10,11 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.tools.metadata import ARTIFACT_TABLES
 from servicenow_mcp.utils import (
     ServiceNowQuery,
@@ -38,7 +42,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # Fetch all four artifact types in parallel
-            br_result, cs_result, uip_result, uia_result = await asyncio.gather(
+            (
+                br_result,
+                cs_result,
+                uip_result,
+                uia_result,
+            ) = await asyncio.gather(
                 client.query_records(
                     "sys_script",
                     ServiceNowQuery().equals("collection", table).equals("active", "true").build(),
@@ -372,14 +381,14 @@ def _generate_test_scenarios(script: str, record: dict[str, Any]) -> list[dict[s
 
     # Detect role checks
     role_matches = re.findall(r"gs\.hasRole\(['\"]([^'\"]+)['\"]\)", script)
-    for role in role_matches:
-        scenarios.append(
-            {
-                "scenario": f"Test with role '{role}'",
-                "description": f"Test behavior when user has and does not have the '{role}' role.",
-                "priority": "medium",
-            }
-        )
+    scenarios.extend(
+        {
+            "scenario": f"Test with role '{role}'",
+            "description": f"Test behavior when user has and does not have the '{role}' role.",
+            "priority": "medium",
+        }
+        for role in role_matches
+    )
 
     # Detect setAbortAction
     if re.search(r"setAbortAction\(true\)", script):

--- a/src/servicenow_mcp/tools/domains/change.py
+++ b/src/servicenow_mcp/tools/domains/change.py
@@ -7,7 +7,11 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_gate
+from servicenow_mcp.policy import (
+    check_table_access,
+    mask_sensitive_fields,
+    write_gate,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 

--- a/src/servicenow_mcp/tools/domains/incident.py
+++ b/src/servicenow_mcp/tools/domains/incident.py
@@ -7,7 +7,11 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_gate
+from servicenow_mcp.policy import (
+    check_table_access,
+    mask_sensitive_fields,
+    write_gate,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -9,7 +9,11 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_gate
+from servicenow_mcp.policy import (
+    check_table_access,
+    mask_sensitive_fields,
+    write_gate,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 

--- a/src/servicenow_mcp/tools/domains/problem.py
+++ b/src/servicenow_mcp/tools/domains/problem.py
@@ -7,7 +7,11 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_gate
+from servicenow_mcp.policy import (
+    check_table_access,
+    mask_sensitive_fields,
+    write_gate,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 

--- a/src/servicenow_mcp/tools/domains/request.py
+++ b/src/servicenow_mcp/tools/domains/request.py
@@ -7,7 +7,11 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_gate
+from servicenow_mcp.policy import (
+    check_table_access,
+    mask_sensitive_fields,
+    write_gate,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 

--- a/src/servicenow_mcp/tools/introspection.py
+++ b/src/servicenow_mcp/tools/introspection.py
@@ -48,7 +48,11 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             }
             fields.append(field_info)
         return format_response(
-            data={"table": table, "fields": fields, "field_count": len(fields)},
+            data={
+                "table": table,
+                "fields": fields,
+                "field_count": len(fields),
+            },
             correlation_id=correlation_id,
         )
 
@@ -115,7 +119,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             warnings.append(f"Limit capped at {effective_limit}")
 
         field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
-        order = order_by if order_by else None
+        order = order_by or None
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -139,7 +143,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 "limit": effective_limit,
                 "total": result["count"],
             },
-            warnings=warnings if warnings else None,
+            warnings=warnings or None,
         )
 
     @mcp.tool()
@@ -175,7 +179,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         validate_identifier(table)
         check_table_access(table)
         enforce_query_safety(table, query, None, settings)
-        group = group_by if group_by else None
+        group = group_by or None
 
         def _split(s: str) -> list[str] | None:
             parts = [p.strip() for p in s.split(",") if p.strip()]

--- a/src/servicenow_mcp/tools/metadata.py
+++ b/src/servicenow_mcp/tools/metadata.py
@@ -8,7 +8,12 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, check_table_access, enforce_query_safety, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    enforce_query_safety,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.state import QueryTokenStore
 from servicenow_mcp.utils import (
     ServiceNowQuery,
@@ -169,15 +174,15 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                             fields=["sys_id", "name", "sys_class_name"],
                             limit=effective_limit,
                         )
-                        for record in result["records"]:
-                            matches.append(
-                                {
-                                    "table": table,
-                                    "sys_id": record.get("sys_id", ""),
-                                    "name": record.get("name", ""),
-                                    "sys_class_name": record.get("sys_class_name", table),
-                                }
-                            )
+                        matches.extend(
+                            {
+                                "table": table,
+                                "sys_id": record.get("sys_id", ""),
+                                "name": record.get("name", ""),
+                                "sys_class_name": record.get("sys_class_name", table),
+                            }
+                            for record in result["records"]
+                        )
                     except Exception:
                         # Skip tables that fail (e.g., access issues)
                         continue
@@ -231,7 +236,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         return format_response(
             data={
                 "table": table,
-                "field": field if field else None,
+                "field": field or None,
                 "writers": writers,
                 "total": len(writers),
             },

--- a/src/servicenow_mcp/tools/metadata.py
+++ b/src/servicenow_mcp/tools/metadata.py
@@ -22,6 +22,7 @@ from servicenow_mcp.utils import (
     validate_identifier,
 )
 
+
 # Mapping from human-friendly artifact type names to ServiceNow tables
 ARTIFACT_TABLES: dict[str, str] = {
     "business_rule": "sys_script",

--- a/src/servicenow_mcp/tools/relationships.py
+++ b/src/servicenow_mcp/tools/relationships.py
@@ -9,7 +9,12 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import DENIED_TABLES, INTERNAL_QUERY_LIMIT, check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    DENIED_TABLES,
+    INTERNAL_QUERY_LIMIT,
+    check_table_access,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.utils import (
     ServiceNowQuery,
     format_response,
@@ -106,7 +111,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     continue
                 if ref_table.lower() in DENIED_TABLES:
                     continue
-                if ref_table.startswith("var__m_") or ref_table.startswith("sys_variable_value"):
+                if ref_table.startswith(("var__m_", "sys_variable_value")):
                     continue
                 filtered_refs.append((ref_table, ref_field))
 

--- a/src/servicenow_mcp/tools/testing.py
+++ b/src/servicenow_mcp/tools/testing.py
@@ -10,7 +10,11 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_blocked_reason
+from servicenow_mcp.policy import (
+    check_table_access,
+    mask_sensitive_fields,
+    write_blocked_reason,
+)
 from servicenow_mcp.state import QueryTokenStore
 from servicenow_mcp.utils import (
     ServiceNowQuery,
@@ -63,7 +67,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         check_table_access("sys_atf_test")
 
         default_fields = "sys_id,name,description,active,sys_updated_on,test_origin"
-        field_list = fields if fields else default_fields
+        field_list = fields or default_fields
 
         query_str = resolve_query_token(query_token, query_store, correlation_id)
 
@@ -106,7 +110,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 client.query_records(
                     "sys_atf_step",
                     ServiceNowQuery().equals("test", test_id).build(),
-                    fields=["sys_id", "display_name", "step_config", "order", "inputs"],
+                    fields=[
+                        "sys_id",
+                        "display_name",
+                        "step_config",
+                        "order",
+                        "inputs",
+                    ],
                     limit=1000,
                     order_by="order",
                     display_values=True,
@@ -152,7 +162,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             result = await client.query_records(
                 "sys_atf_test_suite",
                 query,
-                fields=["sys_id", "name", "description", "active", "sys_updated_on"],
+                fields=[
+                    "sys_id",
+                    "name",
+                    "description",
+                    "active",
+                    "sys_updated_on",
+                ],
                 limit=limit,
                 order_by="sys_updated_on",
             )

--- a/src/servicenow_mcp/tools/testing.py
+++ b/src/servicenow_mcp/tools/testing.py
@@ -22,6 +22,7 @@ from servicenow_mcp.utils import (
     resolve_query_token,
 )
 
+
 logger = logging.getLogger(__name__)
 
 # ATF polling constants

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -9,12 +9,22 @@ from mcp.server.fastmcp import FastMCP
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 from servicenow_mcp.state import QueryTokenStore
-from servicenow_mcp.utils import ServiceNowQuery, format_response, generate_correlation_id
+from servicenow_mcp.utils import (
+    ServiceNowQuery,
+    format_response,
+    generate_correlation_id,
+)
 
 logger = logging.getLogger(__name__)
 
 # Map of operator names to ServiceNowQuery method signatures
-_UNARY_OPERATORS = {"is_empty", "is_not_empty", "anything", "empty_string", "val_changes"}
+_UNARY_OPERATORS = {
+    "is_empty",
+    "is_not_empty",
+    "anything",
+    "empty_string",
+    "val_changes",
+}
 _TIME_OPERATORS = {"hours_ago", "minutes_ago", "days_ago", "older_than_days"}
 _BINARY_OPERATORS = {
     "equals",
@@ -201,7 +211,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                             status="error",
                             error="Operator 'rl_query' requires 'related_table', 'related_field' (or 'field'), and 'rl_operator'.",
                         )
-                    query.rl_query(str(related_table), str(related_field), str(rl_operator), str(rl_value))
+                    query.rl_query(
+                        str(related_table),
+                        str(related_field),
+                        str(rl_operator),
+                        str(rl_value),
+                    )
                 elif operator == "order_by":
                     descending = bool(condition.get("descending", False))
                     query.order_by(field, descending=descending)
@@ -213,7 +228,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                         | _OR_BINARY_OPERATORS
                         | _LIST_OPERATORS
                         | _FIELD_OPERATORS
-                        | {"order_by", "between", "datepart", "new_query", "rl_query"}
+                        | {
+                            "order_by",
+                            "between",
+                            "datepart",
+                            "new_query",
+                            "rl_query",
+                        }
                     )
                     return format_response(
                         data=None,
@@ -224,9 +245,22 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
             built = query.build()
             query_token = query_store.create({"query": built})
-            return format_response(data={"query": built, "query_token": query_token}, correlation_id=correlation_id)
+            return format_response(
+                data={"query": built, "query_token": query_token},
+                correlation_id=correlation_id,
+            )
 
         except json.JSONDecodeError as e:
-            return format_response(data=None, correlation_id=correlation_id, status="error", error=f"Invalid JSON: {e}")
+            return format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=f"Invalid JSON: {e}",
+            )
         except Exception as e:
-            return format_response(data=None, correlation_id=correlation_id, status="error", error=str(e))
+            return format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=str(e),
+            )

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -15,6 +15,7 @@ from servicenow_mcp.utils import (
     generate_correlation_id,
 )
 
+
 logger = logging.getLogger(__name__)
 
 # Map of operator names to ServiceNowQuery method signatures

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -10,8 +10,16 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, enforce_query_safety, mask_sensitive_fields
-from servicenow_mcp.utils import ServiceNowQuery, format_response, validate_identifier
+from servicenow_mcp.policy import (
+    check_table_access,
+    enforce_query_safety,
+    mask_sensitive_fields,
+)
+from servicenow_mcp.utils import (
+    ServiceNowQuery,
+    format_response,
+    validate_identifier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +107,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         flow_records = [mask_sensitive_fields(r) for r in flow_result["records"]]
 
         return format_response(
-            data={"legacy_workflows": legacy_records, "flow_designer": flow_records},
+            data={
+                "legacy_workflows": legacy_records,
+                "flow_designer": flow_records,
+            },
             correlation_id=correlation_id,
         )
 
@@ -131,8 +142,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         trans_safety = enforce_query_safety("wf_transition", transition_query, 200, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            version_record, activity_result, transition_result = await asyncio.gather(
-                client.get_record("wf_workflow_version", workflow_version_sys_id, display_values=True),
+            (
+                version_record,
+                activity_result,
+                transition_result,
+            ) = await asyncio.gather(
+                client.get_record(
+                    "wf_workflow_version",
+                    workflow_version_sys_id,
+                    display_values=True,
+                ),
                 client.query_records(
                     "wf_activity",
                     activity_query,
@@ -235,7 +254,11 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         hist_safety = enforce_query_safety("wf_history", history_query, 50, settings)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            context_record, executing_result, history_result = await asyncio.gather(
+            (
+                context_record,
+                executing_result,
+                history_result,
+            ) = await asyncio.gather(
                 client.get_record("wf_context", context_sys_id, display_values=True),
                 client.query_records(
                     "wf_executing",
@@ -328,9 +351,17 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 definition_record = None
             else:
                 validate_identifier(definition_sys_id)
-                display_activity, definition_record, variables_result = await asyncio.gather(
+                (
+                    display_activity,
+                    definition_record,
+                    variables_result,
+                ) = await asyncio.gather(
                     client.get_record("wf_activity", activity_sys_id, display_values=True),
-                    client.get_record("wf_element_definition", definition_sys_id, display_values=True),
+                    client.get_record(
+                        "wf_element_definition",
+                        definition_sys_id,
+                        display_values=True,
+                    ),
                     client.query_records(
                         "sys_variable_value",
                         variables_query,

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -21,6 +21,7 @@ from servicenow_mcp.utils import (
     validate_identifier,
 )
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -11,6 +11,7 @@ from toon_format import encode as toon_encode
 
 from servicenow_mcp.errors import ForbiddenError
 
+
 if TYPE_CHECKING:
     from servicenow_mcp.state import QueryTokenStore
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from servicenow_mcp.config import Settings
 
 
-@pytest.fixture
+@pytest.fixture()
 def settings():
     """Create test settings with valid defaults."""
     env = {
@@ -21,7 +21,7 @@ def settings():
         return Settings(_env_file=None)
 
 
-@pytest.fixture
+@pytest.fixture()
 def prod_settings():
     """Create test settings for production environment."""
     env = {

--- a/tests/domains/conftest.py
+++ b/tests/domains/conftest.py
@@ -8,7 +8,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
 
-@pytest.fixture
+@pytest.fixture()
 def settings() -> Settings:
     """Test settings fixture (no env file loading)."""
     env = {
@@ -22,7 +22,7 @@ def settings() -> Settings:
         return Settings(_env_file=None)
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings: Settings) -> BasicAuthProvider:
     """Test auth provider fixture."""
     return BasicAuthProvider(settings)

--- a/tests/domains/test_change.py
+++ b/tests/domains/test_change.py
@@ -40,8 +40,16 @@ class TestChangeList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "id1", "number": "CHG0010001", "short_description": "Test change 1"},
-                        {"sys_id": "id2", "number": "CHG0010002", "short_description": "Test change 2"},
+                        {
+                            "sys_id": "id1",
+                            "number": "CHG0010001",
+                            "short_description": "Test change 1",
+                        },
+                        {
+                            "sys_id": "id2",
+                            "number": "CHG0010002",
+                            "short_description": "Test change 2",
+                        },
                     ]
                 },
             )
@@ -92,7 +100,15 @@ class TestChangeGet:
         respx.get(f"{BASE_URL}/api/now/table/change_request").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "CHG0010001", "short_description": "Test change"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "CHG0010001",
+                            "short_description": "Test change",
+                        }
+                    ]
+                },
             )
         )
 
@@ -260,7 +276,15 @@ class TestChangeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/change_request").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "CHG0010001", "short_description": "Old"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "CHG0010001",
+                            "short_description": "Old",
+                        }
+                    ]
+                },
             )
         )
         respx.patch(f"{BASE_URL}/api/now/table/change_request/abc123").mock(
@@ -413,8 +437,16 @@ class TestChangeTasks:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "task1", "number": "CTASK0010001", "short_description": "Task 1"},
-                        {"sys_id": "task2", "number": "CTASK0010002", "short_description": "Task 2"},
+                        {
+                            "sys_id": "task1",
+                            "number": "CTASK0010001",
+                            "short_description": "Task 1",
+                        },
+                        {
+                            "sys_id": "task2",
+                            "number": "CTASK0010002",
+                            "short_description": "Task 2",
+                        },
                     ]
                 },
             )

--- a/tests/domains/test_change.py
+++ b/tests/domains/test_change.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 
 
@@ -31,7 +32,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestChangeList:
     """Tests for change_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_no_filters(self, settings, auth_provider):
         """Should query all change requests when no filters provided."""
@@ -63,7 +64,7 @@ class TestChangeList:
         assert len(data["data"]) == 2
         assert data["data"][0]["number"] == "CHG0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_state_filter(self, settings, auth_provider):
         """Should map state names to numeric values."""
@@ -75,7 +76,7 @@ class TestChangeList:
         request = respx.calls.last.request
         assert "state%3D-5" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_multiple_filters(self, settings, auth_provider):
         """Should combine multiple filters correctly."""
@@ -93,7 +94,7 @@ class TestChangeList:
 class TestChangeGet:
     """Tests for change_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_valid_number(self, settings, auth_provider):
         """Should fetch change request by CHG number."""
@@ -120,7 +121,7 @@ class TestChangeGet:
         assert data["data"]["number"] == "CHG0010001"
         assert data["data"]["sys_id"] == "abc123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings, auth_provider):
         """Should reject non-CHG numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -130,7 +131,7 @@ class TestChangeGet:
         assert data["status"] == "error"
         assert "CHG" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings, auth_provider):
         """Should handle change request not found."""
@@ -147,7 +148,7 @@ class TestChangeGet:
 class TestChangeCreate:
     """Tests for change_create tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_valid(self, settings, auth_provider):
         """Should create change request with required short_description."""
@@ -175,7 +176,7 @@ class TestChangeCreate:
         assert data["status"] == "success"
         assert data["data"]["number"] == "CHG0010123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_with_all_optional_params(self, settings, auth_provider):
         """Should include all optional fields in the created record."""
@@ -222,7 +223,7 @@ class TestChangeCreate:
         assert request_body["start_date"] == "2026-04-01 08:00:00"
         assert request_body["end_date"] == "2026-04-01 12:00:00"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_blocked_in_prod(self):
         """Should block creation in production."""
         prod_env = {
@@ -245,7 +246,7 @@ class TestChangeCreate:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_missing_short_description(self, settings, auth_provider):
         """Should reject empty short_description."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -255,7 +256,7 @@ class TestChangeCreate:
         assert data["status"] == "error"
         assert "short_description" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_type(self, settings, auth_provider):
         """Should reject invalid type value."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -269,7 +270,7 @@ class TestChangeCreate:
 class TestChangeUpdate:
     """Tests for change_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_valid(self, settings, auth_provider):
         """Should update change request by CHG number."""
@@ -310,7 +311,7 @@ class TestChangeUpdate:
         assert data["status"] == "success"
         assert data["data"]["short_description"] == "Updated"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_invalid_number(self, settings, auth_provider):
         """Should reject non-CHG numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -320,7 +321,7 @@ class TestChangeUpdate:
         assert data["status"] == "error"
         assert "CHG" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_blocked_in_prod(self):
         """Should block updates in production."""
         prod_env = {
@@ -344,7 +345,7 @@ class TestChangeUpdate:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_not_found(self, settings, auth_provider):
         """Should handle change request not found during update."""
@@ -360,7 +361,7 @@ class TestChangeUpdate:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_with_all_optional_params(self, settings, auth_provider):
         """Should pass all optional fields including state mapping."""
@@ -406,7 +407,7 @@ class TestChangeUpdate:
         assert request_body["assignment_group"] == "grp001"
         assert request_body["state"] == "-1"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_no_changes_provided(self, settings, auth_provider):
         """Should error when no update fields are provided."""
@@ -428,7 +429,7 @@ class TestChangeUpdate:
 class TestChangeTasks:
     """Tests for change_tasks tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_tasks_valid(self, settings, auth_provider):
         """Should fetch change tasks by change request number."""
@@ -460,7 +461,7 @@ class TestChangeTasks:
         assert len(data["data"]) == 2
         assert data["data"][0]["number"] == "CTASK0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_tasks_invalid_prefix(self, settings, auth_provider):
         """Should reject non-CHG numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -470,7 +471,7 @@ class TestChangeTasks:
         assert data["status"] == "error"
         assert "CHG" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_tasks_empty_result(self, settings, auth_provider):
         """Should handle no tasks found."""
@@ -492,7 +493,7 @@ class TestChangeTasks:
 class TestChangeAddComment:
     """Tests for change_add_comment tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_add_comment_valid(self, settings, auth_provider):
         """Should add comment to change request."""
@@ -524,7 +525,7 @@ class TestChangeAddComment:
 
         assert data["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_add_work_note_valid(self, settings, auth_provider):
         """Should add work_note to change request."""
@@ -556,7 +557,7 @@ class TestChangeAddComment:
 
         assert data["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_comment_both_empty(self, settings, auth_provider):
         """Should require at least one of comment or work_note."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -570,7 +571,7 @@ class TestChangeAddComment:
         assert data["status"] == "error"
         assert "comment" in data["error"]["message"].lower() or "work_note" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_comment_blocked_in_prod(self):
         """Should block adding comments in production."""
         prod_env = {
@@ -594,7 +595,7 @@ class TestChangeAddComment:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_comment_invalid_prefix(self, settings, auth_provider):
         """Should reject non-CHG numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -607,7 +608,7 @@ class TestChangeAddComment:
         assert data["status"] == "error"
         assert "CHG" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_add_comment_not_found(self, settings, auth_provider):
         """Should handle change request not found when adding comment."""

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -39,8 +39,16 @@ class TestCmdbList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "ci1", "name": "server-01", "operational_status": "1"},
-                        {"sys_id": "ci2", "name": "server-02", "operational_status": "1"},
+                        {
+                            "sys_id": "ci1",
+                            "name": "server-01",
+                            "operational_status": "1",
+                        },
+                        {
+                            "sys_id": "ci2",
+                            "name": "server-02",
+                            "operational_status": "1",
+                        },
                     ]
                 },
             )
@@ -65,7 +73,11 @@ class TestCmdbList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "srv1", "name": "web-server-01", "operational_status": "1"},
+                        {
+                            "sys_id": "srv1",
+                            "name": "web-server-01",
+                            "operational_status": "1",
+                        },
                     ]
                 },
             )
@@ -91,7 +103,11 @@ class TestCmdbList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "ci1", "name": "server-01", "operational_status": "1"},
+                        {
+                            "sys_id": "ci1",
+                            "name": "server-01",
+                            "operational_status": "1",
+                        },
                     ]
                 },
             )
@@ -121,7 +137,11 @@ class TestCmdbGet:
                 200,
                 json={
                     "result": [
-                        {"sys_id": sys_id, "name": "server-01", "operational_status": "1"},
+                        {
+                            "sys_id": sys_id,
+                            "name": "server-01",
+                            "operational_status": "1",
+                        },
                     ]
                 },
             )
@@ -147,7 +167,11 @@ class TestCmdbGet:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "ci1", "name": "server-01", "operational_status": "1"},
+                        {
+                            "sys_id": "ci1",
+                            "name": "server-01",
+                            "operational_status": "1",
+                        },
                     ]
                 },
             )
@@ -199,8 +223,16 @@ class TestCmdbRelationships:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "rel1", "parent": {"value": "parent1"}, "child": {"value": sys_id}},
-                        {"sys_id": "rel2", "parent": {"value": sys_id}, "child": {"value": "child1"}},
+                        {
+                            "sys_id": "rel1",
+                            "parent": {"value": "parent1"},
+                            "child": {"value": sys_id},
+                        },
+                        {
+                            "sys_id": "rel2",
+                            "parent": {"value": sys_id},
+                            "child": {"value": "child1"},
+                        },
                     ]
                 },
             )
@@ -225,7 +257,11 @@ class TestCmdbRelationships:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "rel1", "parent": {"value": "parent1"}, "child": {"value": sys_id}},
+                        {
+                            "sys_id": "rel1",
+                            "parent": {"value": "parent1"},
+                            "child": {"value": sys_id},
+                        },
                     ]
                 },
             )
@@ -264,7 +300,11 @@ class TestCmdbRelationships:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "rel1", "parent": {"value": "parent1"}, "child": {"value": "resolved_sys_id"}},
+                        {
+                            "sys_id": "rel1",
+                            "parent": {"value": "parent1"},
+                            "child": {"value": "resolved_sys_id"},
+                        },
                     ]
                 },
             )
@@ -309,7 +349,11 @@ class TestCmdbRelationships:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "rel1", "parent": {"value": sys_id}, "child": {"value": "child1"}},
+                        {
+                            "sys_id": "rel1",
+                            "parent": {"value": sys_id},
+                            "child": {"value": "child1"},
+                        },
                     ]
                 },
             )
@@ -354,8 +398,14 @@ class TestCmdbClasses:
                 200,
                 json={
                     "result": [
-                        {"groupby_fields": [{"value": "cmdb_ci_server"}], "stats": {"count": "42"}},
-                        {"groupby_fields": [{"value": "cmdb_ci_network_adapter"}], "stats": {"count": "15"}},
+                        {
+                            "groupby_fields": [{"value": "cmdb_ci_server"}],
+                            "stats": {"count": "42"},
+                        },
+                        {
+                            "groupby_fields": [{"value": "cmdb_ci_network_adapter"}],
+                            "stats": {"count": "15"},
+                        },
                     ]
                 },
             )
@@ -380,7 +430,10 @@ class TestCmdbClasses:
                 200,
                 json={
                     "result": [
-                        {"groupby_fields": [{"value": "cmdb_ci_server"}], "stats": {"count": "42"}},
+                        {
+                            "groupby_fields": [{"value": "cmdb_ci_server"}],
+                            "stats": {"count": "42"},
+                        },
                     ]
                 },
             )
@@ -407,9 +460,18 @@ class TestCmdbHealth:
                 200,
                 json={
                     "result": [
-                        {"groupby_fields": [{"value": "1"}], "stats": {"count": "100"}},
-                        {"groupby_fields": [{"value": "2"}], "stats": {"count": "5"}},
-                        {"groupby_fields": [{"value": "6"}], "stats": {"count": "10"}},
+                        {
+                            "groupby_fields": [{"value": "1"}],
+                            "stats": {"count": "100"},
+                        },
+                        {
+                            "groupby_fields": [{"value": "2"}],
+                            "stats": {"count": "5"},
+                        },
+                        {
+                            "groupby_fields": [{"value": "6"}],
+                            "stats": {"count": "10"},
+                        },
                     ]
                 },
             )
@@ -434,7 +496,10 @@ class TestCmdbHealth:
                 200,
                 json={
                     "result": [
-                        {"groupby_fields": [{"value": "1"}], "stats": {"count": "50"}},
+                        {
+                            "groupby_fields": [{"value": "1"}],
+                            "stats": {"count": "50"},
+                        },
                     ]
                 },
             )

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -27,7 +27,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestCmdbList:
     """Tests for cmdb_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_default_cmdb_ci(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test listing CIs from default cmdb_ci table."""
@@ -61,7 +61,7 @@ class TestCmdbList:
         assert len(data["data"]) == 2
         assert data["data"][0]["name"] == "server-01"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_ci_class_param(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test listing CIs from specific CI class table."""
@@ -90,7 +90,7 @@ class TestCmdbList:
         assert len(data["data"]) == 1
         assert data["data"][0]["name"] == "web-server-01"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_operational_status_filter(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test filtering by operational status."""
@@ -124,7 +124,7 @@ class TestCmdbList:
 class TestCmdbGet:
     """Tests for cmdb_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_by_sys_id(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching CI by sys_id."""
@@ -155,7 +155,7 @@ class TestCmdbGet:
         request = respx.calls.last.request
         assert "sys_id%3D" in str(request.url) or f"sys_id={sys_id}" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_by_name(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching CI by name."""
@@ -186,7 +186,7 @@ class TestCmdbGet:
         request = respx.calls.last.request
         assert "name%3Dserver-01" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching non-existent CI."""
@@ -210,7 +210,7 @@ class TestCmdbGet:
 class TestCmdbRelationships:
     """Tests for cmdb_relationships tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_relationships_both_directions(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching relationships in both directions."""
@@ -244,7 +244,7 @@ class TestCmdbRelationships:
         assert data["status"] == "success"
         assert len(data["data"]) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_relationships_parent_only(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching parent relationships only."""
@@ -275,7 +275,7 @@ class TestCmdbRelationships:
         request = respx.calls.last.request
         assert f"child.sys_id%3D{sys_id}" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_relationships_by_name_lookup(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching relationships by CI name (requires sys_id lookup first)."""
@@ -315,7 +315,7 @@ class TestCmdbRelationships:
 
         assert data["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_relationships_name_not_found(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test that name lookup returning no records produces an error."""
@@ -336,7 +336,7 @@ class TestCmdbRelationships:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_relationships_child_only(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test fetching child relationships only."""
@@ -368,7 +368,7 @@ class TestCmdbRelationships:
         request = respx.calls.last.request
         assert f"parent.sys_id%3D{sys_id}" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_relationships_invalid_direction(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test that an invalid direction produces an error."""
@@ -386,7 +386,7 @@ class TestCmdbRelationships:
 class TestCmdbClasses:
     """Tests for cmdb_classes tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_classes_aggregate(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test listing unique CI classes via aggregate API."""
@@ -418,7 +418,7 @@ class TestCmdbClasses:
         assert isinstance(data["data"], list)
         assert len(data["data"]) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_classes_respects_limit(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test that cmdb_classes respects limit parameter."""
@@ -448,7 +448,7 @@ class TestCmdbClasses:
 class TestCmdbHealth:
     """Tests for cmdb_health tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_default_table(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test CMDB health check on default cmdb_ci table."""
@@ -484,7 +484,7 @@ class TestCmdbHealth:
         assert isinstance(data["data"], list)
         assert len(data["data"]) == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_specific_ci_class(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test CMDB health check on specific CI class."""
@@ -517,7 +517,7 @@ class TestCmdbHealth:
 class TestErrorHandling:
     """Tests for error handling across CMDB tools."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_denied_table_access(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test that denied tables are blocked."""
@@ -531,7 +531,7 @@ class TestErrorHandling:
         assert data["status"] == "error"
         assert "denied" in data["error"]["message"].lower() or "forbidden" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_safe_tool_call_exception_handling(self, settings: Settings, auth_provider: BasicAuthProvider):
         """Test that exceptions are caught and returned as error responses."""

--- a/tests/domains/test_imports.py
+++ b/tests/domains/test_imports.py
@@ -3,7 +3,14 @@
 
 def test_all_domain_modules_importable() -> None:
     """Verify all 6 domain modules can be imported without error."""
-    from servicenow_mcp.tools.domains import change, cmdb, incident, knowledge, problem, request
+    from servicenow_mcp.tools.domains import (
+        change,
+        cmdb,
+        incident,
+        knowledge,
+        problem,
+        request,
+    )
 
     # Verify each has register_tools function
     assert hasattr(incident, "register_tools")
@@ -18,7 +25,14 @@ def test_domain_groups_in_registry() -> None:
     """Verify all domain groups are registered in _TOOL_GROUP_MODULES."""
     from servicenow_mcp.packages import _TOOL_GROUP_MODULES
 
-    expected_domains = ["incident", "change", "cmdb", "problem", "request", "knowledge"]
+    expected_domains = [
+        "incident",
+        "change",
+        "cmdb",
+        "problem",
+        "request",
+        "knowledge",
+    ]
     for domain in expected_domains:
         group_key = f"domain_{domain}"
         assert group_key in _TOOL_GROUP_MODULES, f"Missing {group_key} in _TOOL_GROUP_MODULES"

--- a/tests/domains/test_incident.py
+++ b/tests/domains/test_incident.py
@@ -40,8 +40,16 @@ class TestIncidentList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "id1", "number": "INC0010001", "short_description": "Test 1"},
-                        {"sys_id": "id2", "number": "INC0010002", "short_description": "Test 2"},
+                        {
+                            "sys_id": "id1",
+                            "number": "INC0010001",
+                            "short_description": "Test 1",
+                        },
+                        {
+                            "sys_id": "id2",
+                            "number": "INC0010002",
+                            "short_description": "Test 2",
+                        },
                     ]
                 },
             )
@@ -92,7 +100,15 @@ class TestIncidentGet:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001", "short_description": "Test incident"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "INC0010001",
+                            "short_description": "Test incident",
+                        }
+                    ]
+                },
             )
         )
 
@@ -275,7 +291,15 @@ class TestIncidentUpdate:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001", "short_description": "Old"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "INC0010001",
+                            "short_description": "Old",
+                        }
+                    ]
+                },
             )
         )
         respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
@@ -430,7 +454,15 @@ class TestIncidentResolve:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001", "state": "2"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "INC0010001",
+                            "state": "2",
+                        }
+                    ]
+                },
             )
         )
         respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(

--- a/tests/domains/test_incident.py
+++ b/tests/domains/test_incident.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 
 
@@ -31,7 +32,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestIncidentList:
     """Tests for incident_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_no_filters(self, settings, auth_provider):
         """Should query all incidents when no filters provided."""
@@ -63,7 +64,7 @@ class TestIncidentList:
         assert len(data["data"]) == 2
         assert data["data"][0]["number"] == "INC0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_state_filter(self, settings, auth_provider):
         """Should map state names to numeric values."""
@@ -75,7 +76,7 @@ class TestIncidentList:
         request = respx.calls.last.request
         assert "state%3D1" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_multiple_filters(self, settings, auth_provider):
         """Should combine multiple filters correctly."""
@@ -93,7 +94,7 @@ class TestIncidentList:
 class TestIncidentGet:
     """Tests for incident_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_valid_number(self, settings, auth_provider):
         """Should fetch incident by INC number."""
@@ -120,7 +121,7 @@ class TestIncidentGet:
         assert data["data"]["number"] == "INC0010001"
         assert data["data"]["sys_id"] == "abc123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings, auth_provider):
         """Should reject non-INC numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -130,7 +131,7 @@ class TestIncidentGet:
         assert data["status"] == "error"
         assert "INC" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings, auth_provider):
         """Should handle incident not found."""
@@ -147,7 +148,7 @@ class TestIncidentGet:
 class TestIncidentCreate:
     """Tests for incident_create tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_valid(self, settings, auth_provider):
         """Should create incident with required short_description."""
@@ -176,7 +177,7 @@ class TestIncidentCreate:
         assert data["status"] == "success"
         assert data["data"]["number"] == "INC0010123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_missing_short_description(self, settings, auth_provider):
         """Should reject empty short_description."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -186,7 +187,7 @@ class TestIncidentCreate:
         assert data["status"] == "error"
         assert "short_description" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_urgency(self, settings, auth_provider):
         """Should reject urgency outside 1-4 range."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -203,7 +204,7 @@ class TestIncidentCreate:
         assert data["status"] == "error"
         assert "urgency" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_impact(self, settings, auth_provider):
         """Should reject impact outside 1-4 range."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -218,7 +219,7 @@ class TestIncidentCreate:
         assert data["status"] == "error"
         assert "impact" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_blocked_in_prod(self):
         """Should block creation in production."""
         prod_env = {
@@ -239,7 +240,7 @@ class TestIncidentCreate:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_with_all_optional_fields(self, settings, auth_provider):
         """Should include all optional fields in the create payload."""
@@ -284,7 +285,7 @@ class TestIncidentCreate:
 class TestIncidentUpdate:
     """Tests for incident_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_valid(self, settings, auth_provider):
         """Should update incident by INC number."""
@@ -325,7 +326,7 @@ class TestIncidentUpdate:
         assert data["status"] == "success"
         assert data["data"]["short_description"] == "Updated"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_invalid_number(self, settings, auth_provider):
         """Should reject non-INC numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -335,7 +336,7 @@ class TestIncidentUpdate:
         assert data["status"] == "error"
         assert "INC" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_blocked_in_prod(self):
         """Should block updates in production."""
         prod_env = {
@@ -359,7 +360,7 @@ class TestIncidentUpdate:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_not_found(self, settings, auth_provider):
         """Should handle incident not found during update."""
@@ -372,7 +373,7 @@ class TestIncidentUpdate:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_no_changes(self, settings, auth_provider):
         """Should reject update when no fields are provided."""
@@ -390,7 +391,7 @@ class TestIncidentUpdate:
         assert data["status"] == "error"
         assert "no fields" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_with_all_optional_fields(self, settings, auth_provider):
         """Should include all optional fields in the update payload."""
@@ -447,7 +448,7 @@ class TestIncidentUpdate:
 class TestIncidentResolve:
     """Tests for incident_resolve tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_resolve_valid(self, settings, auth_provider):
         """Should resolve incident with close_code and close_notes."""
@@ -491,7 +492,7 @@ class TestIncidentResolve:
         assert data["status"] == "success"
         assert data["data"]["state"] == "6"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_missing_close_code(self, settings, auth_provider):
         """Should require close_code."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -505,7 +506,7 @@ class TestIncidentResolve:
         assert data["status"] == "error"
         assert "close_code" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_missing_close_notes(self, settings, auth_provider):
         """Should require close_notes."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -519,7 +520,7 @@ class TestIncidentResolve:
         assert data["status"] == "error"
         assert "close_notes" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_blocked_in_prod(self):
         """Should block resolving in production."""
         prod_env = {
@@ -544,7 +545,7 @@ class TestIncidentResolve:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_invalid_number(self, settings, auth_provider):
         """Should reject non-INC numbers for resolve."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -558,7 +559,7 @@ class TestIncidentResolve:
         assert data["status"] == "error"
         assert "INC" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_resolve_not_found(self, settings, auth_provider):
         """Should handle incident not found during resolve."""
@@ -579,7 +580,7 @@ class TestIncidentResolve:
 class TestIncidentAddComment:
     """Tests for incident_add_comment tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_add_comment_valid(self, settings, auth_provider):
         """Should add comment to incident."""
@@ -611,7 +612,7 @@ class TestIncidentAddComment:
 
         assert data["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_add_work_note_valid(self, settings, auth_provider):
         """Should add work_note to incident."""
@@ -643,7 +644,7 @@ class TestIncidentAddComment:
 
         assert data["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_comment_both_empty(self, settings, auth_provider):
         """Should require at least one of comment or work_note."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -657,7 +658,7 @@ class TestIncidentAddComment:
         assert data["status"] == "error"
         assert "comment" in data["error"]["message"].lower() or "work_note" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_comment_blocked_in_prod(self):
         """Should block adding comments in production."""
         prod_env = {
@@ -681,7 +682,7 @@ class TestIncidentAddComment:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_comment_invalid_number(self, settings, auth_provider):
         """Should reject non-INC numbers for add_comment."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -694,7 +695,7 @@ class TestIncidentAddComment:
         assert data["status"] == "error"
         assert "INC" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_add_comment_not_found(self, settings, auth_provider):
         """Should handle incident not found when adding comment."""

--- a/tests/domains/test_knowledge.py
+++ b/tests/domains/test_knowledge.py
@@ -40,8 +40,16 @@ class TestKnowledgeSearch:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "kb1", "number": "KB0010001", "short_description": "How to reset password"},
-                        {"sys_id": "kb2", "number": "KB0010002", "short_description": "Password policy guide"},
+                        {
+                            "sys_id": "kb1",
+                            "number": "KB0010001",
+                            "short_description": "How to reset password",
+                        },
+                        {
+                            "sys_id": "kb2",
+                            "number": "KB0010002",
+                            "short_description": "Password policy guide",
+                        },
                     ]
                 },
             )
@@ -93,7 +101,15 @@ class TestKnowledgeGet:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001", "short_description": "Test article"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "kb123",
+                            "number": "KB0010001",
+                            "short_description": "Test article",
+                        }
+                    ]
+                },
             )
         )
 
@@ -115,7 +131,14 @@ class TestKnowledgeGet:
                 Response(200, json={"result": []}),  # First query by number fails
                 Response(
                     200,
-                    json={"result": [{"sys_id": "abc123def456abc123def456abc12345", "number": "KB0010001"}]},
+                    json={
+                        "result": [
+                            {
+                                "sys_id": "abc123def456abc123def456abc12345",
+                                "number": "KB0010001",
+                            }
+                        ]
+                    },
                 ),  # Second query by sys_id succeeds
             ]
         )
@@ -269,12 +292,21 @@ class TestKnowledgeUpdate:
     async def test_update_by_number(self, settings, auth_provider):
         """Should update knowledge article by KB number."""
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
-            return_value=Response(200, json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]})
+            return_value=Response(
+                200,
+                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+            )
         )
         respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/kb123").mock(
             return_value=Response(
                 200,
-                json={"result": {"sys_id": "kb123", "number": "KB0010001", "short_description": "Updated title"}},
+                json={
+                    "result": {
+                        "sys_id": "kb123",
+                        "number": "KB0010001",
+                        "short_description": "Updated title",
+                    }
+                },
             )
         )
 
@@ -292,7 +324,17 @@ class TestKnowledgeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             side_effect=[
                 Response(200, json={"result": []}),  # Query by number fails
-                Response(200, json={"result": [{"sys_id": "abc123def456abc123def456abc12345", "number": "KB0010001"}]}),
+                Response(
+                    200,
+                    json={
+                        "result": [
+                            {
+                                "sys_id": "abc123def456abc123def456abc12345",
+                                "number": "KB0010001",
+                            }
+                        ]
+                    },
+                ),
             ]
         )
         respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/abc123def456abc123def456abc12345").mock(
@@ -310,7 +352,8 @@ class TestKnowledgeUpdate:
 
         tools = _register_and_get_tools(settings, auth_provider)
         result = await tools["knowledge_update"](
-            number_or_sys_id="abc123def456abc123def456abc12345", text="Updated content"
+            number_or_sys_id="abc123def456abc123def456abc12345",
+            text="Updated content",
         )
         data = toon_decode(result)
 
@@ -340,7 +383,10 @@ class TestKnowledgeUpdate:
     async def test_update_no_changes_provided(self, settings, auth_provider):
         """Should return error when no update fields are provided."""
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
-            return_value=Response(200, json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]})
+            return_value=Response(
+                200,
+                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+            )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
@@ -376,7 +422,10 @@ class TestKnowledgeUpdate:
     async def test_update_with_workflow_state_kb_base_and_category(self, settings, auth_provider):
         """Should include workflow_state, kb_knowledge_base, and kb_category in update."""
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
-            return_value=Response(200, json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]})
+            return_value=Response(
+                200,
+                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+            )
         )
         respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/kb123").mock(
             return_value=Response(
@@ -424,12 +473,21 @@ class TestKnowledgeFeedback:
     async def test_feedback_with_rating(self, settings, auth_provider):
         """Should submit rating feedback to kb_feedback table."""
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
-            return_value=Response(200, json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]})
+            return_value=Response(
+                200,
+                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+            )
         )
         respx.post(f"{BASE_URL}/api/now/table/kb_feedback").mock(
             return_value=Response(
                 201,
-                json={"result": {"sys_id": "fb001", "article": "kb123", "rating": "5"}},
+                json={
+                    "result": {
+                        "sys_id": "fb001",
+                        "article": "kb123",
+                        "rating": "5",
+                    }
+                },
             )
         )
 
@@ -446,12 +504,21 @@ class TestKnowledgeFeedback:
     async def test_feedback_with_comment(self, settings, auth_provider):
         """Should submit comment feedback to kb_feedback table."""
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
-            return_value=Response(200, json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]})
+            return_value=Response(
+                200,
+                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+            )
         )
         respx.post(f"{BASE_URL}/api/now/table/kb_feedback").mock(
             return_value=Response(
                 201,
-                json={"result": {"sys_id": "fb002", "article": "kb123", "comments": "Very helpful"}},
+                json={
+                    "result": {
+                        "sys_id": "fb002",
+                        "article": "kb123",
+                        "comments": "Very helpful",
+                    }
+                },
             )
         )
 
@@ -468,7 +535,10 @@ class TestKnowledgeFeedback:
     async def test_feedback_both_rating_and_comment(self, settings, auth_provider):
         """Should submit both rating and comment to kb_feedback."""
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
-            return_value=Response(200, json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]})
+            return_value=Response(
+                200,
+                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+            )
         )
         respx.post(f"{BASE_URL}/api/now/table/kb_feedback").mock(
             return_value=Response(
@@ -555,7 +625,14 @@ class TestKnowledgeFeedback:
                 Response(200, json={"result": []}),  # Query by number fails
                 Response(
                     200,
-                    json={"result": [{"sys_id": "abc123def456abc123def456abc12345", "number": "KB0010001"}]},
+                    json={
+                        "result": [
+                            {
+                                "sys_id": "abc123def456abc123def456abc12345",
+                                "number": "KB0010001",
+                            }
+                        ]
+                    },
                 ),  # Query by sys_id succeeds
             ]
         )

--- a/tests/domains/test_knowledge.py
+++ b/tests/domains/test_knowledge.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 
 
@@ -31,7 +32,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestKnowledgeSearch:
     """Tests for knowledge_search tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_search_default_published(self, settings, auth_provider):
         """Should search published articles by default."""
@@ -66,7 +67,7 @@ class TestKnowledgeSearch:
         assert "textLIKEpassword" in str(request.url)
         assert "workflow_state%3Dpublished" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_search_custom_workflow_state(self, settings, auth_provider):
         """Should filter by custom workflow_state."""
@@ -78,7 +79,7 @@ class TestKnowledgeSearch:
         request = respx.calls.last.request
         assert "workflow_state%3Ddraft" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_search_custom_limit(self, settings, auth_provider):
         """Should respect custom limit parameter."""
@@ -94,7 +95,7 @@ class TestKnowledgeSearch:
 class TestKnowledgeGet:
     """Tests for knowledge_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_by_kb_number(self, settings, auth_provider):
         """Should fetch knowledge article by KB number."""
@@ -122,7 +123,7 @@ class TestKnowledgeGet:
         request = respx.calls.last.request
         assert "number%3DKB0010001" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_by_sys_id(self, settings, auth_provider):
         """Should fetch knowledge article by sys_id if 32-char hex."""
@@ -150,7 +151,7 @@ class TestKnowledgeGet:
         assert data["status"] == "success"
         assert data["data"]["number"] == "KB0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings, auth_provider):
         """Should return error when knowledge article not found."""
@@ -172,7 +173,7 @@ class TestKnowledgeGet:
 class TestKnowledgeCreate:
     """Tests for knowledge_create tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_minimal(self, settings, auth_provider):
         """Should create knowledge article with minimal required fields."""
@@ -199,7 +200,7 @@ class TestKnowledgeCreate:
         assert data["data"]["number"] == "KB0010003"
         assert data["data"]["workflow_state"] == "draft"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_missing_short_description(self, settings, auth_provider):
         """Should return error if short_description is empty."""
@@ -210,7 +211,7 @@ class TestKnowledgeCreate:
         assert data["status"] == "error"
         assert "short_description" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_missing_text(self, settings, auth_provider):
         """Should return error if text is empty."""
@@ -221,7 +222,7 @@ class TestKnowledgeCreate:
         assert data["status"] == "error"
         assert "text" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_with_kb_knowledge_base_and_category(self, settings, auth_provider):
         """Should include kb_knowledge_base and kb_category in create data when provided."""
@@ -262,7 +263,7 @@ class TestKnowledgeCreate:
         assert request_body["kb_knowledge_base"] == "base123"
         assert request_body["kb_category"] == "cat456"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_production_blocked(self):
         """Should block write in production environment."""
         prod_env = {
@@ -287,7 +288,7 @@ class TestKnowledgeCreate:
 class TestKnowledgeUpdate:
     """Tests for knowledge_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_by_number(self, settings, auth_provider):
         """Should update knowledge article by KB number."""
@@ -317,7 +318,7 @@ class TestKnowledgeUpdate:
         assert data["status"] == "success"
         assert data["data"]["short_description"] == "Updated title"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_by_sys_id(self, settings, auth_provider):
         """Should update knowledge article by sys_id."""
@@ -360,7 +361,7 @@ class TestKnowledgeUpdate:
         assert data["status"] == "success"
         assert data["data"]["text"] == "Updated content"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_not_found(self, settings, auth_provider):
         """Should return error if article not found."""
@@ -378,7 +379,7 @@ class TestKnowledgeUpdate:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_no_changes_provided(self, settings, auth_provider):
         """Should return error when no update fields are provided."""
@@ -396,7 +397,7 @@ class TestKnowledgeUpdate:
         assert data["status"] == "error"
         assert "no fields" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_production_blocked(self):
         """Should block write in production environment."""
         prod_env = {
@@ -417,7 +418,7 @@ class TestKnowledgeUpdate:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_with_workflow_state_kb_base_and_category(self, settings, auth_provider):
         """Should include workflow_state, kb_knowledge_base, and kb_category in update."""
@@ -468,7 +469,7 @@ class TestKnowledgeUpdate:
 class TestKnowledgeFeedback:
     """Tests for knowledge_feedback tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_with_rating(self, settings, auth_provider):
         """Should submit rating feedback to kb_feedback table."""
@@ -499,7 +500,7 @@ class TestKnowledgeFeedback:
         assert data["data"]["article"] == "kb123"
         assert data["data"]["rating"] == "5"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_with_comment(self, settings, auth_provider):
         """Should submit comment feedback to kb_feedback table."""
@@ -530,7 +531,7 @@ class TestKnowledgeFeedback:
         assert data["data"]["article"] == "kb123"
         assert data["data"]["comments"] == "Very helpful"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_both_rating_and_comment(self, settings, auth_provider):
         """Should submit both rating and comment to kb_feedback."""
@@ -562,7 +563,7 @@ class TestKnowledgeFeedback:
         assert data["data"]["rating"] == "4"
         assert data["data"]["comments"] == "Good article"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_missing_both(self, settings, auth_provider):
         """Should return error if neither rating nor comment provided."""
@@ -573,7 +574,7 @@ class TestKnowledgeFeedback:
         assert data["status"] == "error"
         assert "rating or comment" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_invalid_rating_low(self, settings, auth_provider):
         """Should return error if rating below 1."""
@@ -584,7 +585,7 @@ class TestKnowledgeFeedback:
         assert data["status"] == "error"
         assert "between 1 and 5" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_invalid_rating_high(self, settings, auth_provider):
         """Should return error if rating above 5."""
@@ -595,7 +596,7 @@ class TestKnowledgeFeedback:
         assert data["status"] == "error"
         assert "between 1 and 5" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_feedback_production_blocked(self):
         """Should block write in production environment."""
         prod_env = {
@@ -616,7 +617,7 @@ class TestKnowledgeFeedback:
             assert data["status"] == "error"
             assert "production" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_lookup_by_sys_id(self, settings, auth_provider):
         """Should fall back to sys_id lookup when number lookup returns nothing."""
@@ -656,7 +657,7 @@ class TestKnowledgeFeedback:
         assert data["status"] == "success"
         assert data["data"]["article"] == "abc123def456abc123def456abc12345"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_feedback_article_not_found(self, settings, auth_provider):
         """Should return error when article not found for feedback."""

--- a/tests/domains/test_problem.py
+++ b/tests/domains/test_problem.py
@@ -40,8 +40,16 @@ class TestProblemList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "id1", "number": "PRB0010001", "short_description": "Test 1"},
-                        {"sys_id": "id2", "number": "PRB0010002", "short_description": "Test 2"},
+                        {
+                            "sys_id": "id1",
+                            "number": "PRB0010001",
+                            "short_description": "Test 1",
+                        },
+                        {
+                            "sys_id": "id2",
+                            "number": "PRB0010002",
+                            "short_description": "Test 2",
+                        },
                     ]
                 },
             )
@@ -128,7 +136,15 @@ class TestProblemGet:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001", "short_description": "Test problem"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "PRB0010001",
+                            "short_description": "Test problem",
+                        }
+                    ]
+                },
             )
         )
 
@@ -170,7 +186,15 @@ class TestProblemGet:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001", "short_description": "Test"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "PRB0010001",
+                            "short_description": "Test",
+                        }
+                    ]
+                },
             )
         )
 
@@ -346,7 +370,15 @@ class TestProblemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001", "short_description": "Old"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "abc123",
+                            "number": "PRB0010001",
+                            "short_description": "Old",
+                        }
+                    ]
+                },
             )
         )
         respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(

--- a/tests/domains/test_problem.py
+++ b/tests/domains/test_problem.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 
 
@@ -31,7 +32,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestProblemList:
     """Tests for problem_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_no_filters(self, settings, auth_provider):
         """Should query all problems when no filters provided."""
@@ -63,7 +64,7 @@ class TestProblemList:
         assert len(data["data"]) == 2
         assert data["data"][0]["number"] == "PRB0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_state_filter(self, settings, auth_provider):
         """Should map state names to numeric values using PROBLEM_STATE_MAP."""
@@ -76,7 +77,7 @@ class TestProblemList:
         # "new" maps to "1" via ChoiceRegistry defaults
         assert "state%3D1" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_multiple_filters(self, settings, auth_provider):
         """Should combine multiple filters correctly."""
@@ -97,7 +98,7 @@ class TestProblemList:
         assert "assigned_to%3Duser123" in url_str
         assert "assignment_group%3Dgroup456" in url_str
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_priority_filter(self, settings, auth_provider):
         """Should filter by priority only."""
@@ -112,7 +113,7 @@ class TestProblemList:
         # No state filter should be present
         assert "state%3D" not in url_str
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_all_state(self, settings, auth_provider):
         """Should NOT add state filter when state='all'."""
@@ -129,7 +130,7 @@ class TestProblemList:
 class TestProblemGet:
     """Tests for problem_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_valid_number(self, settings, auth_provider):
         """Should fetch problem by PRB number."""
@@ -156,7 +157,7 @@ class TestProblemGet:
         assert data["data"]["number"] == "PRB0010001"
         assert data["data"]["sys_id"] == "abc123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings, auth_provider):
         """Should reject non-PRB numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -166,7 +167,7 @@ class TestProblemGet:
         assert data["status"] == "error"
         assert "PRB" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings, auth_provider):
         """Should handle problem not found."""
@@ -179,7 +180,7 @@ class TestProblemGet:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_case_insensitive(self, settings, auth_provider):
         """Should uppercase the problem number before querying."""
@@ -211,7 +212,7 @@ class TestProblemGet:
 class TestProblemCreate:
     """Tests for problem_create tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_valid(self, settings, auth_provider):
         """Should create problem with required fields."""
@@ -240,7 +241,7 @@ class TestProblemCreate:
         assert data["status"] == "success"
         assert data["data"]["number"] == "PRB0010002"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_with_optional_fields(self, settings, auth_provider):
         """Should include optional fields when provided."""
@@ -278,7 +279,7 @@ class TestProblemCreate:
         assert data["data"]["description"] == "Detailed info"
         assert data["data"]["assigned_to"] == "user123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_missing_short_description(self, settings, auth_provider):
         """Should reject empty short_description."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -288,7 +289,7 @@ class TestProblemCreate:
         assert data["status"] == "error"
         assert "short_description" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_whitespace_short_description(self, settings, auth_provider):
         """Should reject whitespace-only short_description."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -298,7 +299,7 @@ class TestProblemCreate:
         assert data["status"] == "error"
         assert "short_description" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_urgency_too_high(self, settings, auth_provider):
         """Should reject urgency=5 (max is 4)."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -308,7 +309,7 @@ class TestProblemCreate:
         assert data["status"] == "error"
         assert "urgency" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_urgency_too_low(self, settings, auth_provider):
         """Should reject urgency=0 (min is 1)."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -318,7 +319,7 @@ class TestProblemCreate:
         assert data["status"] == "error"
         assert "urgency" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_impact_too_high(self, settings, auth_provider):
         """Should reject impact=5 (max is 4)."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -328,7 +329,7 @@ class TestProblemCreate:
         assert data["status"] == "error"
         assert "impact" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_invalid_impact_too_low(self, settings, auth_provider):
         """Should reject impact=0 (min is 1)."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -338,7 +339,7 @@ class TestProblemCreate:
         assert data["status"] == "error"
         assert "impact" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_create_blocked_in_prod(self):
         """Should block creation in production."""
         prod_env = {
@@ -363,7 +364,7 @@ class TestProblemCreate:
 class TestProblemUpdate:
     """Tests for problem_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_valid(self, settings, auth_provider):
         """Should update problem by PRB number."""
@@ -404,7 +405,7 @@ class TestProblemUpdate:
         assert data["status"] == "success"
         assert data["data"]["short_description"] == "Updated"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_invalid_number(self, settings, auth_provider):
         """Should reject non-PRB numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -414,7 +415,7 @@ class TestProblemUpdate:
         assert data["status"] == "error"
         assert "PRB" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_not_found(self, settings, auth_provider):
         """Should handle problem not found."""
@@ -427,7 +428,7 @@ class TestProblemUpdate:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_no_changes(self, settings, auth_provider):
         """Should error when no fields to update are provided."""
@@ -445,7 +446,7 @@ class TestProblemUpdate:
         assert data["status"] == "error"
         assert "no fields" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_with_state(self, settings, auth_provider):
         """Should map state name to numeric value using PROBLEM_STATE_MAP."""
@@ -479,7 +480,7 @@ class TestProblemUpdate:
         # "known_error" maps to "3" via ChoiceRegistry defaults
         assert data["data"]["state"] == "3"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_with_all_fields(self, settings, auth_provider):
         """Should update all supported fields."""
@@ -532,7 +533,7 @@ class TestProblemUpdate:
         assert data["data"]["urgency"] == "2"
         assert data["data"]["state"] == "5"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_blocked_in_prod(self):
         """Should block updates in production."""
         prod_env = {
@@ -560,7 +561,7 @@ class TestProblemUpdate:
 class TestProblemRootCause:
     """Tests for problem_root_cause tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_root_cause_valid(self, settings, auth_provider):
         """Should document root cause with cause_notes."""
@@ -593,7 +594,7 @@ class TestProblemRootCause:
         assert data["status"] == "success"
         assert data["data"]["cause_notes"] == "Root cause identified"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_root_cause_with_fix_notes(self, settings, auth_provider):
         """Should include fix_notes when provided."""
@@ -629,7 +630,7 @@ class TestProblemRootCause:
         assert data["data"]["cause_notes"] == "Memory leak in module X"
         assert data["data"]["fix_notes"] == "Patch applied to module X"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_root_cause_invalid_number(self, settings, auth_provider):
         """Should reject non-PRB numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -642,7 +643,7 @@ class TestProblemRootCause:
         assert data["status"] == "error"
         assert "PRB" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_root_cause_not_found(self, settings, auth_provider):
         """Should handle problem not found."""
@@ -658,7 +659,7 @@ class TestProblemRootCause:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_root_cause_empty_cause_notes(self, settings, auth_provider):
         """Should reject empty cause_notes."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -671,7 +672,7 @@ class TestProblemRootCause:
         assert data["status"] == "error"
         assert "cause_notes" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_root_cause_whitespace_cause_notes(self, settings, auth_provider):
         """Should reject whitespace-only cause_notes."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -684,7 +685,7 @@ class TestProblemRootCause:
         assert data["status"] == "error"
         assert "cause_notes" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_root_cause_blocked_in_prod(self):
         """Should block root cause updates in production."""
         prod_env = {

--- a/tests/domains/test_request.py
+++ b/tests/domains/test_request.py
@@ -40,8 +40,16 @@ class TestRequestList:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "id1", "number": "REQ0010001", "short_description": "Request 1"},
-                        {"sys_id": "id2", "number": "REQ0010002", "short_description": "Request 2"},
+                        {
+                            "sys_id": "id1",
+                            "number": "REQ0010001",
+                            "short_description": "Request 1",
+                        },
+                        {
+                            "sys_id": "id2",
+                            "number": "REQ0010002",
+                            "short_description": "Request 2",
+                        },
                     ]
                 },
             )
@@ -107,7 +115,11 @@ class TestRequestGet:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "abc123", "number": "REQ0010001", "short_description": "Test request"},
+                        {
+                            "sys_id": "abc123",
+                            "number": "REQ0010001",
+                            "short_description": "Test request",
+                        },
                     ]
                 },
             )
@@ -153,7 +165,11 @@ class TestRequestGet:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "abc123", "number": "REQ0010001", "short_description": "Test request"},
+                        {
+                            "sys_id": "abc123",
+                            "number": "REQ0010001",
+                            "short_description": "Test request",
+                        },
                     ]
                 },
             )
@@ -182,8 +198,16 @@ class TestRequestItems:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "item1", "number": "RITM0010001", "short_description": "Item 1"},
-                        {"sys_id": "item2", "number": "RITM0010002", "short_description": "Item 2"},
+                        {
+                            "sys_id": "item1",
+                            "number": "RITM0010001",
+                            "short_description": "Item 1",
+                        },
+                        {
+                            "sys_id": "item2",
+                            "number": "RITM0010002",
+                            "short_description": "Item 2",
+                        },
                     ]
                 },
             )
@@ -236,7 +260,11 @@ class TestRequestItemGet:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "item123", "number": "RITM0010001", "short_description": "Test item"},
+                        {
+                            "sys_id": "item123",
+                            "number": "RITM0010001",
+                            "short_description": "Test item",
+                        },
                     ]
                 },
             )

--- a/tests/domains/test_request.py
+++ b/tests/domains/test_request.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 
 
@@ -31,7 +32,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestRequestList:
     """Tests for request_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_no_filters(self, settings, auth_provider):
         """Should query all requests when no filters provided."""
@@ -63,7 +64,7 @@ class TestRequestList:
         assert len(data["data"]) == 2
         assert data["data"][0]["number"] == "REQ0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_state_filter(self, settings, auth_provider):
         """Should apply state filter to query."""
@@ -75,7 +76,7 @@ class TestRequestList:
         request = respx.calls.last.request
         assert "state%3D1" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_requested_for(self, settings, auth_provider):
         """Should apply requested_for filter to query."""
@@ -87,7 +88,7 @@ class TestRequestList:
         request = respx.calls.last.request
         assert "requested_for%3Duser123" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_multiple_filters(self, settings, auth_provider):
         """Should combine multiple filters correctly."""
@@ -106,7 +107,7 @@ class TestRequestList:
 class TestRequestGet:
     """Tests for request_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_valid_number(self, settings, auth_provider):
         """Should fetch request by REQ number."""
@@ -133,7 +134,7 @@ class TestRequestGet:
         assert data["data"]["number"] == "REQ0010001"
         assert data["data"]["sys_id"] == "abc123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings, auth_provider):
         """Should reject non-REQ numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -143,7 +144,7 @@ class TestRequestGet:
         assert data["status"] == "error"
         assert "REQ" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings, auth_provider):
         """Should handle request not found."""
@@ -156,7 +157,7 @@ class TestRequestGet:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_case_insensitive(self, settings, auth_provider):
         """Should uppercase the number before querying."""
@@ -189,7 +190,7 @@ class TestRequestGet:
 class TestRequestItems:
     """Tests for request_items tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_items_valid(self, settings, auth_provider):
         """Should fetch request items by REQ number using dot-walk query."""
@@ -224,7 +225,7 @@ class TestRequestItems:
         request = respx.calls.last.request
         assert "request.number%3DREQ0010001" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_items_invalid_prefix(self, settings, auth_provider):
         """Should reject non-REQ numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -234,7 +235,7 @@ class TestRequestItems:
         assert data["status"] == "error"
         assert "REQ" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_items_empty_result(self, settings, auth_provider):
         """Should succeed with empty list when no items found."""
@@ -251,7 +252,7 @@ class TestRequestItems:
 class TestRequestItemGet:
     """Tests for request_item_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_valid_ritm(self, settings, auth_provider):
         """Should fetch request item by RITM number."""
@@ -278,7 +279,7 @@ class TestRequestItemGet:
         assert data["data"]["number"] == "RITM0010001"
         assert data["data"]["sys_id"] == "item123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings, auth_provider):
         """Should reject non-RITM numbers."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -288,7 +289,7 @@ class TestRequestItemGet:
         assert data["status"] == "error"
         assert "RITM" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_not_found(self, settings, auth_provider):
         """Should handle request item not found."""
@@ -305,7 +306,7 @@ class TestRequestItemGet:
 class TestRequestItemUpdate:
     """Tests for request_item_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_update_valid(self, mock_write_gate, settings, auth_provider):
@@ -336,7 +337,7 @@ class TestRequestItemUpdate:
         assert data["status"] == "success"
         assert data["data"]["state"] == "3"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_update_with_assignment(self, mock_write_gate, settings, auth_provider):
@@ -373,7 +374,7 @@ class TestRequestItemUpdate:
         assert data["data"]["assignment_group"] == "group456"
         assert data["data"]["assigned_to"] == "user789"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_update_invalid_number(self, mock_write_gate, settings, auth_provider):
         """Should reject non-RITM numbers."""
@@ -384,7 +385,7 @@ class TestRequestItemUpdate:
         assert data["status"] == "error"
         assert "RITM" in data["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_update_not_found(self, mock_write_gate, settings, auth_provider):
@@ -398,7 +399,7 @@ class TestRequestItemUpdate:
         assert data["status"] == "error"
         assert "not found" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_update_no_changes(self, mock_write_gate, settings, auth_provider):
@@ -417,7 +418,7 @@ class TestRequestItemUpdate:
         assert data["status"] == "error"
         assert "no fields" in data["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_blocked_in_prod(self):
         """Should block updates in production."""
         prod_env = {

--- a/tests/domains/test_service_catalog.py
+++ b/tests/domains/test_service_catalog.py
@@ -260,7 +260,13 @@ class TestScItemGet:
         respx.get(f"{SC_BASE}/items/item123").mock(
             return_value=Response(
                 200,
-                json={"result": {"sys_id": "item123", "name": "Laptop", "price": "$1200"}},
+                json={
+                    "result": {
+                        "sys_id": "item123",
+                        "name": "Laptop",
+                        "price": "$1200",
+                    }
+                },
             )
         )
 
@@ -288,8 +294,16 @@ class TestScItemVariables:
                 200,
                 json={
                     "result": [
-                        {"name": "urgency", "type": "choice", "mandatory": True},
-                        {"name": "description", "type": "text", "mandatory": False},
+                        {
+                            "name": "urgency",
+                            "type": "choice",
+                            "mandatory": True,
+                        },
+                        {
+                            "name": "description",
+                            "type": "text",
+                            "mandatory": False,
+                        },
                     ]
                 },
             )
@@ -488,7 +502,12 @@ class TestScCartSubmit:
         respx.post(f"{SC_BASE}/cart/submit_order").mock(
             return_value=Response(
                 200,
-                json={"result": {"request_number": "REQ0010001", "request_id": "req123"}},
+                json={
+                    "result": {
+                        "request_number": "REQ0010001",
+                        "request_id": "req123",
+                    }
+                },
             )
         )
 
@@ -535,7 +554,12 @@ class TestScCartCheckout:
         respx.post(f"{SC_BASE}/cart/checkout").mock(
             return_value=Response(
                 200,
-                json={"result": {"request_number": "REQ0010002", "request_id": "req456"}},
+                json={
+                    "result": {
+                        "request_number": "REQ0010002",
+                        "request_id": "req456",
+                    }
+                },
             )
         )
 

--- a/tests/domains/test_service_catalog.py
+++ b/tests/domains/test_service_catalog.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 SC_BASE = f"{BASE_URL}/api/sn_sc/servicecatalog"
 
@@ -35,7 +36,7 @@ def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider
 class TestScCatalogsList:
     """Tests for sc_catalogs_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_defaults(self, settings, auth_provider):
         """Should list catalogs with default parameters."""
@@ -59,7 +60,7 @@ class TestScCatalogsList:
         assert len(data["data"]) == 2
         assert data["data"][0]["title"] == "Service Catalog"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_text_filter(self, settings, auth_provider):
         """Should pass text search parameter."""
@@ -71,7 +72,7 @@ class TestScCatalogsList:
         request = respx.calls.last.request
         assert "sysparm_text=hardware" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_with_limit(self, settings, auth_provider):
         """Should pass limit parameter."""
@@ -90,7 +91,7 @@ class TestScCatalogsList:
 class TestScCatalogGet:
     """Tests for sc_catalog_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_catalog(self, settings, auth_provider):
         """Should fetch a specific catalog by sys_id."""
@@ -116,7 +117,7 @@ class TestScCatalogGet:
 class TestScCategoriesList:
     """Tests for sc_categories_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_categories(self, settings, auth_provider):
         """Should list categories for a catalog."""
@@ -140,7 +141,7 @@ class TestScCategoriesList:
         assert len(data["data"]) == 2
         assert data["data"][0]["title"] == "Hardware"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_categories_with_pagination(self, settings, auth_provider):
         """Should pass limit and offset parameters."""
@@ -154,7 +155,7 @@ class TestScCategoriesList:
         assert "sysparm_limit=10" in url
         assert "sysparm_offset=5" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_categories_top_level_only(self, settings, auth_provider):
         """Should pass top_level_only parameter."""
@@ -173,7 +174,7 @@ class TestScCategoriesList:
 class TestScCategoryGet:
     """Tests for sc_category_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_category(self, settings, auth_provider):
         """Should fetch a specific category by sys_id."""
@@ -199,7 +200,7 @@ class TestScCategoryGet:
 class TestScItemsList:
     """Tests for sc_items_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_items_defaults(self, settings, auth_provider):
         """Should list catalog items with default parameters."""
@@ -223,7 +224,7 @@ class TestScItemsList:
         assert len(data["data"]) == 2
         assert data["data"][0]["name"] == "Laptop"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_items_with_filters(self, settings, auth_provider):
         """Should pass text, catalog, and category filters."""
@@ -253,7 +254,7 @@ class TestScItemsList:
 class TestScItemGet:
     """Tests for sc_item_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_item(self, settings, auth_provider):
         """Should fetch a specific catalog item by sys_id."""
@@ -285,7 +286,7 @@ class TestScItemGet:
 class TestScItemVariables:
     """Tests for sc_item_variables tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_variables(self, settings, auth_provider):
         """Should fetch variables for a catalog item."""
@@ -324,7 +325,7 @@ class TestScItemVariables:
 class TestScOrderNow:
     """Tests for sc_order_now tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_order_now_no_variables(self, mock_write_gate, settings, auth_provider):
@@ -343,7 +344,7 @@ class TestScOrderNow:
         assert data["status"] == "success"
         assert data["data"]["number"] == "REQ0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_order_now_with_variables(self, mock_write_gate, settings, auth_provider):
@@ -365,7 +366,7 @@ class TestScOrderNow:
         assert data["status"] == "success"
         assert data["data"]["number"] == "REQ0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_order_now_blocked_in_prod(self):
         """Should block ordering in production."""
         prod_env = {
@@ -393,7 +394,7 @@ class TestScOrderNow:
 class TestScAddToCart:
     """Tests for sc_add_to_cart tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_add_to_cart_no_variables(self, mock_write_gate, settings, auth_provider):
@@ -412,7 +413,7 @@ class TestScAddToCart:
         assert data["status"] == "success"
         assert data["data"]["cart_item_id"] == "ci123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_add_to_cart_with_variables(self, mock_write_gate, settings, auth_provider):
@@ -434,7 +435,7 @@ class TestScAddToCart:
         assert data["status"] == "success"
         assert data["data"]["cart_item_id"] == "ci123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_to_cart_blocked_in_prod(self):
         """Should block add-to-cart in production."""
         prod_env = {
@@ -462,7 +463,7 @@ class TestScAddToCart:
 class TestScCartGet:
     """Tests for sc_cart_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_cart(self, settings, auth_provider):
         """Should retrieve the current user's cart."""
@@ -494,7 +495,7 @@ class TestScCartGet:
 class TestScCartSubmit:
     """Tests for sc_cart_submit tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_submit_cart(self, mock_write_gate, settings, auth_provider):
@@ -518,7 +519,7 @@ class TestScCartSubmit:
         assert data["status"] == "success"
         assert data["data"]["request_number"] == "REQ0010001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_submit_cart_blocked_in_prod(self):
         """Should block cart submission in production."""
         prod_env = {
@@ -546,7 +547,7 @@ class TestScCartSubmit:
 class TestScCartCheckout:
     """Tests for sc_cart_checkout tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
     async def test_checkout_cart(self, mock_write_gate, settings, auth_provider):
@@ -570,7 +571,7 @@ class TestScCartCheckout:
         assert data["status"] == "success"
         assert data["data"]["request_number"] == "REQ0010002"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_checkout_blocked_in_prod(self):
         """Should block checkout in production."""
         prod_env = {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 # Apply the integration marker to every test in this directory
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_changes.py
+++ b/tests/integration/test_changes.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_connectivity.py
+++ b/tests/integration/test_connectivity.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -50,7 +50,13 @@ class TestDebug:
             ecc_result = await client.query_records(
                 "ecc_queue",
                 "state=error",
-                fields=["sys_id", "name", "queue", "error_string", "sys_created_on"],
+                fields=[
+                    "sys_id",
+                    "name",
+                    "queue",
+                    "error_string",
+                    "sys_created_on",
+                ],
                 limit=20,
             )
 

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_domain_change.py
+++ b/tests/integration/test_domain_change.py
@@ -37,7 +37,13 @@ class TestDomainChange:
             record = await client.get_record(
                 "change_request",
                 change_request_sys_id,
-                fields=["sys_id", "number", "short_description", "state", "type"],
+                fields=[
+                    "sys_id",
+                    "number",
+                    "short_description",
+                    "state",
+                    "type",
+                ],
             )
         assert record["sys_id"] == change_request_sys_id
 

--- a/tests/integration/test_domain_change.py
+++ b/tests/integration/test_domain_change.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_domain_cmdb.py
+++ b/tests/integration/test_domain_cmdb.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_domain_incident.py
+++ b/tests/integration/test_domain_incident.py
@@ -49,7 +49,13 @@ class TestDomainIncident:
             record = await client.get_record(
                 "incident",
                 incident_sys_id,
-                fields=["sys_id", "number", "short_description", "state", "priority"],
+                fields=[
+                    "sys_id",
+                    "number",
+                    "short_description",
+                    "state",
+                    "priority",
+                ],
             )
         assert record["sys_id"] == incident_sys_id
         assert "number" in record

--- a/tests/integration/test_domain_incident.py
+++ b/tests/integration/test_domain_incident.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_domain_knowledge.py
+++ b/tests/integration/test_domain_knowledge.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_domain_problem.py
+++ b/tests/integration/test_domain_problem.py
@@ -37,7 +37,13 @@ class TestDomainProblem:
             record = await client.get_record(
                 "problem",
                 problem_sys_id,
-                fields=["sys_id", "number", "short_description", "state", "priority"],
+                fields=[
+                    "sys_id",
+                    "number",
+                    "short_description",
+                    "state",
+                    "priority",
+                ],
             )
         assert record["sys_id"] == problem_sys_id
 

--- a/tests/integration/test_domain_problem.py
+++ b/tests/integration/test_domain_problem.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_domain_request.py
+++ b/tests/integration/test_domain_request.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_introspection.py
+++ b/tests/integration/test_introspection.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_metadata.py
+++ b/tests/integration/test_metadata.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -33,7 +33,7 @@ class TestPackageLoading:
     """Test that each package preset creates an MCP server with the correct tool count."""
 
     @pytest.mark.parametrize(
-        "package_name,expected_count",
+        ("package_name", "expected_count"),
         list(EXPECTED_TOOL_COUNTS.items()),
         ids=list(EXPECTED_TOOL_COUNTS.keys()),
     )
@@ -84,7 +84,11 @@ class TestPackageLoading:
             "domain_incident,domain_change",
             "metadata,documentation,utility",
         ],
-        ids=["introspection+relationships", "incident+change", "metadata+docs+utility"],
+        ids=[
+            "introspection+relationships",
+            "incident+change",
+            "metadata+docs+utility",
+        ],
     )
     def test_comma_separated_groups_load(self, groups_csv: str) -> None:
         """Verify comma-separated group syntax creates a working server."""

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -8,6 +8,7 @@ import pytest
 from servicenow_mcp.packages import PACKAGE_REGISTRY
 from servicenow_mcp.server import create_mcp_server
 
+
 pytestmark = pytest.mark.integration
 
 # Expected tool counts per package (verified in Wave FINAL F3).

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -5,6 +5,7 @@ import pytest
 from servicenow_mcp.errors import PolicyError
 from servicenow_mcp.policy import check_table_access
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -6,6 +6,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 
+
 pytestmark = pytest.mark.integration
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,7 +21,7 @@ class TestBasicAuthProvider:
         with patch.dict("os.environ", env, clear=True):
             return Settings(_env_file=None)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_headers_returns_authorization(self):
         """get_headers includes an Authorization header."""
         from servicenow_mcp.auth import BasicAuthProvider
@@ -32,7 +32,7 @@ class TestBasicAuthProvider:
 
         assert "Authorization" in headers
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_headers_basic_prefix(self):
         """Authorization header starts with 'Basic '."""
         from servicenow_mcp.auth import BasicAuthProvider
@@ -43,7 +43,7 @@ class TestBasicAuthProvider:
 
         assert headers["Authorization"].startswith("Basic ")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_headers_correct_encoding(self):
         """Authorization header contains correctly base64-encoded credentials."""
         from servicenow_mcp.auth import BasicAuthProvider
@@ -55,7 +55,7 @@ class TestBasicAuthProvider:
         expected = base64.b64encode(b"admin:s3cret").decode("ascii")
         assert headers["Authorization"] == f"Basic {expected}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_headers_with_different_credentials(self):
         """Encoding works for different username/password combinations."""
         from servicenow_mcp.auth import BasicAuthProvider
@@ -70,7 +70,7 @@ class TestBasicAuthProvider:
         expected = base64.b64encode(b"user@company.com:p@ss:w0rd!").decode("ascii")
         assert headers["Authorization"] == f"Basic {expected}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_headers_includes_content_type(self):
         """Headers include JSON content type."""
         from servicenow_mcp.auth import BasicAuthProvider

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -9,10 +9,11 @@ from toon_format import decode as toon_decode
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -32,7 +33,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestChangesUpdatesetInspect:
     """Tests for the changes_updateset_inspect tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_grouped_summary(self, settings, auth_provider):
         """Returns update set members grouped by table/type."""
@@ -98,7 +99,7 @@ class TestChangesUpdatesetInspect:
         assert "groups" in data
         assert len(data["groups"]) == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_flags_risk_indicators(self, settings, auth_provider):
         """Flags risk when dangerous artifact types are present (ACLs, scripts)."""
@@ -139,7 +140,7 @@ class TestChangesUpdatesetInspect:
         assert result["status"] == "success"
         assert len(result["data"]["risk_flags"]) > 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_update_set(self, settings, auth_provider):
         """Handles update set with no members."""
@@ -170,7 +171,7 @@ class TestChangesUpdatesetInspect:
         assert result["status"] == "success"
         assert result["data"]["total_members"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_rejects_invalid_update_set_id(self, settings, auth_provider):
         """Returns error when update_set_id contains invalid characters."""
@@ -185,7 +186,7 @@ class TestChangesUpdatesetInspect:
 class TestChangesDiffArtifact:
     """Tests for the changes_diff_artifact tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_diff_between_versions(self, settings, auth_provider):
         """Returns a text diff between the two most recent versions."""
@@ -229,7 +230,7 @@ class TestChangesDiffArtifact:
         qs = parse_qs(parsed.query)
         assert "sysparm_orderby" not in qs
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_error_when_no_versions(self, settings, auth_provider):
         """Returns error when fewer than 2 versions exist."""
@@ -247,7 +248,7 @@ class TestChangesDiffArtifact:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_diff_version_ordering(self, settings, auth_provider):
         """Verifies that versions[1] (older) is treated as the base 'Old' in the diff output."""
@@ -291,7 +292,7 @@ class TestChangesDiffArtifact:
         assert "// old version" in diff_text
         assert "// new version" in diff_text
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_diff_artifact_uses_builder_order_by(self, settings, auth_provider):
         """Verifies the query uses ServiceNowQuery builder with inline ORDERBYDESC."""
@@ -337,7 +338,7 @@ class TestChangesDiffArtifact:
         qs = parse_qs(parsed.query)
         assert "sysparm_orderby" not in qs
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_caret_in_sys_id_single_sanitized(self, settings, auth_provider):
         """sys_id with carets produces single-sanitized update_name (^ → ^^), not double (^ → ^^^^)."""
@@ -384,7 +385,7 @@ class TestChangesDiffArtifact:
 class TestChangesLastTouched:
     """Tests for the changes_last_touched tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_audit_history(self, settings, auth_provider):
         """Returns who/when/what from sys_audit."""
@@ -425,7 +426,7 @@ class TestChangesLastTouched:
         assert len(result["data"]["changes"]) == 2
         assert result["data"]["changes"][0]["user"] == "admin"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_empty_for_no_audit(self, settings, auth_provider):
         """Returns success with empty changes when no audit trail exists."""
@@ -448,7 +449,7 @@ class TestChangesLastTouched:
 class TestChangesReleaseNotes:
     """Tests for the changes_release_notes tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_generates_markdown_release_notes(self, settings, auth_provider):
         """Generates Markdown release notes from update set."""
@@ -501,7 +502,7 @@ class TestChangesReleaseNotes:
         assert "Sprint 42 Release" in notes
         assert "IncidentUtils" in notes
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_empty_update_set(self, settings, auth_provider):
         """Generates notes even for empty update set."""
@@ -532,7 +533,7 @@ class TestChangesReleaseNotes:
         assert result["status"] == "success"
         assert "Empty Release" in result["data"]["release_notes"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_rejects_invalid_update_set_id(self, settings, auth_provider):
         """Returns error when update_set_id contains invalid characters."""

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -97,7 +97,12 @@ class TestChoiceRegistryFetch:
                 200,
                 json={
                     "result": [
-                        {"name": "incident", "element": "state", "value": "99", "label": "Open"},
+                        {
+                            "name": "incident",
+                            "element": "state",
+                            "value": "99",
+                            "label": "Open",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},
@@ -141,7 +146,12 @@ class TestChoiceRegistryFetch:
                 200,
                 json={
                     "result": [
-                        {"name": "incident", "element": "state", "value": "77", "label": "Awaiting Approval"},
+                        {
+                            "name": "incident",
+                            "element": "state",
+                            "value": "77",
+                            "label": "Awaiting Approval",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},
@@ -188,7 +198,12 @@ class TestChoiceRegistryLabelNormalization:
                 200,
                 json={
                     "result": [
-                        {"name": "incident", "element": "state", "value": "2", "label": "In Progress"},
+                        {
+                            "name": "incident",
+                            "element": "state",
+                            "value": "2",
+                            "label": "In Progress",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},
@@ -208,7 +223,12 @@ class TestChoiceRegistryLabelNormalization:
                 200,
                 json={
                     "result": [
-                        {"name": "problem", "element": "state", "value": "1", "label": "NEW"},
+                        {
+                            "name": "problem",
+                            "element": "state",
+                            "value": "1",
+                            "label": "NEW",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},
@@ -228,7 +248,12 @@ class TestChoiceRegistryLabelNormalization:
                 200,
                 json={
                     "result": [
-                        {"name": "problem", "element": "state", "value": "4", "label": "Root Cause Analysis"},
+                        {
+                            "name": "problem",
+                            "element": "state",
+                            "value": "4",
+                            "label": "Root Cause Analysis",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -10,10 +10,11 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.config import Settings
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings: Settings) -> BasicAuthProvider:
     """Test auth provider fixture."""
     return BasicAuthProvider(settings)
@@ -30,7 +31,7 @@ def _make_registry_with_defaults(settings: Settings, auth_provider: BasicAuthPro
 class TestChoiceRegistryDefaults:
     """Test default (OOTB) choice resolution without network access."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_known_label_returns_value(self, settings, auth_provider):
         """resolve() should return the stored value for a known label."""
         registry = _make_registry_with_defaults(settings, auth_provider)
@@ -38,7 +39,7 @@ class TestChoiceRegistryDefaults:
         result = await registry.resolve("incident", "state", "open")
         assert result == "1"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_unknown_label_returns_passthrough(self, settings, auth_provider):
         """resolve() should passthrough an unrecognized label as-is."""
         registry = _make_registry_with_defaults(settings, auth_provider)
@@ -46,7 +47,7 @@ class TestChoiceRegistryDefaults:
         result = await registry.resolve("incident", "state", "nonexistent")
         assert result == "nonexistent"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_unknown_table_returns_passthrough(self, settings, auth_provider):
         """resolve() should passthrough when the table is not tracked."""
         registry = _make_registry_with_defaults(settings, auth_provider)
@@ -54,7 +55,7 @@ class TestChoiceRegistryDefaults:
         result = await registry.resolve("fake_table", "state", "open")
         assert result == "open"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_resolve_unknown_field_returns_passthrough(self, settings, auth_provider):
         """resolve() should passthrough when the field is not tracked."""
         registry = _make_registry_with_defaults(settings, auth_provider)
@@ -62,7 +63,7 @@ class TestChoiceRegistryDefaults:
         result = await registry.resolve("incident", "fake_field", "open")
         assert result == "open"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_choices_returns_default_map(self, settings, auth_provider):
         """get_choices() should return the full label-to-value dict for a known table/field."""
         registry = _make_registry_with_defaults(settings, auth_provider)
@@ -75,7 +76,7 @@ class TestChoiceRegistryDefaults:
         assert choices["closed"] == "7"
         assert choices["canceled"] == "8"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_choices_unknown_returns_empty(self, settings, auth_provider):
         """get_choices() should return an empty dict for an unknown table/field pair."""
         registry = _make_registry_with_defaults(settings, auth_provider)
@@ -87,7 +88,7 @@ class TestChoiceRegistryDefaults:
 class TestChoiceRegistryFetch:
     """Test HTTP-fetching behavior using respx mocks."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_fetch_merges_instance_data_over_defaults(self, settings, auth_provider):
         """Instance data should override defaults while preserving non-overridden entries."""
@@ -118,7 +119,7 @@ class TestChoiceRegistryFetch:
         closed = await registry.resolve("incident", "state", "closed")
         assert closed == "7"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_fetch_only_happens_once(self, settings, auth_provider):
         """Repeated resolve() calls should only trigger one HTTP fetch."""
@@ -137,7 +138,7 @@ class TestChoiceRegistryFetch:
 
         assert route.call_count == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_fetch_adds_custom_instance_values(self, settings, auth_provider):
         """Instance-only choices not in defaults should be available after fetch."""
@@ -163,7 +164,7 @@ class TestChoiceRegistryFetch:
 
         assert result == "77"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_concurrent_fetch_uses_lock(self, settings, auth_provider):
         """Concurrent resolve() calls should only trigger one HTTP fetch via asyncio.Lock."""
@@ -189,7 +190,7 @@ class TestChoiceRegistryFetch:
 class TestChoiceRegistryLabelNormalization:
     """Test label normalization behavior (spaces, case)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_label_with_spaces_normalized(self, settings, auth_provider):
         """Labels with spaces should be stored as underscore-separated lowercase keys."""
@@ -214,7 +215,7 @@ class TestChoiceRegistryLabelNormalization:
         result = await registry.resolve("incident", "state", "in_progress")
         assert result == "2"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_label_case_insensitive(self, settings, auth_provider):
         """Labels like 'NEW' should be stored as the lowercase key 'new'."""
@@ -239,7 +240,7 @@ class TestChoiceRegistryLabelNormalization:
         result = await registry.resolve("problem", "state", "new")
         assert result == "1"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_label_with_mixed_case_and_spaces(self, settings, auth_provider):
         """'Root Cause Analysis' should normalize to 'root_cause_analysis'."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -280,7 +280,8 @@ class TestServiceNowClientGetMetadata:
         assert route.called
         url = str(route.calls[0].request.url)
         # URL-encoded = becomes %3D in query params
-        assert "name" in url and "incident" in url
+        assert "name" in url
+        assert "incident" in url
 
 
 class TestServiceNowClientAggregate:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -280,9 +280,7 @@ class TestServiceNowClientGetMetadata:
 
         assert route.called
         url = str(route.calls[0].request.url)
-        # URL-encoded = becomes %3D in query params
-        assert "name" in url
-        assert "incident" in url
+        assert "name%3Dincident" in url
 
 
 class TestServiceNowClientAggregate:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,10 +6,11 @@ import respx
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -18,7 +19,7 @@ def auth_provider(settings):
 class TestServiceNowClientGetRecord:
     """Test get_record method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_success(self, settings, auth_provider):
         """Fetches a single record by sys_id."""
@@ -37,7 +38,7 @@ class TestServiceNowClientGetRecord:
         assert record == {"sys_id": "abc123", "number": "INC0001"}
         assert route.called
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_with_fields(self, settings, auth_provider):
         """Respects field selection parameter."""
@@ -55,7 +56,7 @@ class TestServiceNowClientGetRecord:
 
         assert "sysparm_fields" in str(route.calls[0].request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_with_display_values(self, settings, auth_provider):
         """Passes display_value parameter."""
@@ -73,7 +74,7 @@ class TestServiceNowClientGetRecord:
 
         assert "sysparm_display_value=true" in str(route.calls[0].request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_without_display_values(self, settings, auth_provider):
         """Omits display_value param when display_values is False."""
@@ -91,7 +92,7 @@ class TestServiceNowClientGetRecord:
 
         assert "sysparm_display_value" not in str(route.calls[0].request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_not_found(self, settings, auth_provider):
         """Raises NotFoundError for 404."""
@@ -106,7 +107,7 @@ class TestServiceNowClientGetRecord:
             with pytest.raises(NotFoundError):
                 await client.get_record("incident", "missing")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_auth_error(self, settings, auth_provider):
         """Raises AuthError for 401."""
@@ -125,7 +126,7 @@ class TestServiceNowClientGetRecord:
 class TestServiceNowClientQueryRecords:
     """Test query_records method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_success(self, settings, auth_provider):
         """Returns list of matching records."""
@@ -150,7 +151,7 @@ class TestServiceNowClientQueryRecords:
         assert len(result["records"]) == 2
         assert result["count"] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_with_limit_and_offset(self, settings, auth_provider):
         """Passes limit and offset parameters."""
@@ -171,7 +172,7 @@ class TestServiceNowClientQueryRecords:
         assert "sysparm_limit=10" in url
         assert "sysparm_offset=20" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_with_order_by(self, settings, auth_provider):
         """Passes order_by parameter."""
@@ -191,7 +192,7 @@ class TestServiceNowClientQueryRecords:
         url = str(route.calls[0].request.url)
         assert "sysparm_orderby" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_empty_results(self, settings, auth_provider):
         """Handles empty result set."""
@@ -211,7 +212,7 @@ class TestServiceNowClientQueryRecords:
         assert result["records"] == []
         assert result["count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_with_display_values(self, settings, auth_provider):
         """Passes display_value parameter when display_values=True."""
@@ -230,7 +231,7 @@ class TestServiceNowClientQueryRecords:
 
         assert "sysparm_display_value=true" in str(route.calls[0].request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_without_display_values(self, settings, auth_provider):
         """Omits display_value param when display_values is False."""
@@ -253,7 +254,7 @@ class TestServiceNowClientQueryRecords:
 class TestServiceNowClientGetMetadata:
     """Test get_metadata method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_metadata_queries_sys_dictionary(self, settings, auth_provider):
         """Queries sys_dictionary for the given table."""
@@ -287,7 +288,7 @@ class TestServiceNowClientGetMetadata:
 class TestServiceNowClientAggregate:
     """Test aggregate method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_aggregate_count(self, settings, auth_provider):
         """Performs aggregate query for counts."""
@@ -309,7 +310,7 @@ class TestServiceNowClientAggregate:
 
         assert result is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_aggregate_with_field_specific_stats(self, settings, auth_provider):
         """Passes field-specific avg/min/max/sum params."""
@@ -338,7 +339,7 @@ class TestServiceNowClientAggregate:
         assert "sysparm_max_fields" in url
         assert "sysparm_sum_fields" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_aggregate_with_having_and_order_by(self, settings, auth_provider):
         """Passes having and order_by parameters."""
@@ -364,7 +365,7 @@ class TestServiceNowClientAggregate:
         assert "sysparm_orderby" in url
         assert "sysparm_having" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_aggregate_with_display_value(self, settings, auth_provider):
         """Passes display_value parameter."""
@@ -391,7 +392,7 @@ class TestServiceNowClientAggregate:
 class TestServiceNowClientCreateRecord:
     """Test create_record method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_create_record_success(self, settings, auth_provider):
         """Creates a record via POST."""
@@ -413,7 +414,7 @@ class TestServiceNowClientCreateRecord:
 class TestServiceNowClientUpdateRecord:
     """Test update_record method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_update_record_success(self, settings, auth_provider):
         """Updates a record via PATCH."""
@@ -435,7 +436,7 @@ class TestServiceNowClientUpdateRecord:
 class TestServiceNowClientDeleteRecord:
     """Test delete_record method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_delete_record_success(self, settings, auth_provider):
         """Deletes a record via DELETE."""
@@ -452,7 +453,7 @@ class TestServiceNowClientDeleteRecord:
 class TestServiceNowClientErrorHandling:
     """Test error mapping for various HTTP status codes."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_403_raises_forbidden_error(self, settings, auth_provider):
         """403 maps to ForbiddenError."""
@@ -467,7 +468,7 @@ class TestServiceNowClientErrorHandling:
             with pytest.raises(ForbiddenError):
                 await client.get_record("incident", "abc123")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_500_raises_server_error(self, settings, auth_provider):
         """500 maps to ServerError."""
@@ -486,7 +487,7 @@ class TestServiceNowClientErrorHandling:
 class TestServiceNowClientCorrelationId:
     """Test that correlation ID is included in requests."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_correlation_id_in_headers(self, settings, auth_provider):
         """Every request includes an X-Correlation-ID header."""
@@ -506,7 +507,7 @@ class TestServiceNowClientCorrelationId:
 class TestServiceNowClientGetEmail:
     """Test get_email method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_email_success(self, settings, auth_provider):
         """Fetches an email record by ID."""
@@ -531,7 +532,7 @@ class TestServiceNowClientGetEmail:
         assert result["sys_id"] == "email123"
         assert result["subject"] == "Test email"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_email_with_fields(self, settings, auth_provider):
         """Passes sysparm_fields parameter."""
@@ -553,7 +554,7 @@ class TestServiceNowClientGetEmail:
 class TestServiceNowClientGetImportSetRecord:
     """Test get_import_set_record method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_import_set_record_success(self, settings, auth_provider):
         """Retrieves an import set record."""
@@ -578,7 +579,7 @@ class TestServiceNowClientGetImportSetRecord:
         assert result["sys_id"] == "rec123"
         assert result["status"] == "inserted"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_import_set_record_not_found(self, settings, auth_provider):
         """Raises NotFoundError for missing import set record."""
@@ -597,7 +598,7 @@ class TestServiceNowClientGetImportSetRecord:
 class TestServiceNowClientReportingAPIs:
     """Test reporting API methods."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_reports_success(self, settings, auth_provider):
         """Returns a list of reports."""
@@ -621,7 +622,7 @@ class TestServiceNowClientReportingAPIs:
         assert len(result) == 2
         assert result[0]["title"] == "Incident Report"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_reports_with_params(self, settings, auth_provider):
         """Passes search, sort, and pagination parameters."""
@@ -645,7 +646,7 @@ class TestServiceNowClientReportingAPIs:
         assert "sysparm_page" in url
         assert "sysparm_per_page" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_table_description_success(self, settings, auth_provider):
         """Returns table description."""
@@ -663,7 +664,7 @@ class TestServiceNowClientReportingAPIs:
 
         assert result["label"] == "Incident"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_field_descriptions_success(self, settings, auth_provider):
         """Returns field descriptions for a table."""
@@ -691,7 +692,7 @@ class TestServiceNowClientReportingAPIs:
 class TestServiceNowClientCodeSearch:
     """Test Code Search API methods."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_code_search_success(self, settings, auth_provider):
         """Performs code search and returns results."""
@@ -719,7 +720,7 @@ class TestServiceNowClientCodeSearch:
 
         assert result is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_code_search_with_table_and_group(self, settings, auth_provider):
         """Passes table and search_group parameters."""
@@ -740,7 +741,7 @@ class TestServiceNowClientCodeSearch:
         assert "table" in url
         assert "search_group" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_code_search_with_limit(self, settings, auth_provider):
         """Passes limit parameter."""
@@ -756,7 +757,7 @@ class TestServiceNowClientCodeSearch:
         url = str(route.calls[0].request.url)
         assert "limit=50" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_code_search_tables_success(self, settings, auth_provider):
         """Returns list of searchable tables."""
@@ -785,7 +786,7 @@ class TestServiceNowClientCodeSearch:
 class TestServiceNowClientCMDB:
     """Test CMDB API methods."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_cmdb_query_success(self, settings, auth_provider):
         """Queries CMDB instances for a class."""
@@ -810,7 +811,7 @@ class TestServiceNowClientCMDB:
         assert len(result["records"]) == 2
         assert result["count"] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_cmdb_query_with_params(self, settings, auth_provider):
         """Passes query, limit, and offset parameters."""
@@ -837,7 +838,7 @@ class TestServiceNowClientCMDB:
         assert "sysparm_limit=10" in url
         assert "sysparm_offset=5" in url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_cmdb_get_instance_success(self, settings, auth_provider):
         """Retrieves a CMDB CI with relationships."""
@@ -861,7 +862,7 @@ class TestServiceNowClientCMDB:
 
         assert result["attributes"]["sys_id"] == "ci123"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_cmdb_get_instance_not_found(self, settings, auth_provider):
         """Raises NotFoundError for missing CI."""
@@ -876,7 +877,7 @@ class TestServiceNowClientCMDB:
             with pytest.raises(NotFoundError):
                 await client.cmdb_get_instance("cmdb_ci_linux_server", "missing")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_cmdb_get_meta_success(self, settings, auth_provider):
         """Retrieves CMDB class metadata."""
@@ -904,7 +905,7 @@ class TestServiceNowClientCMDB:
 class TestServiceNowClientEncodedQueryTranslator:
     """Test encoded query translator method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_translate_encoded_query_success(self, settings, auth_provider):
         """Translates encoded query to human-readable form."""
@@ -922,7 +923,7 @@ class TestServiceNowClientEncodedQueryTranslator:
 
         assert result is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_translate_encoded_query_passes_params(self, settings, auth_provider):
         """Passes table and query parameters correctly."""
@@ -943,7 +944,7 @@ class TestServiceNowClientEncodedQueryTranslator:
 class TestClientNotInitialized:
     """Test that calling methods without async with context raises RuntimeError."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_record_without_context_manager(self, settings, auth_provider):
         """get_record raises RuntimeError when client is not initialized."""
         from servicenow_mcp.client import ServiceNowClient
@@ -952,7 +953,7 @@ class TestClientNotInitialized:
         with pytest.raises(RuntimeError, match="Client not initialized"):
             await client.get_record("incident", "abc123")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_query_records_without_context_manager(self, settings, auth_provider):
         """query_records raises RuntimeError when client is not initialized."""
         from servicenow_mcp.client import ServiceNowClient
@@ -965,7 +966,7 @@ class TestClientNotInitialized:
 class TestMissingResultKey:
     """Test that missing 'result' key in API response raises ServerError."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_record_missing_result_key(self, settings, auth_provider):
         """ServerError raised when API response lacks 'result' key."""
@@ -983,7 +984,7 @@ class TestMissingResultKey:
             with pytest.raises(ServerError, match="missing 'result' key"):
                 await client.get_record("incident", "abc123")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_missing_result_key(self, settings, auth_provider):
         """ServerError raised when query response lacks 'result' key."""
@@ -1006,7 +1007,7 @@ class TestMissingResultKey:
 class TestInvalidTotalCount:
     """Test that invalid X-Total-Count header defaults to 0."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_invalid_total_count(self, settings, auth_provider):
         """Non-numeric X-Total-Count defaults to 0."""
@@ -1026,7 +1027,7 @@ class TestInvalidTotalCount:
         assert result["count"] == 0
         assert len(result["records"]) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_cmdb_query_invalid_total_count(self, settings, auth_provider):
         """Non-numeric X-Total-Count in CMDB query defaults to 0."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,10 @@ class TestSettings:
 
         env = self._make_env()
         del env["SERVICENOW_INSTANCE_URL"]
-        with patch.dict("os.environ", env, clear=True), pytest.raises((ValueError, TypeError)):
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises((ValueError, TypeError)),
+        ):
             Settings(_env_file=None)
 
     def test_missing_username_raises(self):
@@ -45,7 +48,10 @@ class TestSettings:
 
         env = self._make_env()
         del env["SERVICENOW_USERNAME"]
-        with patch.dict("os.environ", env, clear=True), pytest.raises((ValueError, TypeError)):
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises((ValueError, TypeError)),
+        ):
             Settings(_env_file=None)
 
     def test_missing_password_raises(self):
@@ -54,7 +60,10 @@ class TestSettings:
 
         env = self._make_env()
         del env["SERVICENOW_PASSWORD"]
-        with patch.dict("os.environ", env, clear=True), pytest.raises((ValueError, TypeError)):
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises((ValueError, TypeError)),
+        ):
             Settings(_env_file=None)
 
     def test_default_mcp_tool_package(self):
@@ -183,7 +192,10 @@ class TestSettings:
         from servicenow_mcp.config import Settings
 
         env = self._make_env(SERVICENOW_INSTANCE_URL="http://test.service-now.com")
-        with patch.dict("os.environ", env, clear=True), pytest.raises(ValueError, match="https://"):
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises(ValueError, match="https://"),
+        ):
             Settings(_env_file=None)
 
     def test_max_row_limit_too_low_rejected(self):
@@ -191,7 +203,10 @@ class TestSettings:
         from servicenow_mcp.config import Settings
 
         env = self._make_env(MAX_ROW_LIMIT="0")
-        with patch.dict("os.environ", env, clear=True), pytest.raises(ValueError, match="between 1 and 10000"):
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises(ValueError, match="between 1 and 10000"),
+        ):
             Settings(_env_file=None)
 
     def test_max_row_limit_too_high_rejected(self):
@@ -199,7 +214,10 @@ class TestSettings:
         from servicenow_mcp.config import Settings
 
         env = self._make_env(MAX_ROW_LIMIT="99999")
-        with patch.dict("os.environ", env, clear=True), pytest.raises(ValueError, match="between 1 and 10000"):
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises(ValueError, match="between 1 and 10000"),
+        ):
             Settings(_env_file=None)
 
     def test_invalid_tool_package_rejected(self):

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -9,10 +9,11 @@ from toon_format import decode as toon_decode
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -32,7 +33,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestDebugTrace:
     """Tests for the debug_trace tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_merged_timeline(self, settings, auth_provider):
         """Returns merged timeline from sys_audit, syslog, sys_journal_field."""
@@ -104,7 +105,7 @@ class TestDebugTrace:
         timestamps = [e["timestamp"] for e in result["data"]["timeline"]]
         assert timestamps == sorted(timestamps)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_trace(self, settings, auth_provider):
         """Returns empty timeline when no events found."""
@@ -125,7 +126,7 @@ class TestDebugTrace:
         assert result["status"] == "success"
         assert result["data"]["timeline"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_minutes(self, settings, auth_provider):
         """Queries include gs.minutesAgoStart time filter."""
@@ -144,7 +145,7 @@ class TestDebugTrace:
         result = toon_decode(raw)
         assert result["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_caret_in_sys_id_single_sanitized(self, settings, auth_provider):
         """Values with carets are single-sanitized (^ → ^^), not double (^ → ^^^^)."""
@@ -175,7 +176,7 @@ class TestDebugTrace:
 class TestDebugFlowExecution:
     """Tests for the debug_flow_execution tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_flow_steps(self, settings, auth_provider):
         """Returns flow execution steps from sys_flow_context and sys_flow_log."""
@@ -230,7 +231,7 @@ class TestDebugFlowExecution:
         assert result["data"]["context"]["name"] == "Auto-assign flow"
         assert len(result["data"]["steps"]) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_flow_with_errors(self, settings, auth_provider):
         """Returns error info when flow steps have errors."""
@@ -276,7 +277,7 @@ class TestDebugFlowExecution:
 class TestDebugEmailTrace:
     """Tests for the debug_email_trace tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_email_chain(self, settings, auth_provider):
         """Reconstructs email chain for a record."""
@@ -316,7 +317,7 @@ class TestDebugEmailTrace:
         assert result["status"] == "success"
         assert len(result["data"]["emails"]) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_no_emails(self, settings, auth_provider):
         """Returns empty list when no emails found."""
@@ -335,7 +336,7 @@ class TestDebugEmailTrace:
 class TestDebugIntegrationHealth:
     """Tests for the debug_integration_health tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_ecc_queue_errors(self, settings, auth_provider):
         """Returns ECC queue error summary."""
@@ -366,7 +367,7 @@ class TestDebugIntegrationHealth:
         assert result["data"]["kind"] == "ecc_queue"
         assert len(result["data"]["errors"]) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_rest_message_errors(self, settings, auth_provider):
         """Returns REST message error summary."""
@@ -397,7 +398,7 @@ class TestDebugIntegrationHealth:
         assert result["data"]["kind"] == "rest_message"
         assert len(result["data"]["errors"]) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_hours(self, settings, auth_provider):
         """Queries include gs.hoursAgoStart time filter."""
@@ -414,7 +415,7 @@ class TestDebugIntegrationHealth:
 class TestDebugImportsetRun:
     """Tests for the debug_importset_run tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_import_set_results(self, settings, auth_provider):
         """Returns import set run results."""
@@ -467,7 +468,7 @@ class TestDebugImportsetRun:
         assert result["data"]["summary"]["inserted"] == 1
         assert result["data"]["summary"]["error"] == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_empty_import_set(self, settings, auth_provider):
         """Handles import set with no rows."""
@@ -498,7 +499,7 @@ class TestDebugImportsetRun:
 class TestDebugFieldMutationStory:
     """Tests for the debug_field_mutation_story tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_field_history(self, settings, auth_provider):
         """Returns chronological field mutation history."""
@@ -539,7 +540,7 @@ class TestDebugFieldMutationStory:
         assert mutations[0]["old_value"] == "1"
         assert mutations[1]["new_value"] == "6"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_no_mutations(self, settings, auth_provider):
         """Returns empty when no mutations found for the field."""

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -7,10 +7,11 @@ from toon_format import decode as toon_decode
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -33,7 +34,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestDevToggle:
     """Tests for the dev_toggle tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_toggles_active_field(self, settings, auth_provider):
         """Toggles the active field and returns old/new values."""
@@ -70,7 +71,7 @@ class TestDevToggle:
         assert result["data"]["old_active"] == "true"
         assert result["data"]["new_active"] == "false"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_blocked_in_prod(self, prod_settings, auth_provider):
         """Returns error when environment is production."""
@@ -88,7 +89,7 @@ class TestDevToggle:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_unknown_artifact_type(self, settings, auth_provider):
         """Returns error for unknown artifact type."""
@@ -98,7 +99,7 @@ class TestDevToggle:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Returns error when resolved table is denied by policy."""
@@ -125,7 +126,7 @@ class TestDevToggle:
 class TestDevSetProperty:
     """Tests for the dev_set_property tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_updates_property_value(self, settings, auth_provider):
         """Updates a system property and returns old value."""
@@ -165,7 +166,7 @@ class TestDevSetProperty:
         assert result["data"]["old_value"] == "30"
         assert result["data"]["new_value"] == "60"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error when environment is production."""
@@ -183,7 +184,7 @@ class TestDevSetProperty:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_property_not_found(self, settings, auth_provider):
         """Returns error when property doesn't exist."""
@@ -208,7 +209,7 @@ class TestDevSetProperty:
 class TestDevUtilsSensitiveFieldMasking:
     """Tests for sensitive field masking in dev_utils tool responses."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_dev_set_property_masks_sensitive_value(self, settings, auth_provider):
         """Setting a property with a sensitive name masks old/new values in response."""
@@ -256,7 +257,7 @@ class TestDevUtilsSensitiveFieldMasking:
 class TestDevToggleGenericException:
     """Tests for dev_toggle generic exception handler."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_unexpected_exception(self, settings, auth_provider):
         """dev_toggle returns error envelope when an unexpected exception occurs."""
@@ -277,7 +278,7 @@ class TestDevToggleGenericException:
 class TestDevSetPropertyGenericException:
     """Tests for dev_set_property generic exception handler."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_unexpected_exception(self, settings, auth_provider):
         """dev_set_property returns error envelope when an unexpected exception occurs."""

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -737,16 +737,36 @@ METADATA_URL = f"{BASE_URL}/api/now/table/sys_dictionary"
 
 METADATA_WITH_TWO_MANDATORY = {
     "result": [
-        {"element": "short_description", "mandatory": "true", "internal_type": "string"},
-        {"element": "category", "mandatory": "true", "internal_type": "string"},
-        {"element": "description", "mandatory": "false", "internal_type": "string"},
+        {
+            "element": "short_description",
+            "mandatory": "true",
+            "internal_type": "string",
+        },
+        {
+            "element": "category",
+            "mandatory": "true",
+            "internal_type": "string",
+        },
+        {
+            "element": "description",
+            "mandatory": "false",
+            "internal_type": "string",
+        },
     ]
 }
 
 METADATA_NO_MANDATORY = {
     "result": [
-        {"element": "short_description", "mandatory": "false", "internal_type": "string"},
-        {"element": "description", "mandatory": "false", "internal_type": "string"},
+        {
+            "element": "short_description",
+            "mandatory": "false",
+            "internal_type": "string",
+        },
+        {
+            "element": "description",
+            "mandatory": "false",
+            "internal_type": "string",
+        },
     ]
 }
 
@@ -844,7 +864,11 @@ class TestMandatoryFieldValidation:
                 200,
                 json={
                     "result": [
-                        {"element": "short_description", "mandatory": "true", "internal_type": "string"},
+                        {
+                            "element": "short_description",
+                            "mandatory": "true",
+                            "internal_type": "string",
+                        },
                     ]
                 },
             )

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -10,10 +10,11 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.policy import DENIED_TABLES
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -36,7 +37,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestRecordCreate:
     """Tests for the record_create tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_creates_record_and_returns_masked(self, settings, auth_provider):
         """Creates a record and returns it with sensitive fields masked."""
@@ -67,7 +68,7 @@ class TestRecordCreate:
         assert result["data"]["record"]["short_description"] == "Test incident"
         assert result["data"]["record"]["password"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error when environment is production."""
         from mcp.server.fastmcp import FastMCP
@@ -88,7 +89,7 @@ class TestRecordCreate:
         assert result["status"] == "error"
         assert "production" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Returns error when table is denied by policy."""
         denied = next(iter(DENIED_TABLES))
@@ -103,7 +104,7 @@ class TestRecordCreate:
         assert result["status"] == "error"
         assert "denied" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_json_returns_error(self, settings, auth_provider):
         """Returns error when data is not valid JSON."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -112,7 +113,7 @@ class TestRecordCreate:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_acl_denied_returns_clear_error(self, settings, auth_provider):
         """Returns clear error when ServiceNow ACL denies the operation."""
@@ -130,7 +131,7 @@ class TestRecordCreate:
         assert result["status"] == "error"
         assert "acl" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_generic_exception(self, settings, auth_provider):
         """Returns error envelope on unexpected exception."""
@@ -157,7 +158,7 @@ class TestRecordCreate:
 class TestRecordPreviewCreate:
     """Tests for the record_preview_create tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_returns_token_and_data(self, settings, auth_provider):
         """Returns a preview token and the masked data summary."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -173,7 +174,7 @@ class TestRecordPreviewCreate:
         assert result["data"]["action"] == "create"
         assert result["data"]["data"]["password"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error when environment is production."""
         from mcp.server.fastmcp import FastMCP
@@ -192,7 +193,7 @@ class TestRecordPreviewCreate:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_json_returns_error(self, settings, auth_provider):
         """Returns error when data is not valid JSON."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -207,7 +208,7 @@ class TestRecordPreviewCreate:
 class TestRecordUpdate:
     """Tests for the record_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_updates_record_and_returns_masked(self, settings, auth_provider):
         """Updates a record and returns it with sensitive fields masked."""
@@ -237,7 +238,7 @@ class TestRecordUpdate:
         assert result["data"]["record"]["state"] == "2"
         assert result["data"]["record"]["password"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error in production."""
         from mcp.server.fastmcp import FastMCP
@@ -257,7 +258,7 @@ class TestRecordUpdate:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Returns error for denied table."""
         denied = next(iter(DENIED_TABLES))
@@ -271,7 +272,7 @@ class TestRecordUpdate:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_returns_error(self, settings, auth_provider):
         """Returns error when record doesn't exist."""
@@ -288,7 +289,7 @@ class TestRecordUpdate:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_acl_denied_returns_clear_error(self, settings, auth_provider):
         """Returns clear ACL error."""
@@ -313,7 +314,7 @@ class TestRecordUpdate:
 class TestRecordPreviewUpdate:
     """Tests for the record_preview_update tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_diff_and_token(self, settings, auth_provider):
         """Fetches current record and returns field-level diff with token."""
@@ -345,7 +346,7 @@ class TestRecordPreviewUpdate:
         assert result["data"]["diff"]["short_description"]["old"] == "Original"
         assert result["data"]["diff"]["short_description"]["new"] == "Updated"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_masks_sensitive_fields_in_diff(self, settings, auth_provider):
         """Sensitive fields in the diff are masked."""
@@ -373,7 +374,7 @@ class TestRecordPreviewUpdate:
         assert result["data"]["diff"]["password"]["old"] == "***MASKED***"
         assert result["data"]["diff"]["password"]["new"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error in production."""
         from mcp.server.fastmcp import FastMCP
@@ -400,7 +401,7 @@ class TestRecordPreviewUpdate:
 class TestRecordDelete:
     """Tests for the record_delete tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_deletes_record(self, settings, auth_provider):
         """Deletes a record and returns confirmation."""
@@ -415,7 +416,7 @@ class TestRecordDelete:
         assert result["data"]["sys_id"] == "inc001"
         assert result["data"]["deleted"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error in production."""
         from mcp.server.fastmcp import FastMCP
@@ -431,7 +432,7 @@ class TestRecordDelete:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Returns error for denied table."""
         denied = next(iter(DENIED_TABLES))
@@ -441,7 +442,7 @@ class TestRecordDelete:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_returns_error(self, settings, auth_provider):
         """Returns error when record doesn't exist."""
@@ -454,7 +455,7 @@ class TestRecordDelete:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_acl_denied_returns_clear_error(self, settings, auth_provider):
         """Returns clear ACL error on 403."""
@@ -475,7 +476,7 @@ class TestRecordDelete:
 class TestRecordPreviewDelete:
     """Tests for the record_preview_delete tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_snapshot_and_token(self, settings, auth_provider):
         """Fetches record and returns snapshot with preview token."""
@@ -504,7 +505,7 @@ class TestRecordPreviewDelete:
         assert result["data"]["record_snapshot"]["short_description"] == "Test incident"
         assert result["data"]["record_snapshot"]["password"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_blocked_in_prod(self, prod_settings):
         """Returns error in production."""
         from mcp.server.fastmcp import FastMCP
@@ -520,7 +521,7 @@ class TestRecordPreviewDelete:
         result = toon_decode(raw)
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_returns_error(self, settings, auth_provider):
         """Returns error when record doesn't exist."""
@@ -540,7 +541,7 @@ class TestRecordPreviewDelete:
 class TestRecordApply:
     """Tests for the record_apply tool (applies any previewed action)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_apply_create(self, settings, auth_provider):
         """Applies a previewed create action."""
@@ -574,7 +575,7 @@ class TestRecordApply:
         assert result["data"]["sys_id"] == "new001"
         assert result["data"]["record"]["short_description"] == "Test"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_apply_update(self, settings, auth_provider):
         """Applies a previewed update action."""
@@ -609,7 +610,7 @@ class TestRecordApply:
         assert result["data"]["action"] == "update"
         assert result["data"]["record"]["state"] == "2"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_apply_delete(self, settings, auth_provider):
         """Applies a previewed delete action."""
@@ -640,7 +641,7 @@ class TestRecordApply:
         assert result["data"]["action"] == "delete"
         assert result["data"]["deleted"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_token_returns_error(self, settings, auth_provider):
         """Returns error for an invalid/unknown token."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -650,7 +651,7 @@ class TestRecordApply:
         assert result["status"] == "error"
         assert "invalid" in result["error"]["message"].lower() or "expired" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_token_consumed_only_once(self, settings, auth_provider):
         """Token is single-use - second apply with same token fails."""
@@ -679,7 +680,7 @@ class TestRecordApply:
         assert result2["status"] == "error"
         assert "invalid" in result2["error"]["message"].lower() or "expired" in result2["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_apply_masks_sensitive_fields(self, settings, auth_provider):
         """Applied create masks sensitive fields in the returned record."""
@@ -709,7 +710,7 @@ class TestRecordApply:
         assert result["status"] == "success"
         assert result["data"]["record"]["password"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_apply_acl_denied(self, settings, auth_provider):
         """Returns clear ACL error when ServiceNow denies the apply operation."""
@@ -774,7 +775,7 @@ METADATA_NO_MANDATORY = {
 class TestMandatoryFieldValidation:
     """Tests for mandatory field pre-flight validation on record creation."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_create_missing_mandatory_fields(self, settings, auth_provider):
         """Returns error when mandatory fields are missing from create data."""
@@ -792,7 +793,7 @@ class TestMandatoryFieldValidation:
         assert "category" in result["data"]["missing_fields"]
         assert "Missing mandatory fields" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_create_all_mandatory_present(self, settings, auth_provider):
         """Proceeds with create when all mandatory fields are present."""
@@ -820,7 +821,7 @@ class TestMandatoryFieldValidation:
         assert result["status"] == "success"
         assert result["data"]["sys_id"] == "new001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_preview_create_missing_mandatory_fields(self, settings, auth_provider):
         """Returns error when mandatory fields are missing from preview create data."""
@@ -837,7 +838,7 @@ class TestMandatoryFieldValidation:
         assert "category" in result["data"]["missing_fields"]
         assert "Missing mandatory fields" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_preview_create_all_mandatory_present(self, settings, auth_provider):
         """Returns preview token when all mandatory fields are present."""
@@ -854,7 +855,7 @@ class TestMandatoryFieldValidation:
         assert "token" in result["data"]
         assert result["data"]["action"] == "create"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_apply_create_missing_mandatory_fields(self, settings, auth_provider):
         """record_apply catches newly mandatory fields at apply time."""
@@ -891,7 +892,7 @@ class TestMandatoryFieldValidation:
         assert "category" in result["data"]["missing_fields"]
         assert "Missing mandatory fields" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_create_no_mandatory_fields(self, settings, auth_provider):
         """Proceeds normally when table has no mandatory fields."""
@@ -918,7 +919,7 @@ class TestMandatoryFieldValidation:
         assert result["status"] == "success"
         assert result["data"]["sys_id"] == "new002"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_record_create_metadata_unavailable(self, settings, auth_provider):
         """Create proceeds when metadata endpoint returns 500 (best-effort)."""

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -192,7 +192,11 @@ class TestDocsLogicMap:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "uip1", "short_description": "Make field read-only", "active": "true"},
+                        {
+                            "sys_id": "uip1",
+                            "short_description": "Make field read-only",
+                            "active": "true",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},
@@ -203,7 +207,12 @@ class TestDocsLogicMap:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "uia1", "name": "Close Incident", "action_name": "close", "active": "true"},
+                        {
+                            "sys_id": "uia1",
+                            "name": "Close Incident",
+                            "action_name": "close",
+                            "active": "true",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -7,10 +7,11 @@ from toon_format import decode as toon_decode
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -33,7 +34,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestDocsLogicMap:
     """Tests for the docs_logic_map tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_lifecycle_map(self, settings, auth_provider):
         """Returns automation grouped by lifecycle phase."""
@@ -103,7 +104,7 @@ class TestDocsLogicMap:
         # Should have at least before_insert and after_update
         assert len(data["phases"]) > 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_table_no_automation(self, settings, auth_provider):
         """Table with no automation returns empty phases."""
@@ -124,7 +125,7 @@ class TestDocsLogicMap:
         assert result["status"] == "success"
         assert result["data"]["total_automations"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_br_delete_action_and_no_operations(self, settings, auth_provider):
         """Covers delete action branch and fallback to 'all' when no operations are set."""
@@ -177,7 +178,7 @@ class TestDocsLogicMap:
         assert "before_all" in phases
         assert phases["before_all"][0]["name"] == "On all"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_ui_policies_and_ui_actions_populated(self, settings, auth_provider):
         """Covers non-empty UI policies and UI actions phases."""
@@ -238,7 +239,7 @@ class TestDocsLogicMap:
 class TestDocsArtifactSummary:
     """Tests for the docs_artifact_summary tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_summary_with_dependencies(self, settings, auth_provider):
         """Returns artifact summary with referenced tables and referenced_by."""
@@ -275,7 +276,7 @@ class TestDocsArtifactSummary:
         # Should detect GlideRecord('cmdb_ci') in script
         assert "cmdb_ci" in data["referenced_tables"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_returns_error(self, settings, auth_provider):
         """Returns error for non-existent artifact."""
@@ -289,7 +290,7 @@ class TestDocsArtifactSummary:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_artifact_type_returns_error(self, settings, auth_provider):
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -300,7 +301,7 @@ class TestDocsArtifactSummary:
         assert "bogus_type" in result["error"]["message"]
         assert "Valid:" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_code_search_failure_is_silent(self, settings, auth_provider):
         """Code search exception is caught silently; referenced_by is empty."""
@@ -331,7 +332,7 @@ class TestDocsArtifactSummary:
         assert result["data"]["referenced_by"] == []
         assert "task" in result["data"]["referenced_tables"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_masks_sensitive_fields(self, settings, auth_provider):
         """Sensitive fields in the artifact record are masked in the response."""
@@ -379,7 +380,7 @@ class TestDocsArtifactSummary:
 class TestDocsTestScenarios:
     """Tests for the docs_test_scenarios tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_condition_branches(self, settings, auth_provider):
         """Detects if/else conditions and suggests test scenarios."""
@@ -407,7 +408,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("condition" in s.lower() or "branch" in s.lower() for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_insert_vs_update(self, settings, auth_provider):
         """Detects insert/update operation checks."""
@@ -433,7 +434,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("insert" in s.lower() for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_script_returns_generic(self, settings, auth_provider):
         """Empty script returns generic suggestions."""
@@ -459,7 +460,7 @@ class TestDocsTestScenarios:
         # Should still return at least generic scenarios
         assert len(result["data"]["scenarios"]) >= 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_artifact_type_returns_error(self, settings, auth_provider):
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -470,7 +471,7 @@ class TestDocsTestScenarios:
         assert "bogus_type" in result["error"]["message"]
         assert "Valid:" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_delete_operation(self, settings, auth_provider):
         """Detects delete operation check in script."""
@@ -496,7 +497,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("delete" in s.lower() for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_is_new_record(self, settings, auth_provider):
         """Detects isNewRecord() check in script."""
@@ -522,7 +523,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("new record" in s.lower() for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_role_check(self, settings, auth_provider):
         """Detects gs.hasRole() check in script."""
@@ -548,7 +549,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("admin" in s for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_abort_action(self, settings, auth_provider):
         """Detects setAbortAction(true) in script."""
@@ -574,7 +575,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("abort" in s.lower() for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_gliderecord_dependency(self, settings, auth_provider):
         """Detects GlideRecord table dependencies in script."""
@@ -600,7 +601,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("sys_user" in s for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_no_patterns_returns_generic(self, settings, auth_provider):
         """Script with no detectable patterns returns generic fallback scenario."""
@@ -628,7 +629,7 @@ class TestDocsTestScenarios:
         scenario_names = [s["scenario"] for s in result["data"]["scenarios"]]
         assert any("basic" in s.lower() for s in scenario_names)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_masks_sensitive_fields_in_record(self, settings, auth_provider):
         """Sensitive fields in the artifact record are masked before generating scenarios."""
@@ -664,7 +665,7 @@ class TestDocsTestScenarios:
 class TestDocsReviewNotes:
     """Tests for the docs_review_notes tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_artifact_type_returns_error(self, settings, auth_provider):
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -675,7 +676,7 @@ class TestDocsReviewNotes:
         assert "bogus_type" in result["error"]["message"]
         assert "Valid:" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_script_no_findings(self, settings, auth_provider):
         """Empty script returns empty findings list."""
@@ -701,7 +702,7 @@ class TestDocsReviewNotes:
         assert result["data"]["findings"] == []
         assert result["data"]["finding_count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_current_update(self, settings, auth_provider):
         """Detects current.update() anti-pattern in script."""
@@ -728,7 +729,7 @@ class TestDocsReviewNotes:
         categories = [f["category"] for f in result["data"]["findings"]]
         assert "current_update_in_br" in categories
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_gliderecord_in_loop(self, settings, auth_provider):
         """Detects GlideRecord query inside a loop."""
@@ -764,7 +765,7 @@ class TestDocsReviewNotes:
         categories = [f["category"] for f in findings]
         assert "gliderecord_in_loop" in categories
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_hardcoded_sysid(self, settings, auth_provider):
         """Detects hardcoded 32-char hex sys_ids in script."""
@@ -791,7 +792,7 @@ class TestDocsReviewNotes:
         categories = [f["category"] for f in result["data"]["findings"]]
         assert "hardcoded_sys_id" in categories
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_clean_script_no_findings(self, settings, auth_provider):
         """Clean script returns no findings."""
@@ -817,7 +818,7 @@ class TestDocsReviewNotes:
         assert result["status"] == "success"
         assert len(result["data"]["findings"]) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_masks_sensitive_fields_in_record(self, settings, auth_provider):
         """Sensitive fields in the artifact record are masked before scanning."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -110,7 +110,14 @@ class TestErrorHierarchy:
 
     def test_all_errors_are_exceptions(self) -> None:
         """All error classes are Exception subclasses."""
-        for cls in (AuthError, ForbiddenError, NotFoundError, ServerError, PolicyError, QuerySafetyError):
+        for cls in (
+            AuthError,
+            ForbiddenError,
+            NotFoundError,
+            ServerError,
+            PolicyError,
+            QuerySafetyError,
+        ):
             assert isinstance(cls(), Exception)
 
 

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -113,7 +113,13 @@ class TestTableGet:
         respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "abc123", "number": "INC0001", "state": "1"}},
+                json={
+                    "result": {
+                        "sys_id": "abc123",
+                        "number": "INC0001",
+                        "state": "1",
+                    }
+                },
             )
         )
 
@@ -263,7 +269,11 @@ class TestTableQuery:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "1", "number": "INC0001", "priority": "1 - Critical"},
+                        {
+                            "sys_id": "1",
+                            "number": "INC0001",
+                            "priority": "1 - Critical",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "1"},

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -9,10 +9,11 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.policy import DENIED_TABLES
 from servicenow_mcp.state import QueryTokenStore
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -34,7 +35,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestTableDescribe:
     """Tests for the table_describe tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_field_metadata(self, settings, auth_provider):
         """Returns structured field metadata for a known table."""
@@ -76,7 +77,7 @@ class TestTableDescribe:
         assert result["data"]["fields"][0]["element"] == "number"
         assert result["data"]["fields"][1]["element"] == "state"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Blocked tables return an error response (no HTTP call made)."""
         denied = next(iter(DENIED_TABLES))
@@ -87,7 +88,7 @@ class TestTableDescribe:
         assert result["status"] == "error"
         assert "denied" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_includes_correlation_id(self, settings, auth_provider):
         """Response always contains a correlation_id."""
@@ -106,7 +107,7 @@ class TestTableDescribe:
 class TestTableGet:
     """Tests for the table_get tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_single_record(self, settings, auth_provider):
         """Fetches and returns a single record by sys_id."""
@@ -131,7 +132,7 @@ class TestTableGet:
         assert result["data"]["sys_id"] == "abc123"
         assert result["data"]["number"] == "INC0001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_masks_sensitive_fields(self, settings, auth_provider):
         """Sensitive fields like password are masked in the response."""
@@ -158,7 +159,7 @@ class TestTableGet:
         assert result["data"]["password"] == "***MASKED***"
         assert result["data"]["api_key"] == "***MASKED***"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_returns_error(self, settings, auth_provider):
         """404 from ServiceNow produces an error response."""
@@ -172,7 +173,7 @@ class TestTableGet:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Denied table returns error without making HTTP call."""
         denied = next(iter(DENIED_TABLES))
@@ -187,7 +188,7 @@ class TestTableGet:
 class TestTableQuery:
     """Tests for the table_query tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_matching_records(self, settings, auth_provider):
         """Returns records matching the query with pagination."""
@@ -213,7 +214,7 @@ class TestTableQuery:
         assert len(result["data"]) == 2
         assert result["pagination"]["total"] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_limit_capped_with_warning(self, settings, auth_provider):
         """When requested limit exceeds max_row_limit, it is capped and a warning is added."""
@@ -235,7 +236,7 @@ class TestTableQuery:
         assert result["pagination"]["limit"] == 100
         assert any("capped" in w.lower() for w in result.get("warnings", []))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_large_table_without_date_filter_returns_error(self, settings, auth_provider):
         """Large tables require a date filter; omitting it returns an error."""
         # Add syslog to large tables for this test
@@ -248,7 +249,7 @@ class TestTableQuery:
         assert result["status"] == "error"
         assert "date" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Denied table returns error."""
         denied = next(iter(DENIED_TABLES))
@@ -260,7 +261,7 @@ class TestTableQuery:
         assert result["status"] == "error"
         assert "denied" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_display_values_passed_to_client(self, settings, auth_provider):
         """When display_values=True, sysparm_display_value=true is sent to the API."""
@@ -297,7 +298,7 @@ class TestTableQuery:
 class TestTableAggregate:
     """Tests for the table_aggregate tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_aggregate_stats(self, settings, auth_provider):
         """Returns aggregate statistics for the query."""
@@ -316,7 +317,7 @@ class TestTableAggregate:
         assert result["status"] == "success"
         assert result["data"]["stats"]["count"] == "42"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Denied table returns error."""
         denied = next(iter(DENIED_TABLES))
@@ -336,7 +337,7 @@ class TestErrorPropagation:
     """Verify that ServiceNowMCPError subclasses raised by the client are caught
     by the tool layer and returned inside a format_response error envelope."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_auth_error_returns_error_envelope(self, settings, auth_provider):
         """AuthError (401) from client is caught and returned in error envelope."""
@@ -355,7 +356,7 @@ class TestErrorPropagation:
         assert "not authenticated" in result["error"]["message"].lower()
         assert "correlation_id" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_forbidden_error_returns_error_envelope(self, settings, auth_provider):
         """ForbiddenError (403) from client is caught and returned in error envelope."""
@@ -374,7 +375,7 @@ class TestErrorPropagation:
         assert "insufficient" in result["error"]["message"].lower() or "forbidden" in result["error"]["message"].lower()
         assert "correlation_id" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_error_returns_error_envelope(self, settings, auth_provider):
         """NotFoundError (404) from client is caught and returned in error envelope."""
@@ -393,7 +394,7 @@ class TestErrorPropagation:
         assert "not found" in result["error"]["message"].lower()
         assert "correlation_id" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_server_error_returns_error_envelope(self, settings, auth_provider):
         """ServerError (500) from client is caught and returned in error envelope."""
@@ -415,7 +416,7 @@ class TestErrorPropagation:
         )
         assert "correlation_id" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_tool_auth_error_returns_error_envelope(self, settings, auth_provider):
         """AuthError during table_query is caught and returned in error envelope."""
@@ -438,7 +439,7 @@ class TestErrorPropagation:
         )
         assert "correlation_id" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_aggregate_tool_server_error_returns_error_envelope(self, settings, auth_provider):
         """ServerError during table_aggregate is caught and returned in error envelope."""
@@ -462,7 +463,7 @@ class TestErrorPropagation:
 class TestQueryTokenValidation:
     """Tests that query token validation works correctly."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_invalid_token_returns_error(self, settings, auth_provider):
         """Passing a non-existent token returns a descriptive error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
@@ -472,7 +473,7 @@ class TestQueryTokenValidation:
         assert result["status"] == "error"
         assert "build_query" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_token_queries_without_filter(self, settings, auth_provider):
         """Empty query_token runs query with no filter."""

--- a/tests/test_investigation_helpers.py
+++ b/tests/test_investigation_helpers.py
@@ -150,7 +150,11 @@ class TestFetchAndExplain:
         mock_check: AsyncMock,
     ) -> None:
         """Returns dict with element, explanation, and record keys."""
-        test_record = {"sys_id": "fc001", "name": "Test Flow", "state": "IN_PROGRESS"}
+        test_record = {
+            "sys_id": "fc001",
+            "name": "Test Flow",
+            "state": "IN_PROGRESS",
+        }
         mock_mask.return_value = test_record
 
         client = AsyncMock()
@@ -299,7 +303,11 @@ class TestFetchAndExplain:
             client=client,
             element_id="syslog:x",
             allowed_tables=None,
-            build_explanation=lambda t, s, r: ["Part one.", "Part two.", "Part three."],
+            build_explanation=lambda t, s, r: [
+                "Part one.",
+                "Part two.",
+                "Part three.",
+            ],
         )
 
         assert result["explanation"] == "Part one. Part two. Part three."

--- a/tests/test_investigation_helpers.py
+++ b/tests/test_investigation_helpers.py
@@ -11,6 +11,7 @@ from servicenow_mcp.investigation_helpers import (
     parse_int_param,
 )
 
+
 # ── parse_int_param ──────────────────────────────────────────────────────
 
 
@@ -139,7 +140,7 @@ class TestBuildInvestigationResult:
 class TestFetchAndExplain:
     """Tests for fetch_and_explain()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.investigation_helpers.check_table_access")
     @patch("servicenow_mcp.investigation_helpers.mask_sensitive_fields")
     @patch("servicenow_mcp.investigation_helpers.validate_identifier")
@@ -174,7 +175,7 @@ class TestFetchAndExplain:
         assert result["explanation"] == "Flow 'Test Flow' is stuck."
         assert result["record"] is test_record
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.investigation_helpers.check_table_access")
     @patch("servicenow_mcp.investigation_helpers.mask_sensitive_fields")
     @patch("servicenow_mcp.investigation_helpers.validate_identifier")
@@ -198,7 +199,7 @@ class TestFetchAndExplain:
 
         mock_validate.assert_called_once_with("abc123")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.investigation_helpers.check_table_access")
     @patch("servicenow_mcp.investigation_helpers.mask_sensitive_fields")
     @patch("servicenow_mcp.investigation_helpers.validate_identifier")
@@ -222,7 +223,7 @@ class TestFetchAndExplain:
 
         mock_check.assert_called_once_with("incident")
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.investigation_helpers.check_table_access")
     @patch("servicenow_mcp.investigation_helpers.mask_sensitive_fields")
     @patch("servicenow_mcp.investigation_helpers.validate_identifier")
@@ -250,7 +251,7 @@ class TestFetchAndExplain:
         mock_mask.assert_called_once_with(raw_record)
         assert result["record"] is masked_record
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.investigation_helpers.check_table_access")
     @patch("servicenow_mcp.investigation_helpers.mask_sensitive_fields")
     @patch("servicenow_mcp.investigation_helpers.validate_identifier")
@@ -284,7 +285,7 @@ class TestFetchAndExplain:
         assert len(received_records) == 1
         assert received_records[0] is masked_record
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @patch("servicenow_mcp.investigation_helpers.check_table_access")
     @patch("servicenow_mcp.investigation_helpers.mask_sensitive_fields")
     @patch("servicenow_mcp.investigation_helpers.validate_identifier")
@@ -312,7 +313,7 @@ class TestFetchAndExplain:
 
         assert result["explanation"] == "Part one. Part two. Part three."
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_raises_value_error_for_invalid_element_id(self) -> None:
         """Raises ValueError when element_id is missing a colon."""
         client = AsyncMock()
@@ -325,7 +326,7 @@ class TestFetchAndExplain:
                 build_explanation=lambda t, s, r: ["ok"],
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_raises_value_error_for_disallowed_table(self) -> None:
         """Raises ValueError when the table is not in the allowed set."""
         client = AsyncMock()

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -364,7 +364,13 @@ class TestTableHealth:
         respx.get(f"{BASE_URL}/api/now/stats/incident").mock(
             return_value=httpx.Response(200, json={"result": {"stats": {"count": "100"}}})
         )
-        for table in ["sys_script", "sys_script_client", "sys_security_acl", "sys_ui_policy", "syslog"]:
+        for table in [
+            "sys_script",
+            "sys_script_client",
+            "sys_security_acl",
+            "sys_ui_policy",
+            "syslog",
+        ]:
             respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
                 return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
             )
@@ -1048,7 +1054,16 @@ class TestExplainPerformanceBottlenecks:
         respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": f"br{i}", "name": f"BR {i}", "when": "before"} for i in range(15)]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": f"br{i}",
+                            "name": f"BR {i}",
+                            "when": "before",
+                        }
+                        for i in range(15)
+                    ]
+                },
                 headers={"X-Total-Count": "15"},
             )
         )
@@ -1313,7 +1328,12 @@ class TestTypeCoercion:
     @respx.mock
     async def test_stale_automations_string_stale_days(self, settings, auth_provider):
         """stale_automations run() accepts stale_days as a string."""
-        for table in ["flow_context", "sys_script", "sys_script_include", "sysauto_script"]:
+        for table in [
+            "flow_context",
+            "sys_script",
+            "sys_script_include",
+            "sysauto_script",
+        ]:
             respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
                 return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
             )
@@ -1359,7 +1379,13 @@ class TestTypeCoercion:
         respx.get(f"{BASE_URL}/api/now/stats/incident").mock(
             return_value=httpx.Response(200, json={"result": {"stats": {"count": "100"}}})
         )
-        for table in ["sys_script", "sys_script_client", "sys_security_acl", "sys_ui_policy", "syslog"]:
+        for table in [
+            "sys_script",
+            "sys_script_client",
+            "sys_security_acl",
+            "sys_ui_policy",
+            "syslog",
+        ]:
             respx.get(f"{BASE_URL}/api/now/table/{table}").mock(
                 return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
             )
@@ -1828,7 +1854,13 @@ class TestTableHealthCoverage:
         respx.get(f"{BASE_URL}/api/now/stats/incident").mock(
             return_value=httpx.Response(200, json={"result": {"stats": {"count": "10"}}})
         )
-        for tbl in ["sys_script", "sys_script_client", "sys_security_acl", "sys_ui_policy", "syslog"]:
+        for tbl in [
+            "sys_script",
+            "sys_script_client",
+            "sys_security_acl",
+            "sys_ui_policy",
+            "syslog",
+        ]:
             respx.get(f"{BASE_URL}/api/now/table/{tbl}").mock(
                 return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
             )
@@ -1855,7 +1887,16 @@ class TestTableHealthCoverage:
         respx.get(f"{BASE_URL}/api/now/table/sys_script").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": f"br{i}", "name": f"BR {i}", "when": "before"} for i in range(12)]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": f"br{i}",
+                            "name": f"BR {i}",
+                            "when": "before",
+                        }
+                        for i in range(12)
+                    ]
+                },
                 headers={"X-Total-Count": "12"},
             )
         )
@@ -1868,7 +1909,14 @@ class TestTableHealthCoverage:
             return_value=httpx.Response(
                 200,
                 json={
-                    "result": [{"sys_id": f"acl{i}", "name": "incident.*.read", "operation": "read"} for i in range(22)]
+                    "result": [
+                        {
+                            "sys_id": f"acl{i}",
+                            "name": "incident.*.read",
+                            "operation": "read",
+                        }
+                        for i in range(22)
+                    ]
                 },
                 headers={"X-Total-Count": "22"},
             )

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -7,10 +7,11 @@ from toon_format import decode as toon_decode
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -33,7 +34,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestInvestigateRun:
     """Tests for the investigate_run dispatcher tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_dispatches_to_stale_automations(self, settings, auth_provider):
         """Dispatches to stale_automations and returns findings."""
@@ -86,7 +87,7 @@ class TestInvestigateRun:
         assert result["status"] == "success"
         assert result["data"]["finding_count"] >= 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_rejects_unknown_investigation(self, settings, auth_provider):
         """Returns error for unknown investigation name."""
@@ -96,7 +97,7 @@ class TestInvestigateRun:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_investigate_explain_returns_context(self, settings, auth_provider):
         """investigate_explain returns contextual explanation for a finding."""
@@ -133,7 +134,7 @@ class TestInvestigateRun:
 class TestStaleAutomations:
     """Tests for the stale_automations investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_stuck_flow(self, settings, auth_provider):
         """Finds a stuck Flow Designer context."""
@@ -171,7 +172,7 @@ class TestStaleAutomations:
         assert result["data"]["finding_count"] == 1
         assert result["data"]["findings"][0]["category"] == "stuck_flow"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_clean_instance_no_findings(self, settings, auth_provider):
         """Clean instance returns no findings."""
@@ -192,7 +193,7 @@ class TestStaleAutomations:
         assert result["status"] == "success"
         assert result["data"]["finding_count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_uses_gs_days_ago(self, settings, auth_provider):
         """Queries use gs.daysAgoEnd instead of Python datetime strings."""
@@ -225,7 +226,7 @@ class TestStaleAutomations:
 class TestDeprecatedApis:
     """Tests for the deprecated_apis investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_deprecated_pattern(self, settings, auth_provider):
         """Finds scripts using deprecated Packages. API."""
@@ -261,7 +262,7 @@ class TestDeprecatedApis:
         patterns_found = [f["pattern"] for f in result["data"]["findings"]]
         assert "Packages." in patterns_found
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_clean_code_no_findings(self, settings, auth_provider):
         """Clean code returns no findings."""
@@ -286,7 +287,7 @@ class TestDeprecatedApis:
 class TestTableHealth:
     """Tests for the table_health investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_health_report(self, settings, auth_provider):
         """Returns a complete health report for a table."""
@@ -356,7 +357,7 @@ class TestTableHealth:
         assert data["automation"]["client_scripts"]["count"] == 1
         assert data["automation"]["acl_count"] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_hours(self, settings, auth_provider):
         """All queries include time filter when hours is specified."""
@@ -384,7 +385,7 @@ class TestTableHealth:
         assert result["status"] == "success"
         assert result["data"]["hours"] == 24
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_rejects_invalid_table_identifier(self, settings, auth_provider):
         """Rejects a table name containing injection characters."""
@@ -405,7 +406,7 @@ class TestTableHealth:
 class TestAclConflicts:
     """Tests for the acl_conflicts investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_detects_overlapping_acls(self, settings, auth_provider):
         """Detects two ACLs with the same name but different conditions."""
@@ -446,7 +447,7 @@ class TestAclConflicts:
         assert result["status"] == "success"
         assert result["data"]["finding_count"] >= 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_no_conflicts(self, settings, auth_provider):
         """Unique ACL names produce no conflicts."""
@@ -494,7 +495,7 @@ class TestAclConflicts:
 class TestErrorAnalysis:
     """Tests for the error_analysis investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_clusters_errors_by_source(self, settings, auth_provider):
         """Clusters syslog errors by source field."""
@@ -540,7 +541,7 @@ class TestErrorAnalysis:
         top = result["data"]["findings"][0]
         assert top["frequency"] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_no_errors_clean_report(self, settings, auth_provider):
         """No syslog errors returns clean report."""
@@ -555,7 +556,7 @@ class TestErrorAnalysis:
         assert result["status"] == "success"
         assert result["data"]["finding_count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_hours(self, settings, auth_provider):
         """syslog query includes time filter."""
@@ -576,7 +577,7 @@ class TestErrorAnalysis:
 class TestSlowTransactions:
     """Tests for the slow_transactions investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_slow_query_pattern(self, settings, auth_provider):
         """Finds a slow query pattern from sys_query_pattern."""
@@ -618,7 +619,7 @@ class TestSlowTransactions:
         assert result["data"]["finding_count"] >= 1
         assert result["data"]["findings"][0]["category"] == "slow_query"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_hours(self, settings, auth_provider):
         """Queries include gs.hoursAgoStart time filter."""
@@ -642,7 +643,7 @@ class TestSlowTransactions:
         assert result["status"] == "success"
         assert result["data"]["params"]["hours"] == 12
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_default_hours_is_24(self, settings, auth_provider):
         """Default hours is 24 when not specified."""
@@ -672,7 +673,7 @@ class TestSlowTransactions:
 class TestPerformanceBottlenecks:
     """Tests for the performance_bottlenecks investigation module."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_heavy_automation_table(self, settings, auth_provider):
         """Finds a table with excessive active business rules."""
@@ -711,7 +712,7 @@ class TestPerformanceBottlenecks:
         assert result["data"]["finding_count"] >= 1
         assert result["data"]["findings"][0]["category"] == "heavy_automation"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_hours(self, settings, auth_provider):
         """Queries include time filter when hours is specified."""
@@ -731,7 +732,7 @@ class TestPerformanceBottlenecks:
         assert result["status"] == "success"
         assert result["data"]["params"]["hours"] == 12
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_no_hours_defaults_to_none(self, settings, auth_provider):
         """Hours defaults to None when not specified."""
@@ -758,7 +759,7 @@ class TestPerformanceBottlenecks:
 class TestExplainStaleAutomations:
     """Tests for stale_automations explain() — all four table branches."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_flow_context(self, settings, auth_provider):
         """explain() returns context for a stuck flow_context record."""
@@ -789,7 +790,7 @@ class TestExplainStaleAutomations:
         assert "Approval Flow" in result["data"]["explanation"]
         assert result["data"]["record"]["sys_id"] == "fc001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_sys_script(self, settings, auth_provider):
         """explain() returns context for a disabled business rule."""
@@ -818,7 +819,7 @@ class TestExplainStaleAutomations:
         assert "disabled" in result["data"]["explanation"].lower()
         assert "Old BR" in result["data"]["explanation"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_sys_script_include(self, settings, auth_provider):
         """explain() returns context for a disabled script include."""
@@ -847,7 +848,7 @@ class TestExplainStaleAutomations:
         assert "disabled" in result["data"]["explanation"].lower()
         assert "LegacyHelper" in result["data"]["explanation"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_sysauto_script(self, settings, auth_provider):
         """explain() returns context for a stale scheduled job."""
@@ -880,7 +881,7 @@ class TestExplainStaleAutomations:
 class TestExplainDeprecatedApis:
     """Tests for deprecated_apis explain()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_deprecated_script(self, settings, auth_provider):
         """explain() returns context for a script using deprecated APIs."""
@@ -914,7 +915,7 @@ class TestExplainDeprecatedApis:
 class TestExplainErrorAnalysis:
     """Tests for error_analysis explain()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_syslog_error(self, settings, auth_provider):
         """explain() returns context for a syslog error entry."""
@@ -949,7 +950,7 @@ class TestExplainErrorAnalysis:
 class TestExplainSlowTransactions:
     """Tests for slow_transactions explain()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_query_pattern(self, settings, auth_provider):
         """explain() returns context for a slow query pattern."""
@@ -984,7 +985,7 @@ class TestExplainSlowTransactions:
 class TestExplainPerformanceBottlenecks:
     """Tests for performance_bottlenecks explain() — both branches."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_table_with_colon(self, settings, auth_provider):
         """explain() with table:sys_id returns record context."""
@@ -1013,7 +1014,7 @@ class TestExplainPerformanceBottlenecks:
         assert "bottleneck" in result["data"]["explanation"].lower()
         assert result["data"]["record"]["sys_id"] == "sj001"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explain_invalid_table_identifier(self, settings, auth_provider):
         """explain() with an invalid table name in element_id returns an error."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1026,7 +1027,7 @@ class TestExplainPerformanceBottlenecks:
         assert result["status"] == "error"
         assert "Invalid identifier" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explain_denied_table(self, settings, auth_provider):
         """explain() with a denied table name in element_id returns an error."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1039,7 +1040,7 @@ class TestExplainPerformanceBottlenecks:
         assert result["status"] == "error"
         assert "denied" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_heavy_automation_table(self, settings, auth_provider):
         """explain() with a plain table name returns aggregate context."""
@@ -1084,7 +1085,7 @@ class TestExplainPerformanceBottlenecks:
 class TestExplainAclConflicts:
     """Tests for acl_conflicts explain()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_acl_record(self, settings, auth_provider):
         """explain() returns context for an ACL conflict finding."""
@@ -1124,7 +1125,7 @@ class TestExplainAclConflicts:
 class TestExplainTableHealth:
     """Tests for table_health explain()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_table_health(self, settings, auth_provider):
         """explain() returns aggregate context for a table."""
@@ -1154,7 +1155,7 @@ class TestExplainTableHealth:
 class TestExplainSecurityRestrictions:
     """Tests that explain() rejects element_ids referencing disallowed tables or invalid sys_ids."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_deprecated_apis_rejects_disallowed_table(self, settings, auth_provider):
         """deprecated_apis explain() returns error for a table not in _ALLOWED_TABLES."""
@@ -1169,7 +1170,7 @@ class TestExplainSecurityRestrictions:
         assert "error" in result["data"]
         assert "sys_user" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_error_analysis_rejects_non_syslog_table(self, settings, auth_provider):
         """error_analysis explain() returns error for a table other than syslog."""
@@ -1184,7 +1185,7 @@ class TestExplainSecurityRestrictions:
         assert "error" in result["data"]
         assert "incident" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_slow_transactions_rejects_disallowed_table(self, settings, auth_provider):
         """slow_transactions explain() returns error for a table not in PERFORMANCE_TABLES."""
@@ -1199,7 +1200,7 @@ class TestExplainSecurityRestrictions:
         assert "error" in result["data"]
         assert "sys_user" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_stale_automations_rejects_disallowed_table(self, settings, auth_provider):
         """stale_automations explain() returns error for a table not in _ALLOWED_TABLES."""
@@ -1214,7 +1215,7 @@ class TestExplainSecurityRestrictions:
         assert "error" in result["data"]
         assert "sys_user" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_sys_id_format(self, settings, auth_provider):
         """Any investigation rejects element_id with an invalid sys_id format."""
@@ -1235,7 +1236,7 @@ class TestExplainSecurityRestrictions:
 class TestExplainElementIdSplitGuard:
     """Tests that explain() returns an error dict for element_ids with no colon."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_deprecated_apis_no_colon(self, settings, auth_provider):
         """deprecated_apis explain() returns error for element_id without colon."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1249,7 +1250,7 @@ class TestExplainElementIdSplitGuard:
         assert "error" in result["data"]
         assert "expected 'table:sys_id'" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_error_analysis_no_colon(self, settings, auth_provider):
         """error_analysis explain() returns error for element_id without colon."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1263,7 +1264,7 @@ class TestExplainElementIdSplitGuard:
         assert "error" in result["data"]
         assert "expected 'table:sys_id'" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_slow_transactions_no_colon(self, settings, auth_provider):
         """slow_transactions explain() returns error for element_id without colon."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1277,7 +1278,7 @@ class TestExplainElementIdSplitGuard:
         assert "error" in result["data"]
         assert "expected 'table:sys_id'" in result["data"]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_stale_automations_no_colon(self, settings, auth_provider):
         """stale_automations explain() returns error for element_id without colon."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1298,7 +1299,7 @@ class TestExplainElementIdSplitGuard:
 class TestTypeCoercion:
     """Tests that numeric params passed as strings are properly coerced."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_slow_transactions_string_limit(self, settings, auth_provider):
         """slow_transactions run() accepts limit as a string."""
@@ -1324,7 +1325,7 @@ class TestTypeCoercion:
         assert result["status"] == "success"
         assert result["data"]["params"]["limit"] == 50
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_stale_automations_string_stale_days(self, settings, auth_provider):
         """stale_automations run() accepts stale_days as a string."""
@@ -1348,7 +1349,7 @@ class TestTypeCoercion:
         assert result["data"]["params"]["stale_days"] == 30
         assert result["data"]["params"]["limit"] == 10
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_performance_bottlenecks_string_hours_and_limit(self, settings, auth_provider):
         """performance_bottlenecks run() accepts hours and limit as strings."""
@@ -1372,7 +1373,7 @@ class TestTypeCoercion:
         assert result["data"]["params"]["hours"] == 12
         assert result["data"]["params"]["limit"] == 5
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_table_health_string_hours(self, settings, auth_provider):
         """table_health run() accepts hours as a string."""
@@ -1399,7 +1400,7 @@ class TestTypeCoercion:
         assert result["status"] == "success"
         assert result["data"]["hours"] == 48
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_deprecated_apis_string_limit(self, settings, auth_provider):
         """deprecated_apis run() accepts limit as a string."""
@@ -1423,7 +1424,7 @@ class TestTypeCoercion:
 class TestErrorAnalysisCheckTableAccess:
     """Tests that error_analysis run() calls check_table_access."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_check_table_access_propagates_through_dispatcher(self, settings, auth_provider):
         """error_analysis run() propagates PolicyError through the dispatcher."""
         from unittest.mock import patch
@@ -1449,7 +1450,7 @@ class TestErrorAnalysisCheckTableAccess:
 class TestPerformanceBottlenecksElseBranch:
     """Tests for performance_bottlenecks explain() else-branch (table name only)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explain_invalid_table_chars(self, settings, auth_provider):
         """explain() with invalid chars in table name raises ValueError."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1462,7 +1463,7 @@ class TestPerformanceBottlenecksElseBranch:
         assert result["status"] == "error"
         assert "Invalid identifier" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explain_special_chars_table(self, settings, auth_provider):
         """explain() with special chars in table name (no colon) raises ValueError."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1475,7 +1476,7 @@ class TestPerformanceBottlenecksElseBranch:
         assert result["status"] == "error"
         assert "Invalid identifier" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explain_denied_table_else_branch(self, settings, auth_provider):
         """explain() with a denied table name in the else-branch returns error."""
         tools = _register_and_get_tools(settings, auth_provider)
@@ -1495,7 +1496,7 @@ class TestPerformanceBottlenecksElseBranch:
 class TestPerformanceBottlenecksCoverage:
     """Tests for performance_bottlenecks coverage gaps: invalid params and non-empty loop bodies."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_params_and_nonempty_records(self, settings, auth_provider):
         """Invalid limit/hours fall back to defaults; non-empty sysauto_script and flow_context records hit loop bodies."""
@@ -1563,7 +1564,7 @@ class TestPerformanceBottlenecksCoverage:
 class TestStaleAutomationsCoverage:
     """Tests for stale_automations coverage gaps: invalid params and non-empty loop bodies."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_params_and_nonempty_records(self, settings, auth_provider):
         """Invalid stale_days/limit fall back to defaults; non-empty records hit loop bodies."""
@@ -1648,7 +1649,7 @@ class TestStaleAutomationsCoverage:
 class TestErrorAnalysisCoverage:
     """Tests for error_analysis coverage gaps: invalid params and source filter."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_hours_and_limit(self, settings, auth_provider):
         """Invalid hours/limit fall back to defaults."""
@@ -1669,7 +1670,7 @@ class TestErrorAnalysisCoverage:
         # Invalid limit falls back to 100 (lines 29-30)
         assert result["params"]["limit"] == 100
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_source_filter(self, settings, auth_provider):
         """Source filter triggers the .like() branch (line 36)."""
@@ -1692,7 +1693,7 @@ class TestErrorAnalysisCoverage:
 class TestDeprecatedApisCoverage:
     """Tests for deprecated_apis coverage gaps: invalid limit and code_search exception."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_limit(self, settings, auth_provider):
         """Invalid limit falls back to default 20."""
@@ -1711,7 +1712,7 @@ class TestDeprecatedApisCoverage:
         # Invalid limit falls back to 20 (lines 38-39)
         assert result["params"]["limit"] == 20
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_code_search_exception_skips_pattern(self, settings, auth_provider):
         """When code_search raises for one pattern, it's skipped (lines 56-58)."""
@@ -1743,7 +1744,7 @@ class TestDeprecatedApisCoverage:
 class TestSlowTransactionsCoverage:
     """Tests for slow_transactions coverage gaps."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_hours_and_limit(self, settings, auth_provider):
         """Invalid hours/limit fall back to defaults (lines 36-37, 40-41)."""
@@ -1771,7 +1772,7 @@ class TestSlowTransactionsCoverage:
         assert result["params"]["hours"] == 24
         assert result["params"]["limit"] == 20
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_categories_filter(self, settings, auth_provider):
         """Category filter skips non-matching tables (lines 45, 51)."""
@@ -1792,7 +1793,7 @@ class TestSlowTransactionsCoverage:
         # Only one table should have been queried (the rest skipped)
         assert result["investigation"] == "slow_transactions"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_query_records_exception_skips_table(self, settings, auth_provider):
         """When query_records raises for a table, it's skipped (lines 84-86)."""
@@ -1827,7 +1828,7 @@ class TestSlowTransactionsCoverage:
 class TestTableHealthCoverage:
     """Tests for table_health coverage gaps."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_missing_table_param(self, settings, auth_provider):
         """Missing table param returns error (line 23)."""
@@ -1842,7 +1843,7 @@ class TestTableHealthCoverage:
         assert result["error"] == "Missing required parameter: table"
         assert result["finding_count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_invalid_hours_param(self, settings, auth_provider):
         """Invalid hours falls back to 24 (lines 38-39)."""
@@ -1871,7 +1872,7 @@ class TestTableHealthCoverage:
 
         assert result["hours"] == 24
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_indicators_thresholds(self, settings, auth_provider):
         """Triggers all health indicator thresholds (lines 101, 103, 105)."""
@@ -1961,7 +1962,7 @@ class TestTableHealthCoverage:
 class TestPerformanceBottlenecksCheckTableAccess:
     """Tests that performance_bottlenecks run() calls check_table_access for each queried table."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_run_raises_on_denied_sys_script(self, settings, auth_provider):
         """run() raises PolicyError when sys_script is denied."""
         from unittest.mock import patch
@@ -1988,7 +1989,7 @@ class TestPerformanceBottlenecksCheckTableAccess:
 class TestSlowTransactionsCheckTableAccess:
     """Tests that slow_transactions run() calls check_table_access for each queried table."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_run_raises_on_denied_table(self, settings, auth_provider):
         """run() raises PolicyError when a performance pattern table is denied."""
         from unittest.mock import patch
@@ -2015,7 +2016,7 @@ class TestSlowTransactionsCheckTableAccess:
 class TestStaleAutomationsCheckTableAccess:
     """Tests that stale_automations run() calls check_table_access for each queried table."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_run_raises_on_denied_flow_context(self, settings, auth_provider):
         """run() raises PolicyError when flow_context is denied."""
         from unittest.mock import patch
@@ -2042,7 +2043,7 @@ class TestStaleAutomationsCheckTableAccess:
 class TestTableHealthExplainCheckTableAccess:
     """Tests that table_health explain() calls check_table_access."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explain_raises_on_denied_table(self, settings, auth_provider):
         """explain() raises PolicyError when the element_id table is denied."""
         from unittest.mock import patch
@@ -2071,7 +2072,7 @@ class TestTableHealthExplainCheckTableAccess:
 class TestClampingMinimumOne:
     """Tests that hours/stale_days are clamped to a minimum of 1."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_error_analysis_clamps_hours_zero_to_one(self, settings, auth_provider):
         """error_analysis run() with hours=0 clamps to 1."""
@@ -2094,7 +2095,7 @@ class TestClampingMinimumOne:
         request_url = unquote(str(route.calls[0].request.url))
         assert "javascript:gs.hoursAgoStart(1)" in request_url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_slow_transactions_clamps_hours_zero_to_one(self, settings, auth_provider):
         """slow_transactions run() with hours=0 clamps to 1."""
@@ -2127,7 +2128,7 @@ class TestClampingMinimumOne:
         cancellation_url = unquote(str(routes["syslog_cancellation"].calls[0].request.url))
         assert "javascript:gs.hoursAgoStart(1)" in cancellation_url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_stale_automations_clamps_stale_days_zero_to_one(self, settings, auth_provider):
         """stale_automations run() with stale_days=0 clamps to 1."""
@@ -2159,7 +2160,7 @@ class TestClampingMinimumOne:
         flow_url = unquote(str(flow_route.calls[0].request.url))
         assert "javascript:gs.daysAgoEnd(1)" in flow_url
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_performance_bottlenecks_clamps_negative_hours_to_one(self, settings, auth_provider):
         """performance_bottlenecks run() with hours=-5 clamps to 1."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,6 +10,7 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.state import QueryTokenStore
 
+
 BASE_URL = "https://test.service-now.com"
 
 # Artifact type → ServiceNow table mapping (must match implementation)
@@ -34,7 +35,7 @@ SCRIPT_TABLES = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -56,7 +57,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestMetaListArtifacts:
     """Tests for the meta_list_artifacts tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_lists_artifacts_by_type(self, settings, auth_provider):
         """Lists artifacts filtered by type (e.g., business_rule)."""
@@ -92,7 +93,7 @@ class TestMetaListArtifacts:
         assert result["data"]["artifacts"][0]["name"] == "Set Priority"
         assert result["data"]["artifact_type"] == "business_rule"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_lists_artifacts_with_query_filter(self, settings, auth_provider):
         """Filters artifacts by a user-provided query string."""
@@ -121,7 +122,7 @@ class TestMetaListArtifacts:
         assert result["status"] == "success"
         assert len(result["data"]["artifacts"]) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_unknown_type_returns_error(self, settings, auth_provider):
         """Unknown artifact type returns an error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
@@ -131,7 +132,7 @@ class TestMetaListArtifacts:
         assert result["status"] == "error"
         assert "unknown" in result["error"]["message"].lower() or "type" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_includes_correlation_id(self, settings, auth_provider):
         """Response always contains a correlation_id."""
@@ -150,7 +151,7 @@ class TestMetaListArtifacts:
         assert "correlation_id" in result
         assert len(result["correlation_id"]) > 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_meta_list_artifacts_limit_capped(self, settings, auth_provider):
         """Limit exceeding max_row_limit is capped via enforce_query_safety."""
@@ -181,7 +182,7 @@ class TestMetaListArtifacts:
 class TestMetaGetArtifact:
     """Tests for the meta_get_artifact tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_full_artifact(self, settings, auth_provider):
         """Returns full artifact details including script body."""
@@ -209,7 +210,7 @@ class TestMetaGetArtifact:
         assert result["data"]["sys_id"] == "br1"
         assert result["data"]["script"] == "current.priority = 1;"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_not_found_returns_error(self, settings, auth_provider):
         """404 from ServiceNow produces an error response."""
@@ -227,7 +228,7 @@ class TestMetaGetArtifact:
 class TestMetaFindReferences:
     """Tests for the meta_find_references tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_uses_code_search_api_when_available(self, settings, auth_provider):
         """Prefers Code Search API and returns results from it."""
@@ -258,7 +259,7 @@ class TestMetaFindReferences:
         assert len(result["data"]["matches"]) >= 1
         assert result["data"]["search_method"] == "code_search_api"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_falls_back_to_table_search(self, settings, auth_provider):
         """Falls back to per-table scriptCONTAINS when Code Search API fails."""
@@ -304,7 +305,7 @@ class TestMetaFindReferences:
         tables_found = [m["table"] for m in result["data"]["matches"]]
         assert "sys_script" in tables_found
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_no_references_found(self, settings, auth_provider):
         """Returns empty matches when target string is not found anywhere."""
@@ -323,7 +324,7 @@ class TestMetaFindReferences:
         assert result["status"] == "success"
         assert result["data"]["matches"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_meta_find_references_limit_capped(self, settings, auth_provider):
         """Limit exceeding max_row_limit is capped in fallback per-table queries."""
@@ -360,7 +361,7 @@ class TestMetaFindReferences:
             qs = parse_qs(parsed.query)
             assert qs["sysparm_limit"] == [str(settings.max_row_limit)], f"Table '{table}' should have capped limit"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_caret_in_target_single_sanitized(self, settings, auth_provider):
         """Target with carets is single-sanitized (^ → ^^) in fallback CONTAINS queries."""
@@ -400,7 +401,7 @@ class TestMetaFindReferences:
 class TestMetaWhatWrites:
     """Tests for the meta_what_writes tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_business_rules_writing_to_table(self, settings, auth_provider):
         """Finds business rules that write to the specified table."""
@@ -433,7 +434,7 @@ class TestMetaWhatWrites:
         assert result["data"]["writers"][0]["name"] == "Set Priority"
         assert result["data"]["table"] == "incident"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_field(self, settings, auth_provider):
         """When field is specified, filters business rules whose script references the field."""
@@ -475,7 +476,7 @@ class TestMetaWhatWrites:
         assert len(writers) == 1
         assert writers[0]["name"] == "Set Priority"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_no_writers_found(self, settings, auth_provider):
         """Returns empty writers when no BRs write to the table."""

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -89,7 +89,11 @@ class TestSensitiveFieldMasking:
         """Non-sensitive fields are not modified."""
         from servicenow_mcp.policy import mask_sensitive_fields
 
-        record = {"sys_id": "123", "short_description": "Test", "number": "INC001"}
+        record = {
+            "sys_id": "123",
+            "short_description": "Test",
+            "number": "INC001",
+        }
         masked = mask_sensitive_fields(record)
 
         assert masked == record
@@ -244,7 +248,12 @@ class TestQuerySafety:
         from servicenow_mcp.policy import enforce_query_safety
 
         with pytest.raises(QuerySafetyError, match="date"):
-            enforce_query_safety("syslog", "description=sys_created_on", limit=50, settings=settings)
+            enforce_query_safety(
+                "syslog",
+                "description=sys_created_on",
+                limit=50,
+                settings=settings,
+            )
 
     def test_date_filter_with_operator_passes(self, settings):
         """Date field with a comparison operator passes the check."""

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -116,12 +116,27 @@ class TestRelReferencesTo:
 
         # Build two pages: first page has exactly page_size entries, second has 2
         page1_fields = [
-            {"name": f"table_p1_{i}", "element": "ref_field", "reference": "sys_user", "column_label": f"Ref {i}"}
+            {
+                "name": f"table_p1_{i}",
+                "element": "ref_field",
+                "reference": "sys_user",
+                "column_label": f"Ref {i}",
+            }
             for i in range(page_size)
         ]
         page2_fields = [
-            {"name": "task", "element": "assigned_to", "reference": "sys_user", "column_label": "Assigned to"},
-            {"name": "task", "element": "opened_by", "reference": "sys_user", "column_label": "Opened by"},
+            {
+                "name": "task",
+                "element": "assigned_to",
+                "reference": "sys_user",
+                "column_label": "Assigned to",
+            },
+            {
+                "name": "task",
+                "element": "opened_by",
+                "reference": "sys_user",
+                "column_label": "Opened by",
+            },
         ]
 
         dict_route = respx.get(f"{BASE_URL}/api/now/table/sys_dictionary")
@@ -185,7 +200,12 @@ class TestRelReferencesTo:
                 json={
                     "result": [
                         # Denied table entry - should be skipped
-                        {"name": denied, "element": "user", "reference": "sys_user", "column_label": "User"},
+                        {
+                            "name": denied,
+                            "element": "user",
+                            "reference": "sys_user",
+                            "column_label": "User",
+                        },
                         # var__m_ internal entry - should be skipped
                         {
                             "name": "var__m_some_table",
@@ -489,7 +509,14 @@ class TestRelReferencesToBoundedConcurrency:
     async def test_rel_references_to_bounded_concurrency(self, settings, auth_provider):
         """Verifies that rel_references_to uses a Semaphore to bound concurrent lookups."""
         # Mock sys_dictionary to return many reference fields
-        ref_fields = [{"name": f"table_{i}", "element": "ref_field", "column_label": f"Ref {i}"} for i in range(15)]
+        ref_fields = [
+            {
+                "name": f"table_{i}",
+                "element": "ref_field",
+                "column_label": f"Ref {i}",
+            }
+            for i in range(15)
+        ]
         respx.get(f"{BASE_URL}/api/now/table/sys_dictionary").mock(
             return_value=httpx.Response(
                 200,
@@ -522,7 +549,10 @@ class TestRelReferencesToBoundedConcurrency:
                 self.enter_count += 1
                 await super().__aenter__()
 
-        with patch("servicenow_mcp.tools.relationships.asyncio.Semaphore", TrackingSemaphore):
+        with patch(
+            "servicenow_mcp.tools.relationships.asyncio.Semaphore",
+            TrackingSemaphore,
+        ):
             tools = _register_and_get_tools(settings, auth_provider)
             raw = await tools["rel_references_to"](table="incident", sys_id="abc123")
             result = toon_decode(raw)

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -12,10 +12,11 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.policy import DENIED_TABLES
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -35,7 +36,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestRelReferencesTo:
     """Tests for the rel_references_to tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_incoming_references(self, settings, auth_provider):
         """Finds records in other tables that reference the target record."""
@@ -78,7 +79,7 @@ class TestRelReferencesTo:
         assert len(result["data"]["incoming_references"]) == 1
         assert result["data"]["incoming_references"][0]["table"] == "task_sla"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_no_references(self, settings, auth_provider):
         """Returns empty incoming_references when no references exist."""
@@ -97,7 +98,7 @@ class TestRelReferencesTo:
         assert result["status"] == "success"
         assert result["data"]["incoming_references"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Denied table returns error without making HTTP call."""
         denied = next(iter(DENIED_TABLES))
@@ -108,7 +109,7 @@ class TestRelReferencesTo:
         assert result["status"] == "error"
         assert "denied" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_paginates_all_dictionary_entries(self, settings, auth_provider):
         """Paginated sys_dictionary fetches collect fields across all pages."""
@@ -189,7 +190,7 @@ class TestRelReferencesTo:
         # Verify that two sys_dictionary pages were fetched
         assert dict_route.call_count == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_denied_and_internal_tables(self, settings, auth_provider):
         """Denied tables and system-internal var__m_ entries are skipped."""
@@ -257,7 +258,7 @@ class TestRelReferencesTo:
 class TestRelReferencesFrom:
     """Tests for the rel_references_from tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_outgoing_references(self, settings, auth_provider):
         """Finds what a record references via its reference fields."""
@@ -317,7 +318,7 @@ class TestRelReferencesFrom:
         assert "caller_id" in fields
         assert "assignment_group" in fields
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_finds_inherited_reference_fields(self, settings, auth_provider):
         """Inherited reference fields from parent tables are included."""
@@ -404,7 +405,7 @@ class TestRelReferencesFrom:
         assert "opened_by" in fields
         assert len(outgoing) == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_hierarchy_stops_at_root(self, settings, auth_provider):
         """Hierarchy walk terminates when there is no super_class."""
@@ -456,7 +457,7 @@ class TestRelReferencesFrom:
         # Only one sys_db_object query should have been made (for "task" itself)
         # and it stopped immediately since super_class was empty
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_no_reference_fields(self, settings, auth_provider):
         """Returns empty outgoing_references when record has no reference fields."""
@@ -489,7 +490,7 @@ class TestRelReferencesFrom:
         assert result["status"] == "success"
         assert result["data"]["outgoing_references"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_denied_table_returns_error(self, settings, auth_provider):
         """Denied table returns error."""
         denied = next(iter(DENIED_TABLES))
@@ -504,7 +505,7 @@ class TestRelReferencesFrom:
 class TestRelReferencesToBoundedConcurrency:
     """Tests that rel_references_to limits concurrency via asyncio.Semaphore."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_rel_references_to_bounded_concurrency(self, settings, auth_provider):
         """Verifies that rel_references_to uses a Semaphore to bound concurrent lookups."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -20,7 +20,11 @@ class TestPreviewTokenStore:
     def test_get_returns_stored_payload(self):
         """get() returns the payload stored for a valid token."""
         store = PreviewTokenStore(ttl_seconds=300)
-        payload = {"table": "incident", "sys_id": "abc", "changes": {"state": "2"}}
+        payload = {
+            "table": "incident",
+            "sys_id": "abc",
+            "changes": {"state": "2"},
+        }
         token = store.create(payload)
         result = store.get(token)
         assert result is not None
@@ -36,7 +40,10 @@ class TestPreviewTokenStore:
     def test_get_returns_none_for_expired_token(self):
         """get() returns None for a token that has expired (mocked clock)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = PreviewTokenStore(ttl_seconds=60)
             token = store.create({"table": "incident"})
 
@@ -62,7 +69,10 @@ class TestPreviewTokenStore:
     def test_consume_returns_none_for_expired_token(self):
         """consume() returns None for an expired token (mocked clock)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = PreviewTokenStore(ttl_seconds=60)
             token = store.create({"table": "incident"})
 
@@ -75,7 +85,10 @@ class TestPreviewTokenStore:
     def test_get_returns_payload_before_ttl_expires(self):
         """get() returns the payload when the TTL has not yet expired (mocked clock)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = PreviewTokenStore(ttl_seconds=60)
             token = store.create({"table": "incident", "key": "value"})
 
@@ -89,7 +102,10 @@ class TestPreviewTokenStore:
     def test_consume_at_exact_boundary(self):
         """consume() at exact TTL boundary is NOT expired (uses > not >=)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = PreviewTokenStore(ttl_seconds=60)
             token = store.create({"table": "incident"})
 
@@ -171,7 +187,10 @@ class TestQueryTokenStore:
     def test_get_returns_none_for_expired_token(self):
         """get() returns None for a token that has expired (mocked clock)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = QueryTokenStore(ttl_seconds=60)
             token = store.create({"query": "active=true"})
 
@@ -200,7 +219,10 @@ class TestQueryTokenStore:
     def test_get_returns_payload_before_ttl_expires(self):
         """get() returns the payload when the TTL has not yet expired (mocked clock)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = QueryTokenStore(ttl_seconds=60)
             token = store.create({"query": "active=true"})
 
@@ -214,7 +236,10 @@ class TestQueryTokenStore:
     def test_get_at_exact_boundary(self):
         """get() at exact TTL boundary is NOT expired (uses > not >=)."""
         fake_time = 1000.0
-        with patch("servicenow_mcp.state.time.monotonic", side_effect=lambda: fake_time):
+        with patch(
+            "servicenow_mcp.state.time.monotonic",
+            side_effect=lambda: fake_time,
+        ):
             store = QueryTokenStore(ttl_seconds=60)
             token = store.create({"query": "active=true"})
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -545,7 +545,12 @@ class TestAtfRunTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_test"](test_id="test_long", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_test"](
+            test_id="test_long",
+            poll=True,
+            poll_interval=2,
+            max_poll_duration=10,
+        )
         result = toon_decode(raw)
 
         assert result["status"] == "success"
@@ -572,7 +577,12 @@ class TestAtfRunTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_test"](test_id="test_fail", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_test"](
+            test_id="test_fail",
+            poll=True,
+            poll_interval=2,
+            max_poll_duration=10,
+        )
         result = toon_decode(raw)
 
         assert result["status"] == "success"
@@ -601,7 +611,12 @@ class TestAtfRunSuite:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_suite"](suite_id="suite789", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_suite"](
+            suite_id="suite789",
+            poll=True,
+            poll_interval=2,
+            max_poll_duration=10,
+        )
         result = toon_decode(raw)
 
         assert result["status"] == "success"
@@ -684,7 +699,12 @@ class TestAtfRunSuite:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_suite"](suite_id="suite_long", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_suite"](
+            suite_id="suite_long",
+            poll=True,
+            poll_interval=2,
+            max_poll_duration=10,
+        )
         result = toon_decode(raw)
 
         assert result["status"] == "success"
@@ -712,7 +732,12 @@ class TestAtfRunSuite:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_suite"](suite_id="suite_cancel", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_suite"](
+            suite_id="suite_cancel",
+            poll=True,
+            poll_interval=2,
+            max_poll_duration=10,
+        )
         result = toon_decode(raw)
 
         assert result["status"] == "success"
@@ -732,7 +757,11 @@ class TestAtfTestHealth:
                 200,
                 json={
                     "result": [
-                        {"sys_id": f"res{i}", "status": "success", "sys_created_on": f"2026-02-{i + 1:02d} 10:00:00"}
+                        {
+                            "sys_id": f"res{i}",
+                            "status": "success",
+                            "sys_created_on": f"2026-02-{i + 1:02d} 10:00:00",
+                        }
                         for i in range(10)
                     ]
                 },
@@ -789,14 +818,46 @@ class TestAtfTestHealth:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "r1", "status": "success", "sys_created_on": "2026-02-01 10:00:00"},
-                        {"sys_id": "r2", "status": "success", "sys_created_on": "2026-02-02 10:00:00"},
-                        {"sys_id": "r3", "status": "success", "sys_created_on": "2026-02-03 10:00:00"},
-                        {"sys_id": "r4", "status": "success", "sys_created_on": "2026-02-04 10:00:00"},
-                        {"sys_id": "r5", "status": "failure", "sys_created_on": "2026-02-05 10:00:00"},
-                        {"sys_id": "r6", "status": "failure", "sys_created_on": "2026-02-06 10:00:00"},
-                        {"sys_id": "r7", "status": "failure", "sys_created_on": "2026-02-07 10:00:00"},
-                        {"sys_id": "r8", "status": "failure", "sys_created_on": "2026-02-08 10:00:00"},
+                        {
+                            "sys_id": "r1",
+                            "status": "success",
+                            "sys_created_on": "2026-02-01 10:00:00",
+                        },
+                        {
+                            "sys_id": "r2",
+                            "status": "success",
+                            "sys_created_on": "2026-02-02 10:00:00",
+                        },
+                        {
+                            "sys_id": "r3",
+                            "status": "success",
+                            "sys_created_on": "2026-02-03 10:00:00",
+                        },
+                        {
+                            "sys_id": "r4",
+                            "status": "success",
+                            "sys_created_on": "2026-02-04 10:00:00",
+                        },
+                        {
+                            "sys_id": "r5",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-05 10:00:00",
+                        },
+                        {
+                            "sys_id": "r6",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-06 10:00:00",
+                        },
+                        {
+                            "sys_id": "r7",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-07 10:00:00",
+                        },
+                        {
+                            "sys_id": "r8",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-08 10:00:00",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "8"},
@@ -851,7 +912,9 @@ class TestAtfTestHealth:
         result = toon_decode(raw)
 
         assert result["status"] == "error"
-        assert "exactly one" in result["error"]["message"].lower() and "not both" in result["error"]["message"].lower()
+        error_msg = result["error"]["message"].lower()
+        assert "exactly one" in error_msg
+        assert "not both" in error_msg
 
     @pytest.mark.asyncio
     @respx.mock
@@ -862,14 +925,46 @@ class TestAtfTestHealth:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "r1", "status": "failure", "sys_created_on": "2026-02-01 10:00:00"},
-                        {"sys_id": "r2", "status": "failure", "sys_created_on": "2026-02-02 10:00:00"},
-                        {"sys_id": "r3", "status": "failure", "sys_created_on": "2026-02-03 10:00:00"},
-                        {"sys_id": "r4", "status": "failure", "sys_created_on": "2026-02-04 10:00:00"},
-                        {"sys_id": "r5", "status": "success", "sys_created_on": "2026-02-05 10:00:00"},
-                        {"sys_id": "r6", "status": "success", "sys_created_on": "2026-02-06 10:00:00"},
-                        {"sys_id": "r7", "status": "success", "sys_created_on": "2026-02-07 10:00:00"},
-                        {"sys_id": "r8", "status": "success", "sys_created_on": "2026-02-08 10:00:00"},
+                        {
+                            "sys_id": "r1",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-01 10:00:00",
+                        },
+                        {
+                            "sys_id": "r2",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-02 10:00:00",
+                        },
+                        {
+                            "sys_id": "r3",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-03 10:00:00",
+                        },
+                        {
+                            "sys_id": "r4",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-04 10:00:00",
+                        },
+                        {
+                            "sys_id": "r5",
+                            "status": "success",
+                            "sys_created_on": "2026-02-05 10:00:00",
+                        },
+                        {
+                            "sys_id": "r6",
+                            "status": "success",
+                            "sys_created_on": "2026-02-06 10:00:00",
+                        },
+                        {
+                            "sys_id": "r7",
+                            "status": "success",
+                            "sys_created_on": "2026-02-07 10:00:00",
+                        },
+                        {
+                            "sys_id": "r8",
+                            "status": "success",
+                            "sys_created_on": "2026-02-08 10:00:00",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "8"},
@@ -893,8 +988,16 @@ class TestAtfTestHealth:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "r1", "status": "success", "sys_created_on": "2026-02-01 10:00:00"},
-                        {"sys_id": "r2", "status": "failure", "sys_created_on": "2026-02-02 10:00:00"},
+                        {
+                            "sys_id": "r1",
+                            "status": "success",
+                            "sys_created_on": "2026-02-01 10:00:00",
+                        },
+                        {
+                            "sys_id": "r2",
+                            "status": "failure",
+                            "sys_created_on": "2026-02-02 10:00:00",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "2"},

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -10,10 +10,11 @@ from toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.state import QueryTokenStore
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -35,7 +36,7 @@ def _register_and_get_tools(settings, auth_provider):
 class TestAtfListTests:
     """Tests for the atf_list_tests tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_tests_success(self, settings, auth_provider):
         """Returns ATF tests with expected fields."""
@@ -75,7 +76,7 @@ class TestAtfListTests:
         assert result["data"]["records"][0]["sys_id"] == "test1"
         assert result["data"]["records"][1]["sys_id"] == "test2"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_tests_with_query(self, settings, auth_provider):
         """Verify custom query param is passed through to API call."""
@@ -108,7 +109,7 @@ class TestAtfListTests:
         request = route.calls.last.request
         assert "active=true" in unquote(str(request.url))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_tests_empty_results(self, settings, auth_provider):
         """Returns success with empty data when no tests found."""
@@ -132,7 +133,7 @@ class TestAtfListTests:
 class TestAtfGetTest:
     """Tests for the atf_get_test tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_test_success(self, settings, auth_provider):
         """Returns test record and steps in combined response."""
@@ -185,7 +186,7 @@ class TestAtfGetTest:
         assert result["data"]["step_count"] == 2
         assert len(result["data"]["steps"]) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_test_not_found(self, settings, auth_provider):
         """Returns error envelope when test not found."""
@@ -202,7 +203,7 @@ class TestAtfGetTest:
 
         assert result["status"] == "error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_test_with_steps(self, settings, auth_provider):
         """Returns test with 3 steps ordered correctly."""
@@ -265,7 +266,7 @@ class TestAtfGetTest:
 class TestAtfListSuites:
     """Tests for the atf_list_suites tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_suites_success(self, settings, auth_provider):
         """Returns suites with member counts."""
@@ -304,7 +305,7 @@ class TestAtfListSuites:
         assert result["data"]["suites"][0]["sys_id"] == "suite1"
         assert result["data"]["suites"][0]["member_count"] == "5"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_list_suites_empty(self, settings, auth_provider):
         """Returns success with empty data when no suites found."""
@@ -328,7 +329,7 @@ class TestAtfListSuites:
 class TestAtfGetResults:
     """Tests for the atf_get_results tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_results_for_test(self, settings, auth_provider):
         """Returns test results from sys_atf_test_result table."""
@@ -361,7 +362,7 @@ class TestAtfGetResults:
         assert result["data"]["result_count"] == 1
         assert result["data"]["results"][0]["status"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_results_for_suite(self, settings, auth_provider):
         """Returns suite results from sys_atf_test_suite_result table."""
@@ -395,7 +396,7 @@ class TestAtfGetResults:
         assert result["data"]["result_count"] == 1
         assert result["data"]["results"][0]["status"] == "failure"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_results_both_ids_provided(self, settings, auth_provider):
         """Returns error when both test_id and suite_id are provided."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
@@ -405,7 +406,7 @@ class TestAtfGetResults:
         assert result["status"] == "error"
         assert "not both" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_results_missing_both_ids(self, settings, auth_provider):
         """Returns error when neither test_id nor suite_id provided."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
@@ -415,7 +416,7 @@ class TestAtfGetResults:
         assert result["status"] == "error"
         assert "exactly one" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_get_results_empty(self, settings, auth_provider):
         """Returns success with empty results when no results found."""
@@ -439,7 +440,7 @@ class TestAtfGetResults:
 class TestAtfRunTest:
     """Tests for the atf_run_test tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_test_success_with_poll(self, settings, auth_provider):
         """Mock run + progress endpoints. Returns completed status with execution ID."""
@@ -468,7 +469,7 @@ class TestAtfRunTest:
         assert result["data"]["progress"] == 100
         assert result["data"]["test_id"] == "test456"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_test_no_poll(self, settings, auth_provider):
         """Call with poll=False. Returns immediately with execution ID."""
@@ -489,7 +490,7 @@ class TestAtfRunTest:
         assert result["data"]["polling"] is False
         assert result["data"]["test_id"] == "test999"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_run_test_write_gate_blocks(self, prod_settings):
         """Write gate blocks execution in production environment."""
         from mcp.server.fastmcp import FastMCP
@@ -508,7 +509,7 @@ class TestAtfRunTest:
         assert result["status"] == "error"
         assert "production" in result["error"]["message"].lower() or "blocked" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_test_no_execution_id(self, settings, auth_provider):
         """Returns error when ATF run does not return an execution ID."""
@@ -526,7 +527,7 @@ class TestAtfRunTest:
         assert result["status"] == "error"
         assert "no execution id" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_test_timeout(self, settings, auth_provider):
         """Mock progress endpoint always returning In Progress. Assert timeout."""
@@ -559,7 +560,7 @@ class TestAtfRunTest:
         assert result["data"]["last_known_state"] == "in progress"
         assert "warnings" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_test_failed_execution(self, settings, auth_provider):
         """Mock progress returning Failure status. Assert failure captured."""
@@ -593,7 +594,7 @@ class TestAtfRunTest:
 class TestAtfRunSuite:
     """Tests for the atf_run_suite tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_suite_success_with_poll(self, settings, auth_provider):
         """Mock run + progress. Returns completed status."""
@@ -624,7 +625,7 @@ class TestAtfRunSuite:
         assert result["data"]["status"] == "completed"
         assert result["data"]["suite_id"] == "suite789"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_suite_no_poll(self, settings, auth_provider):
         """Call with poll=False. Returns immediately."""
@@ -644,7 +645,7 @@ class TestAtfRunSuite:
         assert result["data"]["status"] == "started"
         assert result["data"]["polling"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_run_suite_write_gate_blocks(self, prod_settings):
         """Write gate blocks suite execution in production."""
         from mcp.server.fastmcp import FastMCP
@@ -663,7 +664,7 @@ class TestAtfRunSuite:
         assert result["status"] == "error"
         assert "production" in result["error"]["message"].lower() or "blocked" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_suite_no_execution_id(self, settings, auth_provider):
         """Returns error when ATF suite run does not return an execution ID."""
@@ -681,7 +682,7 @@ class TestAtfRunSuite:
         assert result["status"] == "error"
         assert "no execution id" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_suite_timeout(self, settings, auth_provider):
         """Mock progress always returning In Progress. Assert timeout with warnings."""
@@ -714,7 +715,7 @@ class TestAtfRunSuite:
         assert result["data"]["last_known_state"] == "in progress"
         assert "warnings" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_run_suite_cancelled(self, settings, auth_provider):
         """Mock progress returning Cancelled. Assert captured in response."""
@@ -748,7 +749,7 @@ class TestAtfRunSuite:
 class TestAtfTestHealth:
     """Tests for the atf_test_health tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_all_passing(self, settings, auth_provider):
         """Mock 10 results all passed. Assert 100% pass rate, not flaky."""
@@ -780,7 +781,7 @@ class TestAtfTestHealth:
         assert result["data"]["pass_rate"] == 1.0
         assert result["data"]["flaky"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_flaky_detection(self, settings, auth_provider):
         """Mock alternating pass/fail pattern. Assert flaky=true."""
@@ -809,7 +810,7 @@ class TestAtfTestHealth:
         assert result["data"]["flaky"] is True
         assert result["data"]["transition_count"] >= 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_trending_downward(self, settings, auth_provider):
         """Mock recent failures after earlier passes. Assert trend degrading."""
@@ -872,7 +873,7 @@ class TestAtfTestHealth:
         assert result["data"]["recent_trend"] == "degrading"
         assert result["data"]["pass_rate"] == 0.5
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_no_results(self, settings, auth_provider):
         """Mock empty results. Assert appropriate zero-state response."""
@@ -894,7 +895,7 @@ class TestAtfTestHealth:
         assert result["data"]["recent_trend"] == "no_data"
         assert "warnings" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_health_missing_both_ids(self, settings, auth_provider):
         """Call with neither test_id nor suite_id. Assert error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
@@ -904,7 +905,7 @@ class TestAtfTestHealth:
         assert result["status"] == "error"
         assert "exactly one" in result["error"]["message"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_health_both_ids_provided(self, settings, auth_provider):
         """Call with both test_id and suite_id. Assert error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
@@ -916,7 +917,7 @@ class TestAtfTestHealth:
         assert "exactly one" in error_msg
         assert "not both" in error_msg
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_trending_upward(self, settings, auth_provider):
         """Mock early failures then later passes. Assert trend improving."""
@@ -979,7 +980,7 @@ class TestAtfTestHealth:
         assert result["data"]["recent_trend"] == "improving"
         assert result["data"]["pass_rate"] == 0.5
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_insufficient_data_trend(self, settings, auth_provider):
         """Mock fewer than 4 runs. Assert trend is insufficient_data."""
@@ -1012,7 +1013,7 @@ class TestAtfTestHealth:
         assert result["data"]["total_runs"] == 2
         assert result["data"]["recent_trend"] == "insufficient_data"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_health_for_suite(self, settings, auth_provider):
         """Mock suite results. Assert rolled-up metrics computed."""

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -59,7 +59,11 @@ class TestBuildQuery:
         conditions = json.dumps(
             [
                 {"operator": "equals", "field": "active", "value": "true"},
-                {"operator": "hours_ago", "field": "sys_created_on", "value": 24},
+                {
+                    "operator": "hours_ago",
+                    "field": "sys_created_on",
+                    "value": 24,
+                },
                 {"operator": "like", "field": "source", "value": "incident"},
             ]
         )
@@ -172,7 +176,11 @@ class TestBuildQuery:
         conditions = json.dumps(
             [
                 {"operator": "starts_with", "field": "name", "value": "INC"},
-                {"operator": "or_starts_with", "field": "name", "value": "REQ"},
+                {
+                    "operator": "or_starts_with",
+                    "field": "name",
+                    "value": "REQ",
+                },
             ]
         )
         raw = tools["build_query"](conditions=conditions)
@@ -186,7 +194,11 @@ class TestBuildQuery:
         tools = _register_and_get_tools(settings, auth_provider)
         conditions = json.dumps(
             [
-                {"operator": "in_list", "field": "state", "value": ["1", "2", "3"]},
+                {
+                    "operator": "in_list",
+                    "field": "state",
+                    "value": ["1", "2", "3"],
+                },
             ]
         )
         raw = tools["build_query"](conditions=conditions)
@@ -200,7 +212,11 @@ class TestBuildQuery:
         tools = _register_and_get_tools(settings, auth_provider)
         conditions = json.dumps(
             [
-                {"operator": "not_in_list", "field": "priority", "value": ["4", "5"]},
+                {
+                    "operator": "not_in_list",
+                    "field": "priority",
+                    "value": ["4", "5"],
+                },
             ]
         )
         raw = tools["build_query"](conditions=conditions)
@@ -243,7 +259,11 @@ class TestBuildQuery:
         conditions = json.dumps(
             [
                 {"operator": "equals", "field": "active", "value": "true"},
-                {"operator": "order_by", "field": "sys_created_on", "descending": True},
+                {
+                    "operator": "order_by",
+                    "field": "sys_created_on",
+                    "descending": True,
+                },
             ]
         )
         raw = tools["build_query"](conditions=conditions)
@@ -282,7 +302,10 @@ class TestBuildQuery:
         from unittest.mock import patch
 
         tools = _register_and_get_tools(settings, auth_provider)
-        with patch("servicenow_mcp.tools.utility.ServiceNowQuery", side_effect=RuntimeError("boom")):
+        with patch(
+            "servicenow_mcp.tools.utility.ServiceNowQuery",
+            side_effect=RuntimeError("boom"),
+        ):
             raw = tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
         result = toon_decode(raw)
         assert result["status"] == "error"
@@ -525,7 +548,12 @@ class TestBuildQuery:
         tools = _register_and_get_tools(settings, auth_provider)
         conditions = json.dumps(
             [
-                {"operator": "rl_query", "field": "state", "rl_operator": "=", "value": "2"},
+                {
+                    "operator": "rl_query",
+                    "field": "state",
+                    "rl_operator": "=",
+                    "value": "2",
+                },
             ]
         )
         raw = tools["build_query"](conditions=conditions)

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -9,7 +9,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.state import QueryTokenStore
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,14 +98,20 @@ class TestSerialize:
 
     def test_serialize_falls_back_to_json_on_toon_failure(self):
         """When toon_encode raises, serialize falls back to json.dumps."""
-        with patch("servicenow_mcp.utils.toon_encode", side_effect=TypeError("unsupported type")):
+        with patch(
+            "servicenow_mcp.utils.toon_encode",
+            side_effect=TypeError("unsupported type"),
+        ):
             result = serialize({"key": "value"})
         parsed = json.loads(result)
         assert parsed["key"] == "value"
 
     def test_serialize_fallback_json_is_indented(self):
         """The JSON fallback uses indent=2."""
-        with patch("servicenow_mcp.utils.toon_encode", side_effect=RuntimeError("boom")):
+        with patch(
+            "servicenow_mcp.utils.toon_encode",
+            side_effect=RuntimeError("boom"),
+        ):
             result = serialize({"a": 1})
         # indent=2 means the output should have newlines and spaces
         assert "\n" in result

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -377,9 +377,24 @@ class TestWorkflowMap:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "a1", "name": "First", "x": "10", "y": "50"},
-                        {"sys_id": "a2", "name": "Second", "x": "200", "y": "50"},
-                        {"sys_id": "a3", "name": "Third", "x": "400", "y": "50"},
+                        {
+                            "sys_id": "a1",
+                            "name": "First",
+                            "x": "10",
+                            "y": "50",
+                        },
+                        {
+                            "sys_id": "a2",
+                            "name": "Second",
+                            "x": "200",
+                            "y": "50",
+                        },
+                        {
+                            "sys_id": "a3",
+                            "name": "Third",
+                            "x": "400",
+                            "y": "50",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "3"},
@@ -438,8 +453,18 @@ class TestWorkflowMap:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "a1", "name": "Script 1", "x": "10", "y": "50"},
-                        {"sys_id": "a2", "name": "Script 2", "x": "200", "y": "50"},
+                        {
+                            "sys_id": "a1",
+                            "name": "Script 1",
+                            "x": "10",
+                            "y": "50",
+                        },
+                        {
+                            "sys_id": "a2",
+                            "name": "Script 2",
+                            "x": "200",
+                            "y": "50",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "2"},
@@ -453,9 +478,24 @@ class TestWorkflowMap:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "sv1", "variable": "var1", "value": "script_a1", "document_key": "a1"},
-                        {"sys_id": "sv2", "variable": "var2", "value": "script_a2", "document_key": "a2"},
-                        {"sys_id": "sv3", "variable": "var3", "value": "condition_a1", "document_key": "a1"},
+                        {
+                            "sys_id": "sv1",
+                            "variable": "var1",
+                            "value": "script_a1",
+                            "document_key": "a1",
+                        },
+                        {
+                            "sys_id": "sv2",
+                            "variable": "var2",
+                            "value": "script_a2",
+                            "document_key": "a2",
+                        },
+                        {
+                            "sys_id": "sv3",
+                            "variable": "var3",
+                            "value": "condition_a1",
+                            "document_key": "a1",
+                        },
                     ]
                 },
                 headers={"X-Total-Count": "3"},
@@ -481,7 +521,12 @@ class TestWorkflowMap:
         respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_none").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "wfv_none", "name": "No Activities WF"}},
+                json={
+                    "result": {
+                        "sys_id": "wfv_none",
+                        "name": "No Activities WF",
+                    }
+                },
             )
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,10 +9,11 @@ from toon_format import decode as toon_decode
 
 from servicenow_mcp.auth import BasicAuthProvider
 
+
 BASE_URL = "https://test.service-now.com"
 
 
-@pytest.fixture
+@pytest.fixture()
 def auth_provider(settings):
     """Create a BasicAuthProvider from test settings."""
     return BasicAuthProvider(settings)
@@ -58,7 +59,7 @@ class TestWorkflowToolRegistration:
 class TestWorkflowContexts:
     """Tests for the workflow_contexts tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_both_legacy_and_flow_contexts(self, settings, auth_provider):
         """Returns legacy workflow contexts and flow designer contexts."""
@@ -115,7 +116,7 @@ class TestWorkflowContexts:
         assert result["data"]["legacy_workflows"][0]["name"] == "Incident Workflow"
         assert result["data"]["flow_designer"][0]["name"] == "Auto-assign Flow"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_results_for_both_engines(self, settings, auth_provider):
         """Returns empty lists when no contexts found."""
@@ -134,7 +135,7 @@ class TestWorkflowContexts:
         assert result["data"]["legacy_workflows"] == []
         assert result["data"]["flow_designer"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_state(self, settings, auth_provider):
         """Passes state filter through to the legacy query."""
@@ -174,7 +175,7 @@ class TestWorkflowContexts:
         qs = parse_qs(urlparse(str(request.url)).query)
         assert "state=finished" in qs["sysparm_query"][0]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_filters_by_table(self, settings, auth_provider):
         """Passes table filter through to the legacy query."""
@@ -195,7 +196,7 @@ class TestWorkflowContexts:
         qs = parse_qs(urlparse(str(request.url)).query)
         assert "table=incident" in qs["sysparm_query"][0]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_server_error(self, settings, auth_provider):
         """Returns error envelope when legacy context query fails."""
@@ -223,7 +224,7 @@ class TestWorkflowContexts:
 class TestWorkflowMap:
     """Tests for the workflow_map tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_full_map(self, settings, auth_provider):
         """Returns version, activities, and transitions."""
@@ -328,7 +329,7 @@ class TestWorkflowMap:
         assert len(result["data"]["activities"][1]["variables"]) == 1
         assert result["data"]["activities"][1]["variables"][0]["value"] == "some_script_body"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_activities_and_transitions(self, settings, auth_provider):
         """Returns version with empty activities and transitions lists."""
@@ -361,7 +362,7 @@ class TestWorkflowMap:
         assert result["data"]["activities"] == []
         assert result["data"]["transitions"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_activities_sorted_by_x_position(self, settings, auth_provider):
         """Activities are returned ordered by x position from the query."""
@@ -416,7 +417,7 @@ class TestWorkflowMap:
         assert names == ["First", "Second", "Third"]
         assert all(a["variables"] == [] for a in result["data"]["activities"])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_error_on_missing_version(self, settings, auth_provider):
         """Returns error when the workflow version is not found."""
@@ -438,7 +439,7 @@ class TestWorkflowMap:
         assert isinstance(result["error"], dict)
         assert "Not found" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_map_groups_variables_by_activity(self, settings, auth_provider):
         """Variables are grouped correctly per activity in the map."""
@@ -514,7 +515,7 @@ class TestWorkflowMap:
         assert len(a1["variables"]) == 2
         assert len(a2["variables"]) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_map_empty_activities_skips_variable_fetch(self, settings, auth_provider):
         """No sys_variable_value call when there are no activities."""
@@ -553,7 +554,7 @@ class TestWorkflowMap:
 class TestWorkflowStatus:
     """Tests for the workflow_status tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_context_with_executing_and_history(self, settings, auth_provider):
         """Returns context record alongside executing and history lists."""
@@ -627,7 +628,7 @@ class TestWorkflowStatus:
         assert result["data"]["executing"][0]["activity.name"] == "Approval"
         assert result["data"]["history"][0]["result"] == "success"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_executing_all_completed(self, settings, auth_provider):
         """Returns empty executing list when all activities have finished."""
@@ -678,7 +679,7 @@ class TestWorkflowStatus:
         assert result["data"]["executing"] == []
         assert len(result["data"]["history"]) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_multiple_executing_activities(self, settings, auth_provider):
         """Returns multiple currently-executing activities."""
@@ -739,7 +740,7 @@ class TestWorkflowStatus:
         assert result["status"] == "success"
         assert len(result["data"]["executing"]) == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_history_with_faults(self, settings, auth_provider):
         """Returns history entries with populated fault_description."""
@@ -801,7 +802,7 @@ class TestWorkflowStatus:
         assert history[0]["fault_description"] == "NullPointerException at line 42"
         assert history[1]["fault_description"] == "Invalid email address"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_error_on_missing_context(self, settings, auth_provider):
         """Returns error envelope when wf_context is not found."""
@@ -825,7 +826,7 @@ class TestWorkflowStatus:
 class TestWorkflowActivityDetail:
     """Tests for the workflow_activity_detail tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_activity_with_linked_definition(self, settings, auth_provider):
         """Returns activity display values alongside the element definition."""
@@ -897,7 +898,7 @@ class TestWorkflowActivityDetail:
         assert len(result["data"]["variables"]) == 1
         assert result["data"]["variables"][0]["value"] == "current.state = 2;"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_activity_with_no_definition(self, settings, auth_provider):
         """Returns definition as None when activity has no linked definition."""
@@ -929,7 +930,7 @@ class TestWorkflowActivityDetail:
         assert result["data"]["definition"] is None
         assert result["data"]["variables"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_error_on_missing_activity(self, settings, auth_provider):
         """Returns error when the activity record is not found."""
@@ -945,7 +946,7 @@ class TestWorkflowActivityDetail:
         assert isinstance(result["error"], dict)
         assert "Not found" in result["error"]["message"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_activity_includes_multiple_variables(self, settings, auth_provider):
         """Returns multiple configured variables for an activity."""
@@ -1017,7 +1018,7 @@ class TestWorkflowActivityDetail:
 class TestWorkflowVersionList:
     """Tests for the workflow_version_list tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_versions_for_table(self, settings, auth_provider):
         """Returns workflow versions defined for a specific table."""
@@ -1062,7 +1063,7 @@ class TestWorkflowVersionList:
         assert len(result["data"]["versions"]) == 2
         assert result["data"]["versions"][0]["table"] == "incident"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_empty_result(self, settings, auth_provider):
         """Returns empty versions list when none found."""
@@ -1077,7 +1078,7 @@ class TestWorkflowVersionList:
         assert result["status"] == "success"
         assert result["data"]["versions"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_active_only_false_includes_inactive(self, settings, auth_provider):
         """Omits the active filter when active_only is False."""
@@ -1110,7 +1111,7 @@ class TestWorkflowVersionList:
         qs = parse_qs(urlparse(str(request.url)).query)
         assert "active=true" not in qs["sysparm_query"][0]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_returns_versions_with_display_values(self, settings, auth_provider):
         """Display values are requested for version records."""
@@ -1145,7 +1146,7 @@ class TestWorkflowVersionList:
         request = version_route.calls[0].request
         assert "sysparm_display_value=true" in str(request.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @respx.mock
     async def test_handles_server_error(self, settings, auth_provider):
         """Returns error envelope on server error."""


### PR DESCRIPTION
## Summary

Expand the ruff lint configuration from 8 rule categories to 21, enforcing stricter code quality standards across the codebase.

### New Rule Categories

| Rule | Category | What it catches |
|---|---|---|
| `C4` | flake8-comprehensions | Unnecessary list/dict comprehensions |
| `DTZ` | flake8-datetimez | Naive datetime usage |
| `T20` | flake8-print | Print statements in production code |
| `PTH` | flake8-use-pathlib | `os.path` usage where `pathlib` is better |
| `TC` | flake8-type-checking | Type-checking import optimization |
| `RET` | flake8-return | Unnecessary return patterns |
| `PLW` | pylint-warnings | Pylint warning-level issues |
| `PT` | flake8-pytest-style | Pytest best practices |
| `A` | flake8-builtins | Shadowing Python builtins |
| `COM` | flake8-commas | Trailing comma enforcement |
| `PIE` | flake8-pie | Misc linting rules |
| `ISC` | flake8-implicit-str-concat | Implicit string concatenation |
| `G` | flake8-logging-format | Logging format best practices |
| `INP` | flake8-no-pep420 | Missing `__init__.py` detection |
| `TID` | flake8-tidy-imports | Import hygiene |
| `ERA` | eradicate | Commented-out code detection |

### Intentional Ignores

| Rule | Reason |
|---|---|
| `COM812` | Conflicts with ruff formatter |
| `ISC001` | Conflicts with ruff formatter |
| `TC001-003` | Would require `from __future__ import annotations` which breaks runtime type resolution |
| `RET504` | Unnecessary assignment before return reduces debuggability |
| `RET505` | Unnecessary else after return is sometimes clearer |

### Per-file Ignores

- `tests/**/*.py`: `T20` (print OK), `ERA001` (commented code OK)
- `src/servicenow_mcp/tools/domains/*.py`: `A002` (ServiceNow API uses `type` as parameter name)
- `src/servicenow_mcp/tools/changes.py`: `A002` (ServiceNow API uses `format` as parameter name)

### Verification

- **Lint**: All checks passed (0 errors)
- **Tests**: 940 passed, 81 deselected (integration)