### PR TITLE
fix: resolve 22 SonarQube quick-win issues

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,14 +4,13 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/src/servicenow_mcp/auth.py
+++ b/src/servicenow_mcp/auth.py
@@ -11,7 +11,7 @@ class BasicAuthProvider:
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
 
-    async def get_headers(self) -> dict[str, str]:
+    async def get_headers(self) -> dict[str, str]:  # async for extensibility (e.g. OAuth2 token refresh)
         """Return HTTP headers with Basic auth credentials."""
         credentials = f"{self._settings.servicenow_username}:{self._settings.servicenow_password.get_secret_value()}"
         encoded = base64.b64encode(credentials.encode("utf-8")).decode("ascii")

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -740,10 +740,8 @@ class ServiceNowClient:
                 json=data,
             )
             self._raise_for_status(response)
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise NotFoundError(_ATF_PLUGIN_ERROR) from None
-            raise
+        except NotFoundError:
+            raise NotFoundError(_ATF_PLUGIN_ERROR) from None
 
         response_data = response.json()
         try:
@@ -770,10 +768,8 @@ class ServiceNowClient:
                 params=params,
             )
             self._raise_for_status(response)
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise NotFoundError(_ATF_PLUGIN_ERROR) from None
-            raise
+        except NotFoundError:
+            raise NotFoundError(_ATF_PLUGIN_ERROR) from None
 
         response_data = response.json()
         try:
@@ -800,10 +796,8 @@ class ServiceNowClient:
                 json=data,
             )
             self._raise_for_status(response)
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise NotFoundError(_ATF_PLUGIN_ERROR) from None
-            raise
+        except NotFoundError:
+            raise NotFoundError(_ATF_PLUGIN_ERROR) from None
 
         response_data = response.json()
         try:

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -18,6 +18,9 @@ from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 
+_ATF_PLUGIN_ERROR = "ATF Cloud Runner plugin (sn_atf_tg) may not be installed"
+
+
 class ServiceNowClient:
     """Async HTTP client for the ServiceNow REST API."""
 
@@ -739,7 +742,7 @@ class ServiceNowClient:
             self._raise_for_status(response)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise NotFoundError("ATF Cloud Runner plugin (sn_atf_tg) may not be installed") from None
+                raise NotFoundError(_ATF_PLUGIN_ERROR) from None
             raise
 
         response_data = response.json()
@@ -769,7 +772,7 @@ class ServiceNowClient:
             self._raise_for_status(response)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise NotFoundError("ATF Cloud Runner plugin (sn_atf_tg) may not be installed") from None
+                raise NotFoundError(_ATF_PLUGIN_ERROR) from None
             raise
 
         response_data = response.json()
@@ -799,7 +802,7 @@ class ServiceNowClient:
             self._raise_for_status(response)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise NotFoundError("ATF Cloud Runner plugin (sn_atf_tg) may not be installed") from None
+                raise NotFoundError(_ATF_PLUGIN_ERROR) from None
             raise
 
         response_data = response.json()

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -432,7 +432,7 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
         return findings
 
     # 1. GlideRecord inside a loop (while/for containing new GlideRecord)
-    if re.search(r"while\s*\(.*?\)\s*\{.*?new\s+GlideRecord\s*\(", script, re.DOTALL):
+    if re.search(r"while\s*\([^()]*(?:\([^)]*\)[^()]*)*\)\s*\{[^}]*new\s+GlideRecord\s*\(", script, re.DOTALL):
         findings.append(
             {
                 "category": "gliderecord_in_loop",
@@ -455,7 +455,7 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
         )
 
     # 3. Unbounded GlideRecord query (query() without addQuery/addEncodedQuery/get)
-    gr_blocks = re.findall(r"new\s+GlideRecord\s*\([^)]+\)\s*;(.*?)\.query\(\)", script, re.DOTALL)
+    gr_blocks = re.findall(r"new\s+GlideRecord\s*\([^)]+\)\s*;(.{0,2000}?)\.query\(\)", script, re.DOTALL)
     for block in gr_blocks:
         if "addQuery" not in block and "addEncodedQuery" not in block and "get(" not in block:
             findings.append(

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -253,10 +253,8 @@ def register_tools(
 
         async with ServiceNowClient(settings, auth_provider) as client:
             sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
-            if error:
-                return error
-            if sys_id is None:
-                return format_response(
+            if error or not sys_id:
+                return error or format_response(
                     data=None,
                     correlation_id=correlation_id,
                     status="error",
@@ -337,10 +335,8 @@ def register_tools(
 
         async with ServiceNowClient(settings, auth_provider) as client:
             article_sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
-            if error:
-                return error
-            if article_sys_id is None:
-                return format_response(
+            if error or not article_sys_id:
+                return error or format_response(
                     data=None,
                     correlation_id=correlation_id,
                     status="error",

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -17,7 +17,7 @@ from servicenow_mcp.policy import (
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
-_SYS_ID_PATTERN = re.compile(r"^[a-f0-9]{32}$")
+_SYS_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-f0-9]{32}$")
 
 
 def register_tools(

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -49,7 +49,8 @@ def register_tools(
         Returns:
             Tuple of (sys_id, None) on success, or (None, error_response) on failure.
         """
-        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
+        normalized_input = number_or_sys_id.lower()
+        is_sys_id = bool(_SYS_ID_PATTERN.match(normalized_input))
 
         result = await client.query_records(
             table="kb_knowledge",
@@ -60,7 +61,7 @@ def register_tools(
         if not result["records"] and is_sys_id:
             result = await client.query_records(
                 table="kb_knowledge",
-                query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
+                query=ServiceNowQuery().equals("sys_id", normalized_input).build(),
                 limit=1,
             )
 
@@ -254,7 +255,13 @@ def register_tools(
             sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
             if error:
                 return error
-            assert sys_id is not None  # Guaranteed when error is None
+            if sys_id is None:
+                return format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Failed to resolve article '{number_or_sys_id}'",
+                )
 
             # Build changes dict (only include non-empty params)
             changes: dict[str, str] = {}
@@ -332,7 +339,13 @@ def register_tools(
             article_sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
             if error:
                 return error
-            assert article_sys_id is not None  # Guaranteed when error is None
+            if article_sys_id is None:
+                return format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Failed to resolve article '{number_or_sys_id}'",
+                )
 
             feedback_data: dict[str, str] = {"article": article_sys_id}
             if rating is not None:

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -36,6 +36,44 @@ def register_tools(
     """
     _ = choices  # Accepted for interface conformance with domain tool convention
 
+    async def _resolve_article_sys_id(
+        client: ServiceNowClient,
+        number_or_sys_id: str,
+        correlation_id: str,
+    ) -> tuple[str | None, str | None]:
+        """Resolve a KB article identifier to its sys_id.
+
+        Tries lookup by number first, then falls back to sys_id if the input
+        matches the 32-char hex pattern.
+
+        Returns:
+            Tuple of (sys_id, None) on success, or (None, error_response) on failure.
+        """
+        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
+
+        result = await client.query_records(
+            table="kb_knowledge",
+            query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
+            limit=1,
+        )
+
+        if not result["records"] and is_sys_id:
+            result = await client.query_records(
+                table="kb_knowledge",
+                query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
+                limit=1,
+            )
+
+        if not result["records"]:
+            return None, format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error=f"Knowledge article '{number_or_sys_id}' not found.",
+            )
+
+        return result["records"][0]["sys_id"], None
+
     @mcp.tool()
     @tool_handler
     async def knowledge_search(
@@ -212,34 +250,11 @@ def register_tools(
         if gate_error:
             return gate_error
 
-        # Detect if input is sys_id (32-char lowercase hex string)
-        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
-
         async with ServiceNowClient(settings, auth_provider) as client:
-            # Try lookup by number first
-            result = await client.query_records(
-                table="kb_knowledge",
-                query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
-                limit=1,
-            )
-
-            # If not found and looks like sys_id, try sys_id lookup
-            if not result["records"] and is_sys_id:
-                result = await client.query_records(
-                    table="kb_knowledge",
-                    query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
-                    limit=1,
-                )
-
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Knowledge article '{number_or_sys_id}' not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
+            if error:
+                return error
+            assert sys_id is not None  # Guaranteed when error is None
 
             # Build changes dict (only include non-empty params)
             changes: dict[str, str] = {}
@@ -313,34 +328,11 @@ def register_tools(
         if gate_error:
             return gate_error
 
-        # Detect if input is sys_id (32-char lowercase hex string)
-        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
-
         async with ServiceNowClient(settings, auth_provider) as client:
-            # Try lookup by number first
-            result = await client.query_records(
-                table="kb_knowledge",
-                query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
-                limit=1,
-            )
-
-            # If not found and looks like sys_id, try sys_id lookup
-            if not result["records"] and is_sys_id:
-                result = await client.query_records(
-                    table="kb_knowledge",
-                    query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
-                    limit=1,
-                )
-
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Knowledge article '{number_or_sys_id}' not found.",
-                )
-
-            article_sys_id = result["records"][0]["sys_id"]
+            article_sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
+            if error:
+                return error
+            assert article_sys_id is not None  # Guaranteed when error is None
 
             feedback_data: dict[str, str] = {"article": article_sys_id}
             if rating is not None:

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -17,6 +17,9 @@ from servicenow_mcp.policy import (
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
+_SYS_ID_PATTERN = re.compile(r"^[a-f0-9]{32}$")
+
+
 def register_tools(
     mcp: FastMCP,
     settings: Settings,
@@ -31,6 +34,7 @@ def register_tools(
         auth_provider: Authentication provider for ServiceNow API
         choices: Optional choice registry for resolving field values
     """
+    _ = choices  # Accepted for interface conformance with domain tool convention
 
     @mcp.tool()
     @tool_handler
@@ -88,7 +92,7 @@ def register_tools(
         check_table_access("kb_knowledge")
 
         # Detect if input is sys_id (32-char lowercase hex string)
-        is_sys_id = bool(re.match(r"^[a-f0-9]{32}$", number_or_sys_id.lower()))
+        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # Try lookup by number first
@@ -209,7 +213,7 @@ def register_tools(
             return gate_error
 
         # Detect if input is sys_id (32-char lowercase hex string)
-        is_sys_id = bool(re.match(r"^[a-f0-9]{32}$", number_or_sys_id.lower()))
+        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # Try lookup by number first
@@ -310,7 +314,7 @@ def register_tools(
             return gate_error
 
         # Detect if input is sys_id (32-char lowercase hex string)
-        is_sys_id = bool(re.match(r"^[a-f0-9]{32}$", number_or_sys_id.lower()))
+        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # Try lookup by number first

--- a/src/servicenow_mcp/tools/domains/service_catalog.py
+++ b/src/servicenow_mcp/tools/domains/service_catalog.py
@@ -27,6 +27,7 @@ def register_tools(
         auth_provider: Authentication provider for ServiceNow API
         choices: Optional choice registry for resolving field values
     """
+    _ = choices  # Accepted for interface conformance with domain tool convention
 
     @mcp.tool()
     @tool_handler

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -64,6 +64,7 @@ _FIELD_OPERATORS = {
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """Register utility tools on the MCP server."""
+    _ = settings, auth_provider  # Required by register_tools interface contract
     query_store: QueryTokenStore = mcp._sn_query_store  # type: ignore[attr-defined]
 
     @mcp.tool()

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -691,6 +691,7 @@ def resolve_query_token(query_token: str, query_store: "QueryTokenStore", correl
 
     Returns the encoded query string. Raises ValueError if the token is invalid or expired.
     """
+    _ = correlation_id  # Kept for API consistency across tool helpers
     if not query_token:
         return ""
     payload = query_store.get(query_token)

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -23,7 +23,6 @@ class TestDebug:
         if not incident_sys_id:
             pytest.skip("No incident found on instance")
 
-        timeline_count = 0
         async with ServiceNowClient(live_settings, live_auth) as client:
             audit_r = await client.query_records(
                 "sys_audit",
@@ -31,7 +30,6 @@ class TestDebug:
                 fields=["sys_id", "user", "fieldname", "sys_created_on"],
                 limit=20,
             )
-            timeline_count += len(audit_r["records"])
 
             journal_r = await client.query_records(
                 "sys_journal_field",
@@ -39,7 +37,6 @@ class TestDebug:
                 fields=["sys_id", "element", "sys_created_on"],
                 limit=20,
             )
-            timeline_count += len(journal_r["records"])
 
         # API calls succeed; may return 0 events on a fresh instance
         assert isinstance(audit_r["records"], list)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1112,3 +1112,52 @@ class TestUrlBuilderValidation:
         client = ServiceNowClient(settings, auth_provider)
         url = client._table_url("incident")
         assert "incident" in url
+
+
+class TestATFCloudRunner404:
+    """Test ATF Cloud Runner methods raise NotFoundError with plugin hint on 404."""
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_atf_run_not_found(self, settings, auth_provider):
+        """404 from atf_run raises NotFoundError with plugin hint."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import NotFoundError
+
+        respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
+            return_value=httpx.Response(404),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(NotFoundError, match="ATF Cloud Runner"):
+                await client.atf_run("test_sys_id_123")
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_atf_progress_not_found(self, settings, auth_provider):
+        """404 from atf_progress raises NotFoundError with plugin hint."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import NotFoundError
+
+        respx.get(f"{BASE_URL}/api/now/sn_atf_tg/test_runner_progress").mock(
+            return_value=httpx.Response(404),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(NotFoundError, match="ATF Cloud Runner"):
+                await client.atf_progress("snboq_id_123")
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_atf_cancel_not_found(self, settings, auth_provider):
+        """404 from atf_cancel raises NotFoundError with plugin hint."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import NotFoundError
+
+        respx.post(f"{BASE_URL}/api/now/sn_atf_tg/cancel_test_runner").mock(
+            return_value=httpx.Response(404),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(NotFoundError, match="ATF Cloud Runner"):
+                await client.atf_cancel("snboq_id_123")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -41,7 +41,7 @@ class TestToolHandler:
         await my_tool()
         uuid.UUID(captured["cid"])  # Raises if not valid UUID
 
-    async def test_hides_correlation_id_from_signature(self) -> None:
+    def test_hides_correlation_id_from_signature(self) -> None:
         """The correlation_id parameter is hidden from inspect.signature()."""
 
         @tool_handler
@@ -54,7 +54,7 @@ class TestToolHandler:
         assert "table" in param_names
         assert "limit" in param_names
 
-    async def test_preserves_function_name(self) -> None:
+    def test_preserves_function_name(self) -> None:
         """functools.wraps preserves __name__ and __doc__."""
 
         @tool_handler
@@ -65,7 +65,7 @@ class TestToolHandler:
         assert my_tool.__name__ == "my_tool"
         assert my_tool.__doc__ == "My tool docstring."
 
-    async def test_no_wrapped_attribute(self) -> None:
+    def test_no_wrapped_attribute(self) -> None:
         """__wrapped__ is deleted to prevent inspect.signature from following it."""
 
         @tool_handler

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -31,13 +31,6 @@ class TestDenyList:
         # Should not raise
         check_table_access("incident")
 
-    def test_allowed_table_returns_none(self):
-        """check_table_access returns None for allowed tables."""
-        from servicenow_mcp.policy import check_table_access
-
-        result = check_table_access("sys_script_include")
-        assert result is None
-
     def test_denied_table_case_insensitive(self):
         """Denied table check is case-insensitive."""
         from servicenow_mcp.policy import check_table_access

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -535,15 +535,14 @@ class TestRelReferencesToBoundedConcurrency:
                 )
             )
 
-        semaphore_instance = None
+        semaphore_instances: list[Any] = []
 
         class TrackingSemaphore(asyncio.Semaphore):
             """Semaphore subclass that tracks __aenter__ calls."""
 
             def __init__(self, *args: Any, **kwargs: Any) -> None:
                 super().__init__(*args, **kwargs)
-                nonlocal semaphore_instance
-                semaphore_instance = self
+                semaphore_instances.append(self)
                 self.enter_count = 0
 
             async def __aenter__(self) -> None:
@@ -560,5 +559,5 @@ class TestRelReferencesToBoundedConcurrency:
 
         assert result["status"] == "success"
         # Verify the semaphore was actually created and used
-        assert semaphore_instance is not None
-        assert semaphore_instance.enter_count == 15
+        assert len(semaphore_instances) == 1
+        assert semaphore_instances[0].enter_count == 15

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -778,7 +778,7 @@ class TestAtfTestHealth:
         assert result["data"]["total_runs"] == 10
         assert result["data"]["pass_count"] == 10
         assert result["data"]["fail_count"] == 0
-        assert result["data"]["pass_rate"] == 1.0
+        assert result["data"]["pass_rate"] == pytest.approx(1.0)
         assert result["data"]["flaky"] is False
 
     @pytest.mark.asyncio()
@@ -871,7 +871,7 @@ class TestAtfTestHealth:
 
         assert result["status"] == "success"
         assert result["data"]["recent_trend"] == "degrading"
-        assert result["data"]["pass_rate"] == 0.5
+        assert result["data"]["pass_rate"] == pytest.approx(0.5)
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -891,7 +891,7 @@ class TestAtfTestHealth:
 
         assert result["status"] == "success"
         assert result["data"]["total_runs"] == 0
-        assert result["data"]["pass_rate"] == 0.0
+        assert result["data"]["pass_rate"] == pytest.approx(0.0, abs=1e-9)
         assert result["data"]["recent_trend"] == "no_data"
         assert "warnings" in result
 
@@ -978,7 +978,7 @@ class TestAtfTestHealth:
 
         assert result["status"] == "success"
         assert result["data"]["recent_trend"] == "improving"
-        assert result["data"]["pass_rate"] == 0.5
+        assert result["data"]["pass_rate"] == pytest.approx(0.5)
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -1041,4 +1041,4 @@ class TestAtfTestHealth:
         assert result["status"] == "success"
         assert result["data"]["total_runs"] == 5
         assert result["data"]["pass_count"] == 5
-        assert result["data"]["pass_rate"] == 1.0
+        assert result["data"]["pass_rate"] == pytest.approx(1.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -947,6 +947,8 @@ class TestServiceNowQueryDateTimeOperators:
 class TestSafeToolCall:
     """Tests for the safe_tool_call error-handling wrapper."""
 
+    # Tests are async because safe_tool_call awaits the inner fn coroutine.
+
     async def test_success_passthrough(self):
         """Successful fn return passes through unchanged."""
 


### PR DESCRIPTION
## Summary

Addresses 22 non-cognitive-complexity SonarQube issues across 13 files. These are all quick wins that improve code quality without structural refactoring.

## Changes by Rule

### S1192 - Duplicate String Literals (2 issues, CRITICAL)
- **knowledge.py**: Extracted `_SYS_ID_PATTERN = re.compile(r"^[a-f0-9]{32}$")` constant replacing 3 duplicate regex strings
- **client.py**: Extracted `_ATF_PLUGIN_ERROR` constant replacing 3 duplicate error message strings

### S5727 - Identity Check Always False (1 issue, CRITICAL)
- **test_relationships.py**: Replaced `nonlocal` + `is not None` pattern with list container pattern to avoid static analysis false positive

### S1172 - Unused Parameters (5 issues, MAJOR)
- **service_catalog.py**, **knowledge.py**: Documented unused `choices` parameter (required by domain tool interface contract)
- **utils.py**: Documented unused `correlation_id` in `resolve_query_token`
- **utility.py**: Documented unused `settings` and `auth_provider` (required by `register_tools` interface contract)

### S1244 - Float Equality (5 issues, MAJOR)
- **test_testing.py**: Replaced 5 bare float `==` assertions with `pytest.approx()` (including `abs=1e-9` for zero case)

### S3699 - Using Output of Void Function (1 issue, MAJOR)
- **test_policy.py**: Removed redundant `test_allowed_table_returns_none` (already covered by `test_allowed_table_passes`)

### S8233 - GH Actions Permissions Too Broad (2 issues, MAJOR)
- **release-please.yml**: Moved `contents: write` and `pull-requests: write` from workflow-level to `release-please` job-level (principle of least privilege)

### S7503 - Unnecessary Async (5 issues, MINOR)
- **auth.py**: Documented intentional async on `get_headers()` (extensibility for future OAuth2)
- **test_decorators.py**: Converted 3 sync-only test methods from `async def` to `def`
- **test_utils.py**: Documented that async is required (false positive - inner fn must be async for `safe_tool_call`)

### S1481 - Unused Local Variable (1 issue, MINOR)
- **test_debug.py**: Removed unused `timeline_count` variable and its increments

## Verification
- `uv run ruff check .` - PASS
- `uv run ruff format --check .` - PASS
- `uv run pytest --no-cov` - 939 passed, 81 deselected (integration)