### PR TITLE
fix: harden input validation in utility, documentation, and knowledge tools

### DIFF
--- a/src/servicenow_mcp/tools/developer.py
+++ b/src/servicenow_mcp/tools/developer.py
@@ -54,6 +54,80 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         ]
         return [f for f in mandatory_fields if f not in data]
 
+    async def _check_mandatory_or_error(
+        client: ServiceNowClient,
+        table: str,
+        data: dict[str, Any],
+        correlation_id: str,
+    ) -> str | None:
+        """Check for missing mandatory fields and return error response if any, else None."""
+        missing = await _check_mandatory_fields(client, table, data)
+        if missing:
+            return format_response(
+                data={"table": table, "missing_fields": missing},
+                correlation_id=correlation_id,
+                status="error",
+                error=f"Missing mandatory fields for table '{table}': {', '.join(missing)}",
+            )
+        return None
+
+    async def _execute_apply_action(
+        client: ServiceNowClient,
+        payload: dict[str, Any],
+        table: str,
+        correlation_id: str,
+    ) -> str:
+        """Execute a previewed create/update/delete action."""
+        action = payload["action"]
+
+        if action == "create":
+            err = await _check_mandatory_or_error(client, table, payload["data"], correlation_id)
+            if err:
+                return err
+            result = await client.create_record(table, payload["data"])
+            return format_response(
+                data={
+                    "action": "create",
+                    "table": table,
+                    "sys_id": result["sys_id"],
+                    "record": mask_sensitive_fields(result),
+                },
+                correlation_id=correlation_id,
+            )
+
+        if action == "update":
+            sys_id = payload["sys_id"]
+            result = await client.update_record(table, sys_id, payload["changes"])
+            return format_response(
+                data={
+                    "action": "update",
+                    "table": table,
+                    "sys_id": sys_id,
+                    "record": mask_sensitive_fields(result),
+                },
+                correlation_id=correlation_id,
+            )
+
+        if action == "delete":
+            sys_id = payload["sys_id"]
+            await client.delete_record(table, sys_id)
+            return format_response(
+                data={
+                    "action": "delete",
+                    "table": table,
+                    "sys_id": sys_id,
+                    "deleted": True,
+                },
+                correlation_id=correlation_id,
+            )
+
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Unknown preview action: '{action}'",
+        )
+
     @mcp.tool()
     @tool_handler
     async def record_create(table: str, data: str, *, correlation_id: str) -> str:
@@ -73,14 +147,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         record_data = json.loads(data)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            missing = await _check_mandatory_fields(client, table, record_data)
-            if missing:
-                return format_response(
-                    data={"table": table, "missing_fields": missing},
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Missing mandatory fields for table '{table}': {', '.join(missing)}",
-                )
+            err = await _check_mandatory_or_error(client, table, record_data, correlation_id)
+            if err:
+                return err
             created = await client.create_record(table, record_data)
 
         return format_response(
@@ -111,14 +180,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         record_data = json.loads(data)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            missing = await _check_mandatory_fields(client, table, record_data)
-            if missing:
-                return format_response(
-                    data={"table": table, "missing_fields": missing},
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Missing mandatory fields for table '{table}': {', '.join(missing)}",
-                )
+            err = await _check_mandatory_or_error(client, table, record_data, correlation_id)
+            if err:
+                return err
 
         # Store for later apply - no further HTTP call needed
         token = preview_store.create(
@@ -310,7 +374,6 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 error="Invalid or expired preview token",
             )
 
-        action = payload["action"]
         table = payload["table"]
 
         # Defense in depth - re-check access and write gate
@@ -320,58 +383,4 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             return blocked
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            if action == "create":
-                missing = await _check_mandatory_fields(client, payload["table"], payload["data"])
-                if missing:
-                    return format_response(
-                        data={
-                            "table": payload["table"],
-                            "missing_fields": missing,
-                        },
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=f"Missing mandatory fields for table '{payload['table']}': {', '.join(missing)}",
-                    )
-                result = await client.create_record(table, payload["data"])
-                return format_response(
-                    data={
-                        "action": "create",
-                        "table": table,
-                        "sys_id": result["sys_id"],
-                        "record": mask_sensitive_fields(result),
-                    },
-                    correlation_id=correlation_id,
-                )
-
-            if action == "update":
-                sys_id = payload["sys_id"]
-                result = await client.update_record(table, sys_id, payload["changes"])
-                return format_response(
-                    data={
-                        "action": "update",
-                        "table": table,
-                        "sys_id": sys_id,
-                        "record": mask_sensitive_fields(result),
-                    },
-                    correlation_id=correlation_id,
-                )
-
-            if action == "delete":
-                sys_id = payload["sys_id"]
-                await client.delete_record(table, sys_id)
-                return format_response(
-                    data={
-                        "action": "delete",
-                        "table": table,
-                        "sys_id": sys_id,
-                        "deleted": True,
-                    },
-                    correlation_id=correlation_id,
-                )
-
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Unknown preview action: '{action}'",
-            )
+            return await _execute_apply_action(client, payload, table, correlation_id)

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -326,7 +326,7 @@ def _extract_gliderecord_tables(script: str) -> list[str]:
     return result
 
 
-_WHILE_BLOCK_RE: re.Pattern[str] = re.compile(r"while\s*\([^)]*(?:\([^)]*\)[^)]*)*\)\s*\{")
+_WHILE_BLOCK_RE: re.Pattern[str] = re.compile(r"\bwhile\s*\(")
 _GR_IN_BLOCK_RE: re.Pattern[str] = re.compile(r"new\s+GlideRecord\s*\(")
 
 _SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
@@ -435,6 +435,19 @@ def _generate_test_scenarios(script: str) -> list[dict[str, str]]:
     return scenarios
 
 
+def _find_block_end(script: str, open_brace_idx: int) -> int:
+    """Return the index of the matching closing brace, or end of script."""
+    depth = 0
+    for idx in range(open_brace_idx, len(script)):
+        if script[idx] == "{":
+            depth += 1
+        elif script[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return idx
+    return len(script) - 1
+
+
 def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
     """Scan script for common ServiceNow anti-patterns."""
     findings: list[dict[str, str]] = []
@@ -443,7 +456,16 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
         return findings
 
     # 1. GlideRecord inside a loop (while/for containing new GlideRecord)
-    if any(_GR_IN_BLOCK_RE.search(script, m.end()) for m in _WHILE_BLOCK_RE.finditer(script)):
+    has_gr_in_loop = False
+    for m in _WHILE_BLOCK_RE.finditer(script):
+        open_brace_idx = script.find("{", m.start())
+        if open_brace_idx == -1:
+            continue
+        close_brace_idx = _find_block_end(script, open_brace_idx)
+        if _GR_IN_BLOCK_RE.search(script[open_brace_idx : close_brace_idx + 1]):
+            has_gr_in_loop = True
+            break
+    if has_gr_in_loop:
         findings.append(
             {
                 "category": "gliderecord_in_loop",

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -43,7 +43,7 @@ def _resolve_artifact_table(artifact_type: str, correlation_id: str) -> tuple[st
 async def _fetch_artifact_script(client: ServiceNowClient, table: str, sys_id: str) -> tuple[dict[str, Any], str]:
     """Fetch an artifact record and return (masked_record, script_body)."""
     record = mask_sensitive_fields(await client.get_record(table, sys_id))
-    script = record.get("script", "")
+    script = record.get("script", "") or ""
     return record, script
 
 
@@ -326,6 +326,9 @@ def _extract_gliderecord_tables(script: str) -> list[str]:
     return result
 
 
+_WHILE_BLOCK_RE: re.Pattern[str] = re.compile(r"while\s*\([^)]*(?:\([^)]*\)[^)]*)*\)\s*\{")
+_GR_IN_BLOCK_RE: re.Pattern[str] = re.compile(r"new\s+GlideRecord\s*\(")
+
 _SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
     (
         re.compile(r"current\.operation\(\)\s*==\s*['\"]insert['\"]"),
@@ -440,7 +443,7 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
         return findings
 
     # 1. GlideRecord inside a loop (while/for containing new GlideRecord)
-    if re.search(r"while\s*\([^()]*(?:\([^)]*\)[^()]*)*\)\s*\{[^}]*new\s+GlideRecord\s*\(", script, re.DOTALL):
+    if any(_GR_IN_BLOCK_RE.search(script, m.end()) for m in _WHILE_BLOCK_RE.finditer(script)):
         findings.append(
             {
                 "category": "gliderecord_in_loop",

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -43,7 +43,7 @@ def _resolve_artifact_table(artifact_type: str, correlation_id: str) -> tuple[st
 async def _fetch_artifact_script(client: ServiceNowClient, table: str, sys_id: str) -> tuple[dict[str, Any], str]:
     """Fetch an artifact record and return (masked_record, script_body)."""
     record = mask_sensitive_fields(await client.get_record(table, sys_id))
-    script = record.get("script", "")
+    script = record.get("script", "") or ""
     return record, script
 
 
@@ -257,7 +257,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         async with ServiceNowClient(settings, auth_provider) as client:
             record, script = await _fetch_artifact_script(client, table, sys_id)
 
-        scenarios = _generate_test_scenarios(script, record)
+        scenarios = _generate_test_scenarios(script)
 
         return format_response(
             data={
@@ -326,6 +326,9 @@ def _extract_gliderecord_tables(script: str) -> list[str]:
     return result
 
 
+_WHILE_BLOCK_RE: re.Pattern[str] = re.compile(r"while\s*\([^)]*(?:\([^)]*\)[^)]*)*\)\s*\{")
+_GR_IN_BLOCK_RE: re.Pattern[str] = re.compile(r"new\s+GlideRecord\s*\(")
+
 _SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
     (
         re.compile(r"current\.operation\(\)\s*==\s*['\"]insert['\"]"),
@@ -378,7 +381,7 @@ _SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
 ]
 
 
-def _generate_test_scenarios(script: str, record: dict[str, Any]) -> list[dict[str, str]]:
+def _generate_test_scenarios(script: str) -> list[dict[str, str]]:
     """Analyze script and generate test scenario suggestions."""
     scenarios: list[dict[str, str]] = []
 
@@ -440,7 +443,7 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
         return findings
 
     # 1. GlideRecord inside a loop (while/for containing new GlideRecord)
-    if re.search(r"while\s*\([^()]*(?:\([^)]*\)[^()]*)*\)\s*\{[^}]*new\s+GlideRecord\s*\(", script, re.DOTALL):
+    if any(_GR_IN_BLOCK_RE.search(script, m.end()) for m in _WHILE_BLOCK_RE.finditer(script)):
         findings.append(
             {
                 "category": "gliderecord_in_loop",

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -1,6 +1,7 @@
 """Documentation tools for generating logic maps, summaries, test scenarios, and review notes."""
 
 import asyncio
+import itertools
 import re
 from typing import Any
 
@@ -327,6 +328,7 @@ def _extract_gliderecord_tables(script: str) -> list[str]:
 
 
 _WHILE_BLOCK_RE: re.Pattern[str] = re.compile(r"\bwhile\s*\(")
+_FOR_BLOCK_RE: re.Pattern[str] = re.compile(r"\bfor\s*\(")
 _GR_IN_BLOCK_RE: re.Pattern[str] = re.compile(r"new\s+GlideRecord(?:Secure)?\s*\(")
 
 _SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
@@ -457,12 +459,47 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
 
     # 1. GlideRecord inside a loop (while/for containing new GlideRecord)
     has_gr_in_loop = False
-    for m in _WHILE_BLOCK_RE.finditer(script):
-        open_brace_idx = script.find("{", m.start())
-        if open_brace_idx == -1:
+    loop_matches = sorted(
+        itertools.chain(_WHILE_BLOCK_RE.finditer(script), _FOR_BLOCK_RE.finditer(script)),
+        key=lambda m: m.start(),
+    )
+    for m in loop_matches:
+        # Find the matching closing paren for the condition
+        open_paren = script.find("(", m.start())
+        if open_paren == -1:
             continue
-        close_brace_idx = _find_block_end(script, open_brace_idx)
-        if _GR_IN_BLOCK_RE.search(script[open_brace_idx : close_brace_idx + 1]):
+        depth = 1
+        pos = open_paren + 1
+        while pos < len(script) and depth > 0:
+            if script[pos] == "(":
+                depth += 1
+            elif script[pos] == ")":
+                depth -= 1
+            pos += 1
+        # pos is now right after the closing ")"
+
+        # Skip whitespace to find block start
+        body_start = pos
+        while body_start < len(script) and script[body_start] in " \t\r\n":
+            body_start += 1
+
+        if body_start >= len(script):
+            continue
+
+        if script[body_start] == "{":
+            # Braced block - use existing _find_block_end
+            block_end = _find_block_end(script, body_start)
+            block = script[body_start : block_end + 1]
+        else:
+            # Single statement (no braces) - find the next semicolon or newline
+            stmt_end = len(script)
+            for terminator in (";", "\n"):
+                idx = script.find(terminator, body_start)
+                if idx != -1:
+                    stmt_end = min(stmt_end, idx + 1)
+            block = script[body_start:stmt_end]
+
+        if _GR_IN_BLOCK_RE.search(block):
             has_gr_in_loop = True
             break
     if has_gr_in_loop:
@@ -471,7 +508,7 @@ def _scan_for_anti_patterns(script: str) -> list[dict[str, str]]:
                 "category": "gliderecord_in_loop",
                 "severity": "warning",
                 "message": "GlideRecord instantiated inside a loop. This is a major performance "
-                "concern — move the query outside the loop or use GlideAggregate.",
+                "concern - move the query outside the loop or use GlideAggregate.",
             }
         )
 

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -23,6 +23,60 @@ from servicenow_mcp.utils import (
 )
 
 
+# ── Shared helpers ────────────────────────────────────────────────────────
+
+
+def _resolve_artifact_table(artifact_type: str, correlation_id: str) -> tuple[str, str | None]:
+    """Resolve artifact_type to its table name, returning (table, None) or ("", error_response)."""
+    table = ARTIFACT_TABLES.get(artifact_type)
+    if not table:
+        valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
+        return "", format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Unknown artifact type '{artifact_type}'. Valid: {valid_types}",
+        )
+    return table, None
+
+
+async def _fetch_artifact_script(client: ServiceNowClient, table: str, sys_id: str) -> tuple[dict[str, Any], str]:
+    """Fetch an artifact record and return (masked_record, script_body)."""
+    record = mask_sensitive_fields(await client.get_record(table, sys_id))
+    script = record.get("script", "")
+    return record, script
+
+
+def _classify_br_phases(br_records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Classify business rules by lifecycle phase."""
+    phases: dict[str, list[dict[str, Any]]] = {}
+    for br in br_records:
+        when = br.get("when", "before")
+        operations = []
+        if br.get("action_insert") == "true":
+            operations.append("insert")
+        if br.get("action_update") == "true":
+            operations.append("update")
+        if br.get("action_delete") == "true":
+            operations.append("delete")
+        if not operations:
+            operations = ["all"]
+
+        for op in operations:
+            phase_key = f"{when}_{op}"
+            if phase_key not in phases:
+                phases[phase_key] = []
+            phases[phase_key].append(
+                {
+                    "type": "business_rule",
+                    "sys_id": br.get("sys_id", ""),
+                    "name": br.get("name", ""),
+                    "order": br.get("order", ""),
+                }
+            )
+    return phases
+
+
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """Register documentation tools on the MCP server."""
 
@@ -84,31 +138,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             )
 
         # Build phase map from business rules
-        phases: dict[str, list[dict[str, Any]]] = {}
-        for br in br_result["records"]:
-            when = br.get("when", "before")
-            operations = []
-            if br.get("action_insert") == "true":
-                operations.append("insert")
-            if br.get("action_update") == "true":
-                operations.append("update")
-            if br.get("action_delete") == "true":
-                operations.append("delete")
-            if not operations:
-                operations = ["all"]
-
-            for op in operations:
-                phase_key = f"{when}_{op}"
-                if phase_key not in phases:
-                    phases[phase_key] = []
-                phases[phase_key].append(
-                    {
-                        "type": "business_rule",
-                        "sys_id": br.get("sys_id", ""),
-                        "name": br.get("name", ""),
-                        "order": br.get("order", ""),
-                    }
-                )
+        phases = _classify_br_phases(br_result["records"])
 
         # Add client scripts under 'client' phase
         cs_records = cs_result["records"]
@@ -173,23 +203,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             artifact_type: The artifact type (e.g. business_rule, script_include).
             sys_id: The sys_id of the artifact.
         """
-        table = ARTIFACT_TABLES.get(artifact_type)
-        if not table:
-            valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Unknown artifact type '{artifact_type}'. Valid: {valid_types}",
-            )
+        table, err = _resolve_artifact_table(artifact_type, correlation_id)
+        if err:
+            return err
 
         check_table_access(table)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            record = mask_sensitive_fields(await client.get_record(table, sys_id))
+            record, script = await _fetch_artifact_script(client, table, sys_id)
 
             # Parse script for GlideRecord('table_name') references
-            script = record.get("script", "")
             referenced_tables = _extract_gliderecord_tables(script)
 
             # Search for what references this artifact
@@ -225,23 +248,15 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             artifact_type: The artifact type (e.g. business_rule, script_include).
             sys_id: The sys_id of the artifact.
         """
-        table = ARTIFACT_TABLES.get(artifact_type)
-        if not table:
-            valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Unknown artifact type '{artifact_type}'. Valid: {valid_types}",
-            )
+        table, err = _resolve_artifact_table(artifact_type, correlation_id)
+        if err:
+            return err
 
         check_table_access(table)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            record = await client.get_record(table, sys_id)
+            record, script = await _fetch_artifact_script(client, table, sys_id)
 
-        record = mask_sensitive_fields(record)
-        script = record.get("script", "")
         scenarios = _generate_test_scenarios(script, record)
 
         return format_response(
@@ -269,23 +284,15 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             artifact_type: The artifact type (e.g. business_rule, script_include).
             sys_id: The sys_id of the artifact.
         """
-        table = ARTIFACT_TABLES.get(artifact_type)
-        if not table:
-            valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Unknown artifact type '{artifact_type}'. Valid: {valid_types}",
-            )
+        table, err = _resolve_artifact_table(artifact_type, correlation_id)
+        if err:
+            return err
 
         check_table_access(table)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            record = await client.get_record(table, sys_id)
+            record, script = await _fetch_artifact_script(client, table, sys_id)
 
-        record = mask_sensitive_fields(record)
-        script = record.get("script", "")
         findings = _scan_for_anti_patterns(script)
 
         return format_response(
@@ -319,6 +326,58 @@ def _extract_gliderecord_tables(script: str) -> list[str]:
     return result
 
 
+_SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
+    (
+        re.compile(r"current\.operation\(\)\s*==\s*['\"]insert['\"]"),
+        {
+            "scenario": "Test insert operation path",
+            "description": "Create a new record and verify the insert-specific logic executes correctly.",
+            "priority": "high",
+        },
+    ),
+    (
+        re.compile(r"current\.operation\(\)\s*==\s*['\"]update['\"]"),
+        {
+            "scenario": "Test update operation path",
+            "description": "Update an existing record and verify the update-specific logic executes correctly.",
+            "priority": "high",
+        },
+    ),
+    (
+        re.compile(r"current\.operation\(\)\s*==\s*['\"]delete['\"]"),
+        {
+            "scenario": "Test delete operation path",
+            "description": "Delete a record and verify the delete-specific logic executes correctly.",
+            "priority": "high",
+        },
+    ),
+    (
+        re.compile(r"current\.isNewRecord\(\)"),
+        {
+            "scenario": "Test new record vs existing record",
+            "description": "Test behavior for both new and existing records since isNewRecord() is used.",
+            "priority": "high",
+        },
+    ),
+    (
+        re.compile(r"\bif\s*\("),
+        {
+            "scenario": "Test condition branches",
+            "description": "Verify each conditional branch (if/else) is tested with appropriate input values.",
+            "priority": "medium",
+        },
+    ),
+    (
+        re.compile(r"setAbortAction\(true\)"),
+        {
+            "scenario": "Test abort action trigger",
+            "description": "Verify conditions under which the operation is aborted and that the abort message is appropriate.",
+            "priority": "high",
+        },
+    ),
+]
+
+
 def _generate_test_scenarios(script: str, record: dict[str, Any]) -> list[dict[str, str]]:
     """Analyze script and generate test scenario suggestions."""
     scenarios: list[dict[str, str]] = []
@@ -333,53 +392,12 @@ def _generate_test_scenarios(script: str, record: dict[str, Any]) -> list[dict[s
         )
         return scenarios
 
-    # Detect operation() checks → insert/update/delete scenarios
-    if re.search(r"current\.operation\(\)\s*==\s*['\"]insert['\"]", script):
-        scenarios.append(
-            {
-                "scenario": "Test insert operation path",
-                "description": "Create a new record and verify the insert-specific logic executes correctly.",
-                "priority": "high",
-            }
-        )
-    if re.search(r"current\.operation\(\)\s*==\s*['\"]update['\"]", script):
-        scenarios.append(
-            {
-                "scenario": "Test update operation path",
-                "description": "Update an existing record and verify the update-specific logic executes correctly.",
-                "priority": "high",
-            }
-        )
-    if re.search(r"current\.operation\(\)\s*==\s*['\"]delete['\"]", script):
-        scenarios.append(
-            {
-                "scenario": "Test delete operation path",
-                "description": "Delete a record and verify the delete-specific logic executes correctly.",
-                "priority": "high",
-            }
-        )
+    # Check data-driven patterns
+    for pattern, scenario in _SCENARIO_PATTERNS:
+        if pattern.search(script):
+            scenarios.append(scenario)
 
-    # Detect isNewRecord() checks
-    if re.search(r"current\.isNewRecord\(\)", script):
-        scenarios.append(
-            {
-                "scenario": "Test new record vs existing record",
-                "description": "Test behavior for both new and existing records since isNewRecord() is used.",
-                "priority": "high",
-            }
-        )
-
-    # Detect if/else condition branches
-    if re.search(r"\bif\s*\(", script):
-        scenarios.append(
-            {
-                "scenario": "Test condition branches",
-                "description": "Verify each conditional branch (if/else) is tested with appropriate input values.",
-                "priority": "medium",
-            }
-        )
-
-    # Detect role checks
+    # Detect role checks (dynamic - can't be data-driven)
     role_matches = re.findall(r"gs\.hasRole\(['\"]([^'\"]+)['\"]\)", script)
     scenarios.extend(
         {
@@ -389,16 +407,6 @@ def _generate_test_scenarios(script: str, record: dict[str, Any]) -> list[dict[s
         }
         for role in role_matches
     )
-
-    # Detect setAbortAction
-    if re.search(r"setAbortAction\(true\)", script):
-        scenarios.append(
-            {
-                "scenario": "Test abort action trigger",
-                "description": "Verify conditions under which the operation is aborted and that the abort message is appropriate.",
-                "priority": "high",
-            }
-        )
 
     # Detect GlideRecord queries (data dependency)
     tables = _extract_gliderecord_tables(script)

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -327,7 +327,7 @@ def _extract_gliderecord_tables(script: str) -> list[str]:
 
 
 _WHILE_BLOCK_RE: re.Pattern[str] = re.compile(r"\bwhile\s*\(")
-_GR_IN_BLOCK_RE: re.Pattern[str] = re.compile(r"new\s+GlideRecord\s*\(")
+_GR_IN_BLOCK_RE: re.Pattern[str] = re.compile(r"new\s+GlideRecord(?:Secure)?\s*\(")
 
 _SCENARIO_PATTERNS: list[tuple[re.Pattern[str], dict[str, str]]] = [
     (

--- a/src/servicenow_mcp/tools/domains/_helpers.py
+++ b/src/servicenow_mcp/tools/domains/_helpers.py
@@ -1,0 +1,168 @@
+"""Shared helpers for domain tool modules."""
+
+from servicenow_mcp.choices import ChoiceRegistry
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.policy import mask_sensitive_fields
+from servicenow_mcp.utils import ServiceNowQuery, format_response
+
+
+def validate_number_prefix(number: str, prefix: str, entity_label: str, correlation_id: str) -> str | None:
+    """Return an error response if *number* does not start with *prefix*, else None.
+
+    Args:
+        number: The record number to validate (e.g. "INC0010001")
+        prefix: Expected prefix (e.g. "INC", "PRB", "CHG", "REQ", "RITM")
+        entity_label: Human-readable entity name for error messages (e.g. "incident", "problem", "change request", "request", "request item")
+        correlation_id: Request correlation ID
+    """
+    if not number.upper().startswith(prefix):
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Invalid {entity_label} number: {number}. Must start with {prefix} prefix.",
+        )
+    return None
+
+
+async def lookup_record_by_number(
+    client: ServiceNowClient,
+    table: str,
+    number: str,
+    entity_label: str,
+    correlation_id: str,
+) -> tuple[str, str | None]:
+    """Look up a record by number and return (sys_id, None) or ("", error_response).
+
+    Args:
+        client: Active ServiceNow client
+        table: Table name (e.g. "incident")
+        number: Record number (already validated, will be uppercased)
+        entity_label: Human-readable name for error messages (e.g. "Incident", "Problem")
+        correlation_id: Request correlation ID
+    """
+    result = await client.query_records(
+        table=table,
+        query=ServiceNowQuery().equals("number", number.upper()).build(),
+        limit=1,
+    )
+    if not result["records"]:
+        return "", format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"{entity_label} {number} not found.",
+        )
+    return result["records"][0]["sys_id"], None
+
+
+async def fetch_record_by_number(
+    client: ServiceNowClient,
+    table: str,
+    number: str,
+    entity_label: str,
+    correlation_id: str,
+) -> str:
+    """Fetch a single record by number, returning a formatted success or error response.
+
+    Used by _get tools that return the full record. Applies mask_sensitive_fields.
+
+    Args:
+        client: Active ServiceNow client
+        table: Table name (e.g. "incident")
+        number: Record number (already validated, will be uppercased)
+        entity_label: Human-readable name for error messages (e.g. "Incident")
+        correlation_id: Request correlation ID
+    """
+    result = await client.query_records(
+        table=table,
+        query=ServiceNowQuery().equals("number", number.upper()).build(),
+        display_values=True,
+        limit=1,
+    )
+    if not result["records"]:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"{entity_label} {number} not found.",
+        )
+    masked = mask_sensitive_fields(result["records"][0])
+    return format_response(data=masked, correlation_id=correlation_id)
+
+
+def validate_int_range(value: int, field_name: str, min_val: int, max_val: int, correlation_id: str) -> str | None:
+    """Return an error response if *value* is outside [min_val, max_val], else None.
+
+    Args:
+        value: The integer value to validate
+        field_name: Field name for error message (e.g. "urgency", "impact")
+        min_val: Minimum allowed value (inclusive)
+        max_val: Maximum allowed value (inclusive)
+        correlation_id: Request correlation ID
+    """
+    if value < min_val or value > max_val:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"{field_name} must be between {min_val} and {max_val}, got {value}.",
+        )
+    return None
+
+
+def validate_required_string(value: str, field_name: str, correlation_id: str) -> str | None:
+    """Return an error response if *value* is empty or whitespace, else None.
+
+    Args:
+        value: The string value to validate
+        field_name: Field name for error message (e.g. "short_description", "close_code")
+        correlation_id: Request correlation ID
+    """
+    if not value or not value.strip():
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"{field_name} is required and cannot be empty.",
+        )
+    return None
+
+
+def validate_no_empty_changes(changes: dict[str, str], correlation_id: str) -> str | None:
+    """Return an error response if *changes* dict is empty, else None.
+
+    Args:
+        changes: Dictionary of field changes
+        correlation_id: Request correlation ID
+    """
+    if not changes:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="No fields to update provided.",
+        )
+    return None
+
+
+def parse_field_list(fields: str) -> list[str] | None:
+    """Parse a comma-separated field string into a list, or None if empty.
+
+    Args:
+        fields: Comma-separated field names (may contain whitespace around commas)
+    """
+    return [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+
+
+async def resolve_state(table: str, state: str, choices: ChoiceRegistry | None) -> str:
+    """Resolve a human-readable state label to its internal value.
+
+    Args:
+        table: ServiceNow table name (e.g. "incident")
+        state: State label to resolve (will be lowercased)
+        choices: Optional ChoiceRegistry for label-to-value mapping
+    """
+    if choices:
+        return await choices.resolve(table, "state", state.lower())
+    return state

--- a/src/servicenow_mcp/tools/domains/change.py
+++ b/src/servicenow_mcp/tools/domains/change.py
@@ -9,6 +9,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     check_table_access,
+    enforce_query_safety,
     mask_sensitive_fields,
     write_gate,
 )
@@ -22,6 +23,10 @@ from servicenow_mcp.tools.domains._helpers import (
     validate_required_string,
 )
 from servicenow_mcp.utils import ServiceNowQuery, format_response
+
+
+_CHANGE_ENTITY_LABEL = "change request"
+_CHANGE_ENTITY_TITLE = "Change request"
 
 
 def register_tools(
@@ -74,13 +79,16 @@ def register_tools(
         query = q.build()
         field_list = parse_field_list(fields)
 
+        safety = enforce_query_safety("change_request", query, limit, settings)
+        effective_limit = safety["limit"]
+
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="change_request",
                 query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)
@@ -95,12 +103,12 @@ def register_tools(
         """
         check_table_access("change_request")
 
-        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        err = validate_number_prefix(number, "CHG", _CHANGE_ENTITY_LABEL, correlation_id)
         if err:
             return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            return await fetch_record_by_number(client, "change_request", number, "Change request", correlation_id)
+            return await fetch_record_by_number(client, "change_request", number, _CHANGE_ENTITY_TITLE, correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -196,13 +204,13 @@ def register_tools(
         if blocked:
             return blocked
 
-        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        err = validate_number_prefix(number, "CHG", _CHANGE_ENTITY_LABEL, correlation_id)
         if err:
             return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
             sys_id, err = await lookup_record_by_number(
-                client, "change_request", number, "Change request", correlation_id
+                client, "change_request", number, _CHANGE_ENTITY_TITLE, correlation_id
             )
             if err:
                 return err
@@ -247,19 +255,23 @@ def register_tools(
         """
         check_table_access("change_task")
 
-        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        err = validate_number_prefix(number, "CHG", _CHANGE_ENTITY_LABEL, correlation_id)
         if err:
             return err
 
         field_list = parse_field_list(fields)
 
+        query = ServiceNowQuery().equals("change_request.number", number.upper()).build()
+        safety = enforce_query_safety("change_task", query, limit, settings)
+        effective_limit = safety["limit"]
+
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="change_task",
-                query=ServiceNowQuery().equals("change_request.number", number.upper()).build(),
+                query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)
@@ -286,7 +298,7 @@ def register_tools(
         if blocked:
             return blocked
 
-        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        err = validate_number_prefix(number, "CHG", _CHANGE_ENTITY_LABEL, correlation_id)
         if err:
             return err
 
@@ -300,7 +312,7 @@ def register_tools(
 
         async with ServiceNowClient(settings, auth_provider) as client:
             sys_id, err = await lookup_record_by_number(
-                client, "change_request", number, "Change request", correlation_id
+                client, "change_request", number, _CHANGE_ENTITY_TITLE, correlation_id
             )
             if err:
                 return err

--- a/src/servicenow_mcp/tools/domains/change.py
+++ b/src/servicenow_mcp/tools/domains/change.py
@@ -12,6 +12,15 @@ from servicenow_mcp.policy import (
     mask_sensitive_fields,
     write_gate,
 )
+from servicenow_mcp.tools.domains._helpers import (
+    fetch_record_by_number,
+    lookup_record_by_number,
+    parse_field_list,
+    resolve_state,
+    validate_no_empty_changes,
+    validate_number_prefix,
+    validate_required_string,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
@@ -56,14 +65,14 @@ def register_tools(
 
         q = ServiceNowQuery()
         if state:
-            resolved = await choices.resolve("change_request", "state", state.lower()) if choices else state
+            resolved = await resolve_state("change_request", state, choices)
             q = q.equals_if("state", resolved, True)
         q = q.equals_if("type", type, bool(type))
         q = q.equals_if("risk", risk, bool(risk))
         q = q.equals_if("assignment_group", assignment_group, bool(assignment_group))
 
         query = q.build()
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -86,30 +95,12 @@ def register_tools(
         """
         check_table_access("change_request")
 
-        if not number.upper().startswith("CHG"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid change request number: {number}. Must start with CHG prefix.",
-            )
+        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="change_request",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                display_values=True,
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Change request {number} not found.",
-                )
-            masked = mask_sensitive_fields(result["records"][0])
-            return format_response(data=masked, correlation_id=correlation_id)
+            return await fetch_record_by_number(client, "change_request", number, "Change request", correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -141,13 +132,9 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not short_description or not short_description.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="short_description is required and cannot be empty.",
-            )
+        err = validate_required_string(short_description, "short_description", correlation_id)
+        if err:
+            return err
 
         valid_types = ["standard", "normal", "emergency"]
         if type and type not in valid_types:
@@ -209,29 +196,16 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("CHG"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid change request number: {number}. Must start with CHG prefix.",
-            )
+        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="change_request",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
+            sys_id, err = await lookup_record_by_number(
+                client, "change_request", number, "Change request", correlation_id
             )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Change request {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            if err:
+                return err
 
             changes = {}
             if short_description:
@@ -245,15 +219,11 @@ def register_tools(
             if assignment_group:
                 changes["assignment_group"] = assignment_group
             if state:
-                changes["state"] = await choices.resolve("change_request", "state", state.lower()) if choices else state
+                changes["state"] = await resolve_state("change_request", state, choices)
 
-            if not changes:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="No fields to update provided.",
-                )
+            err = validate_no_empty_changes(changes, correlation_id)
+            if err:
+                return err
 
             updated = await client.update_record("change_request", sys_id, changes)
             masked = mask_sensitive_fields(updated)
@@ -277,15 +247,11 @@ def register_tools(
         """
         check_table_access("change_task")
 
-        if not number.upper().startswith("CHG"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid change request number: {number}. Must start with CHG prefix.",
-            )
+        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        if err:
+            return err
 
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -320,13 +286,9 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("CHG"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid change request number: {number}. Must start with CHG prefix.",
-            )
+        err = validate_number_prefix(number, "CHG", "change request", correlation_id)
+        if err:
+            return err
 
         if not comment and not work_note:
             return format_response(
@@ -337,20 +299,11 @@ def register_tools(
             )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="change_request",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
+            sys_id, err = await lookup_record_by_number(
+                client, "change_request", number, "Change request", correlation_id
             )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Change request {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            if err:
+                return err
 
             changes = {}
             if comment:

--- a/src/servicenow_mcp/tools/domains/cmdb.py
+++ b/src/servicenow_mcp/tools/domains/cmdb.py
@@ -13,6 +13,14 @@ from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
+_SYS_ID_RE: re.Pattern[str] = re.compile(r"^[a-f0-9]{32}$")
+
+
+def _is_sys_id(value: str) -> bool:
+    """Check if a string looks like a ServiceNow sys_id (32-char hex)."""
+    return bool(_SYS_ID_RE.match(value.lower()))
+
+
 def register_tools(
     mcp: FastMCP,
     settings: Settings,
@@ -87,7 +95,7 @@ def register_tools(
         check_table_access(ci_class)
 
         # Detect if input is sys_id (32-char hex string)
-        is_sys_id = bool(re.match(r"^[a-f0-9]{32}$", name_or_sys_id.lower()))
+        is_sys_id = _is_sys_id(name_or_sys_id)
 
         if is_sys_id:
             query = ServiceNowQuery().equals("sys_id", name_or_sys_id).build()
@@ -131,7 +139,7 @@ def register_tools(
         check_table_access("cmdb_rel_ci")
 
         # Detect if input is sys_id (32-char hex string)
-        is_sys_id = bool(re.match(r"^[a-f0-9]{32}$", name_or_sys_id.lower()))
+        is_sys_id = _is_sys_id(name_or_sys_id)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             # If name provided, resolve to sys_id first

--- a/src/servicenow_mcp/tools/domains/incident.py
+++ b/src/servicenow_mcp/tools/domains/incident.py
@@ -12,6 +12,16 @@ from servicenow_mcp.policy import (
     mask_sensitive_fields,
     write_gate,
 )
+from servicenow_mcp.tools.domains._helpers import (
+    fetch_record_by_number,
+    lookup_record_by_number,
+    parse_field_list,
+    resolve_state,
+    validate_int_range,
+    validate_no_empty_changes,
+    validate_number_prefix,
+    validate_required_string,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
@@ -56,14 +66,14 @@ def register_tools(
 
         q = ServiceNowQuery()
         if state and state != "all":
-            resolved = await choices.resolve("incident", "state", state.lower()) if choices else state
+            resolved = await resolve_state("incident", state, choices)
             q = q.equals_if("state", resolved, True)
         q = q.equals_if("priority", priority, bool(priority))
         q = q.equals_if("assigned_to", assigned_to, bool(assigned_to))
         q = q.equals_if("assignment_group", assignment_group, bool(assignment_group))
 
         query = q.build()
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -86,30 +96,12 @@ def register_tools(
         """
         check_table_access("incident")
 
-        if not number.upper().startswith("INC"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid incident number: {number}. Must start with INC prefix.",
-            )
+        err = validate_number_prefix(number, "INC", "incident", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="incident",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                display_values=True,
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Incident {number} not found.",
-                )
-            masked = mask_sensitive_fields(result["records"][0])
-            return format_response(data=masked, correlation_id=correlation_id)
+            return await fetch_record_by_number(client, "incident", number, "Incident", correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -147,29 +139,17 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not short_description or not short_description.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="short_description is required and cannot be empty.",
-            )
+        err = validate_required_string(short_description, "short_description", correlation_id)
+        if err:
+            return err
 
-        if urgency < 1 or urgency > 4:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"urgency must be between 1 and 4, got {urgency}.",
-            )
+        err = validate_int_range(urgency, "urgency", 1, 4, correlation_id)
+        if err:
+            return err
 
-        if impact < 1 or impact > 4:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"impact must be between 1 and 4, got {impact}.",
-            )
+        err = validate_int_range(impact, "impact", 1, 4, correlation_id)
+        if err:
+            return err
 
         record_data = {
             "short_description": short_description,
@@ -234,29 +214,14 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("INC"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid incident number: {number}. Must start with INC prefix.",
-            )
+        err = validate_number_prefix(number, "INC", "incident", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="incident",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Incident {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, err = await lookup_record_by_number(client, "incident", number, "Incident", correlation_id)
+            if err:
+                return err
 
             changes = {}
             if short_description:
@@ -268,7 +233,7 @@ def register_tools(
             if priority > 0:
                 changes["priority"] = str(priority)
             if state:
-                changes["state"] = await choices.resolve("incident", "state", state.lower()) if choices else state
+                changes["state"] = await resolve_state("incident", state, choices)
             if description:
                 changes["description"] = description
             if assignment_group:
@@ -280,13 +245,9 @@ def register_tools(
             if subcategory:
                 changes["subcategory"] = subcategory
 
-            if not changes:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="No fields to update provided.",
-                )
+            err = validate_no_empty_changes(changes, correlation_id)
+            if err:
+                return err
 
             updated = await client.update_record("incident", sys_id, changes)
             masked = mask_sensitive_fields(updated)
@@ -314,45 +275,22 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("INC"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid incident number: {number}. Must start with INC prefix.",
-            )
+        err = validate_number_prefix(number, "INC", "incident", correlation_id)
+        if err:
+            return err
 
-        if not close_code or not close_code.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="close_code is required and cannot be empty.",
-            )
+        err = validate_required_string(close_code, "close_code", correlation_id)
+        if err:
+            return err
 
-        if not close_notes or not close_notes.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="close_notes is required and cannot be empty.",
-            )
+        err = validate_required_string(close_notes, "close_notes", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="incident",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Incident {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, err = await lookup_record_by_number(client, "incident", number, "Incident", correlation_id)
+            if err:
+                return err
 
             resolved_state = await choices.resolve("incident", "state", "resolved") if choices else "6"
             changes = {
@@ -387,13 +325,9 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("INC"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid incident number: {number}. Must start with INC prefix.",
-            )
+        err = validate_number_prefix(number, "INC", "incident", correlation_id)
+        if err:
+            return err
 
         if not comment and not work_note:
             return format_response(
@@ -404,20 +338,9 @@ def register_tools(
             )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="incident",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Incident {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, err = await lookup_record_by_number(client, "incident", number, "Incident", correlation_id)
+            if err:
+                return err
 
             changes = {}
             if comment:

--- a/src/servicenow_mcp/tools/domains/incident.py
+++ b/src/servicenow_mcp/tools/domains/incident.py
@@ -9,6 +9,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     check_table_access,
+    enforce_query_safety,
     mask_sensitive_fields,
     write_gate,
 )
@@ -75,13 +76,16 @@ def register_tools(
         query = q.build()
         field_list = parse_field_list(fields)
 
+        safety = enforce_query_safety("incident", query, limit, settings)
+        effective_limit = safety["limit"]
+
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="incident",
                 query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)
@@ -148,6 +152,10 @@ def register_tools(
             return err
 
         err = validate_int_range(impact, "impact", 1, 4, correlation_id)
+        if err:
+            return err
+
+        err = validate_int_range(priority, "priority", 1, 5, correlation_id)
         if err:
             return err
 

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -11,6 +11,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     check_table_access,
+    enforce_query_safety,
     mask_sensitive_fields,
     write_gate,
 )
@@ -158,13 +159,16 @@ def register_tools(
         )
         field_list = parse_field_list(fields)
 
+        safety = enforce_query_safety("kb_knowledge", search_query, limit, settings)
+        effective_limit = safety["limit"]
+
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="kb_knowledge",
                 query=search_query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -86,49 +86,6 @@ def register_tools(
         record = result["records"][0]
         return record["sys_id"], record, None
 
-    async def _resolve_article_sys_id(
-        client: ServiceNowClient,
-        number_or_sys_id: str,
-        correlation_id: str,
-        display_values: bool = False,
-    ) -> tuple[str, dict[str, str] | None, str | None]:
-        """Resolve a KB number or sys_id to (sys_id, record_or_None, error_or_None).
-
-        When display_values=True, returns the full record (for knowledge_get).
-        Otherwise returns just the sys_id (for update/feedback).
-        """
-        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
-
-        result = await client.query_records(
-            table="kb_knowledge",
-            query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
-            display_values=display_values,
-            limit=1,
-        )
-
-        if not result["records"] and is_sys_id:
-            result = await client.query_records(
-                table="kb_knowledge",
-                query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
-                display_values=display_values,
-                limit=1,
-            )
-
-        if not result["records"]:
-            return (
-                "",
-                None,
-                format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Knowledge article '{number_or_sys_id}' not found.",
-                ),
-            )
-
-        record = result["records"][0]
-        return record["sys_id"], record, None
-
     @mcp.tool()
     @tool_handler
     async def knowledge_search(

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -85,6 +85,49 @@ def register_tools(
         record = result["records"][0]
         return record["sys_id"], record, None
 
+    async def _resolve_article_sys_id(
+        client: ServiceNowClient,
+        number_or_sys_id: str,
+        correlation_id: str,
+        display_values: bool = False,
+    ) -> tuple[str, dict[str, str] | None, str | None]:
+        """Resolve a KB number or sys_id to (sys_id, record_or_None, error_or_None).
+
+        When display_values=True, returns the full record (for knowledge_get).
+        Otherwise returns just the sys_id (for update/feedback).
+        """
+        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
+
+        result = await client.query_records(
+            table="kb_knowledge",
+            query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
+            display_values=display_values,
+            limit=1,
+        )
+
+        if not result["records"] and is_sys_id:
+            result = await client.query_records(
+                table="kb_knowledge",
+                query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
+                display_values=display_values,
+                limit=1,
+            )
+
+        if not result["records"]:
+            return (
+                "",
+                None,
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Knowledge article '{number_or_sys_id}' not found.",
+                ),
+            )
+
+        record = result["records"][0]
+        return record["sys_id"], record, None
+
     @mcp.tool()
     @tool_handler
     async def knowledge_search(

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -23,8 +23,8 @@ _SYS_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-f0-9]{32}$")
 
 
 def _collect_non_empty(**fields: str) -> dict[str, str]:
-    """Collect non-empty string values into a dict."""
-    return {k: v for k, v in fields.items() if v}
+    """Return only the entries whose values are non-empty after stripping whitespace."""
+    return {k: stripped for k, v in fields.items() if (stripped := v.strip())}
 
 
 def register_tools(

--- a/src/servicenow_mcp/tools/domains/knowledge.py
+++ b/src/servicenow_mcp/tools/domains/knowledge.py
@@ -14,10 +14,16 @@ from servicenow_mcp.policy import (
     mask_sensitive_fields,
     write_gate,
 )
+from servicenow_mcp.tools.domains._helpers import parse_field_list, validate_no_empty_changes, validate_required_string
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
 _SYS_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-f0-9]{32}$")
+
+
+def _collect_non_empty(**fields: str) -> dict[str, str]:
+    """Collect non-empty string values into a dict."""
+    return {k: v for k, v in fields.items() if v}
 
 
 def register_tools(
@@ -40,40 +46,44 @@ def register_tools(
         client: ServiceNowClient,
         number_or_sys_id: str,
         correlation_id: str,
-    ) -> tuple[str | None, str | None]:
-        """Resolve a KB article identifier to its sys_id.
+        display_values: bool = False,
+    ) -> tuple[str, dict[str, str] | None, str | None]:
+        """Resolve a KB number or sys_id to (sys_id, record_or_None, error_or_None).
 
-        Tries lookup by number first, then falls back to sys_id if the input
-        matches the 32-char hex pattern.
-
-        Returns:
-            Tuple of (sys_id, None) on success, or (None, error_response) on failure.
+        When display_values=True, returns the full record (for knowledge_get).
+        Otherwise returns just the sys_id (for update/feedback).
         """
-        normalized_input = number_or_sys_id.lower()
-        is_sys_id = bool(_SYS_ID_PATTERN.match(normalized_input))
+        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
 
         result = await client.query_records(
             table="kb_knowledge",
             query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
+            display_values=display_values,
             limit=1,
         )
 
         if not result["records"] and is_sys_id:
             result = await client.query_records(
                 table="kb_knowledge",
-                query=ServiceNowQuery().equals("sys_id", normalized_input).build(),
+                query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
+                display_values=display_values,
                 limit=1,
             )
 
         if not result["records"]:
-            return None, format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Knowledge article '{number_or_sys_id}' not found.",
+            return (
+                "",
+                None,
+                format_response(
+                    data=None,
+                    correlation_id=correlation_id,
+                    status="error",
+                    error=f"Knowledge article '{number_or_sys_id}' not found.",
+                ),
             )
 
-        return result["records"][0]["sys_id"], None
+        record = result["records"][0]
+        return record["sys_id"], record, None
 
     @mcp.tool()
     @tool_handler
@@ -103,7 +113,7 @@ def register_tools(
             .equals("workflow_state", workflow_state)
             .build()
         )
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -130,36 +140,15 @@ def register_tools(
         """
         check_table_access("kb_knowledge")
 
-        # Detect if input is sys_id (32-char lowercase hex string)
-        is_sys_id = bool(_SYS_ID_PATTERN.match(number_or_sys_id.lower()))
-
         async with ServiceNowClient(settings, auth_provider) as client:
-            # Try lookup by number first
-            result = await client.query_records(
-                table="kb_knowledge",
-                query=ServiceNowQuery().equals("number", number_or_sys_id.upper()).build(),
-                display_values=True,
-                limit=1,
+            _sys_id, record, err = await _resolve_article_sys_id(
+                client, number_or_sys_id, correlation_id, display_values=True
             )
+            if err:
+                return err
 
-            # If not found and looks like sys_id, try sys_id lookup
-            if not result["records"] and is_sys_id:
-                result = await client.query_records(
-                    table="kb_knowledge",
-                    query=ServiceNowQuery().equals("sys_id", number_or_sys_id).build(),
-                    display_values=True,
-                    limit=1,
-                )
-
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Knowledge article '{number_or_sys_id}' not found.",
-                )
-
-            masked = mask_sensitive_fields(result["records"][0])
+            assert record is not None  # guaranteed when err is None
+            masked = mask_sensitive_fields(record)
             return format_response(data=masked, correlation_id=correlation_id)
 
     @mcp.tool()
@@ -183,21 +172,13 @@ def register_tools(
             workflow_state: Workflow state (default "draft")
         """
         # Validate required fields
-        if not short_description.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="short_description is required and cannot be empty.",
-            )
+        err = validate_required_string(short_description, "short_description", correlation_id)
+        if err:
+            return err
 
-        if not text.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="text is required and cannot be empty.",
-            )
+        err = validate_required_string(text, "text", correlation_id)
+        if err:
+            return err
 
         check_table_access("kb_knowledge")
 
@@ -252,41 +233,23 @@ def register_tools(
             return gate_error
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
-            if error or not sys_id:
-                return error or format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Failed to resolve article '{number_or_sys_id}'",
-                )
+            sys_id, _, err = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
+            if err:
+                return err
 
-            # Build changes dict (only include non-empty params)
-            changes: dict[str, str] = {}
-            if short_description:
-                changes["short_description"] = short_description
-            if text:
-                changes["text"] = text
-            if workflow_state:
-                changes["workflow_state"] = workflow_state
-            if kb_knowledge_base:
-                changes["kb_knowledge_base"] = kb_knowledge_base
-            if kb_category:
-                changes["kb_category"] = kb_category
-
-            if not changes:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="No fields to update provided.",
-                )
-
-            update_result = await client.update_record(
-                table="kb_knowledge",
-                sys_id=sys_id,
-                data=changes,
+            changes = _collect_non_empty(
+                short_description=short_description,
+                text=text,
+                workflow_state=workflow_state,
+                kb_knowledge_base=kb_knowledge_base,
+                kb_category=kb_category,
             )
+
+            err = validate_no_empty_changes(changes, correlation_id)
+            if err:
+                return err
+
+            update_result = await client.update_record(table="kb_knowledge", sys_id=sys_id, data=changes)
             masked = mask_sensitive_fields(update_result)
             return format_response(data=masked, correlation_id=correlation_id)
 
@@ -334,14 +297,9 @@ def register_tools(
             return gate_error
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            article_sys_id, error = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
-            if error or not article_sys_id:
-                return error or format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Failed to resolve article '{number_or_sys_id}'",
-                )
+            article_sys_id, _, err = await _resolve_article_sys_id(client, number_or_sys_id, correlation_id)
+            if err:
+                return err
 
             feedback_data: dict[str, str] = {"article": article_sys_id}
             if rating is not None:

--- a/src/servicenow_mcp/tools/domains/problem.py
+++ b/src/servicenow_mcp/tools/domains/problem.py
@@ -12,6 +12,16 @@ from servicenow_mcp.policy import (
     mask_sensitive_fields,
     write_gate,
 )
+from servicenow_mcp.tools.domains._helpers import (
+    fetch_record_by_number,
+    lookup_record_by_number,
+    parse_field_list,
+    resolve_state,
+    validate_int_range,
+    validate_no_empty_changes,
+    validate_number_prefix,
+    validate_required_string,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
@@ -56,13 +66,13 @@ def register_tools(
 
         q = ServiceNowQuery()
         if state and state != "all":
-            resolved = await choices.resolve("problem", "state", state.lower()) if choices else state
+            resolved = await resolve_state("problem", state, choices)
             q = q.equals_if("state", resolved, True)
         q = q.equals_if("priority", priority, bool(priority))
         q = q.equals_if("assigned_to", assigned_to, bool(assigned_to))
         q = q.equals_if("assignment_group", assignment_group, bool(assignment_group))
         query = q.build()
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -85,30 +95,12 @@ def register_tools(
         """
         check_table_access("problem")
 
-        if not number.upper().startswith("PRB"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid problem number: {number}. Must start with PRB prefix.",
-            )
+        err = validate_number_prefix(number, "PRB", "problem", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="problem",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                display_values=True,
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Problem {number} not found.",
-                )
-            masked = mask_sensitive_fields(result["records"][0])
-            return format_response(data=masked, correlation_id=correlation_id)
+            return await fetch_record_by_number(client, "problem", number, "Problem", correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -144,29 +136,17 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not short_description or not short_description.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="short_description is required and cannot be empty.",
-            )
+        err = validate_required_string(short_description, "short_description", correlation_id)
+        if err:
+            return err
 
-        if urgency < 1 or urgency > 4:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"urgency must be between 1 and 4, got {urgency}.",
-            )
+        err = validate_int_range(urgency, "urgency", 1, 4, correlation_id)
+        if err:
+            return err
 
-        if impact < 1 or impact > 4:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"impact must be between 1 and 4, got {impact}.",
-            )
+        err = validate_int_range(impact, "impact", 1, 4, correlation_id)
+        if err:
+            return err
 
         record_data = {
             "short_description": short_description,
@@ -229,29 +209,14 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("PRB"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid problem number: {number}. Must start with PRB prefix.",
-            )
+        err = validate_number_prefix(number, "PRB", "problem", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="problem",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Problem {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, err = await lookup_record_by_number(client, "problem", number, "Problem", correlation_id)
+            if err:
+                return err
 
             changes = {}
             if short_description:
@@ -263,7 +228,7 @@ def register_tools(
             if priority > 0:
                 changes["priority"] = str(priority)
             if state:
-                changes["state"] = await choices.resolve("problem", "state", state.lower()) if choices else state
+                changes["state"] = await resolve_state("problem", state, choices)
             if description:
                 changes["description"] = description
             if assigned_to:
@@ -275,13 +240,9 @@ def register_tools(
             if subcategory:
                 changes["subcategory"] = subcategory
 
-            if not changes:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="No fields to update provided.",
-                )
+            err = validate_no_empty_changes(changes, correlation_id)
+            if err:
+                return err
 
             updated = await client.update_record("problem", sys_id, changes)
             masked = mask_sensitive_fields(updated)
@@ -309,37 +270,18 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("PRB"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid problem number: {number}. Must start with PRB prefix.",
-            )
+        err = validate_number_prefix(number, "PRB", "problem", correlation_id)
+        if err:
+            return err
 
-        if not cause_notes or not cause_notes.strip():
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="cause_notes is required and cannot be empty.",
-            )
+        err = validate_required_string(cause_notes, "cause_notes", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="problem",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Problem {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, err = await lookup_record_by_number(client, "problem", number, "Problem", correlation_id)
+            if err:
+                return err
 
             changes = {"cause_notes": cause_notes}
             if fix_notes and fix_notes.strip():

--- a/src/servicenow_mcp/tools/domains/problem.py
+++ b/src/servicenow_mcp/tools/domains/problem.py
@@ -9,6 +9,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     check_table_access,
+    enforce_query_safety,
     mask_sensitive_fields,
     write_gate,
 )
@@ -74,13 +75,16 @@ def register_tools(
         query = q.build()
         field_list = parse_field_list(fields)
 
+        safety = enforce_query_safety("problem", query, limit, settings)
+        effective_limit = safety["limit"]
+
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="problem",
                 query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)
@@ -145,6 +149,10 @@ def register_tools(
             return err
 
         err = validate_int_range(impact, "impact", 1, 4, correlation_id)
+        if err:
+            return err
+
+        err = validate_int_range(priority, "priority", 1, 5, correlation_id)
         if err:
             return err
 

--- a/src/servicenow_mcp/tools/domains/request.py
+++ b/src/servicenow_mcp/tools/domains/request.py
@@ -9,6 +9,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     check_table_access,
+    enforce_query_safety,
     mask_sensitive_fields,
     write_gate,
 )
@@ -69,13 +70,16 @@ def register_tools(
         query = q.build()
         field_list = parse_field_list(fields)
 
+        safety = enforce_query_safety("sc_request", query, limit, settings)
+        effective_limit = safety["limit"]
+
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="sc_request",
                 query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)
@@ -120,14 +124,18 @@ def register_tools(
             return err
 
         field_list = parse_field_list(fields)
+        query = ServiceNowQuery().equals("request.number", number.upper()).build()
+
+        safety = enforce_query_safety("sc_req_item", query, limit, settings)
+        effective_limit = safety["limit"]
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
                 table="sc_req_item",
-                query=ServiceNowQuery().equals("request.number", number.upper()).build(),
+                query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)

--- a/src/servicenow_mcp/tools/domains/request.py
+++ b/src/servicenow_mcp/tools/domains/request.py
@@ -12,6 +12,14 @@ from servicenow_mcp.policy import (
     mask_sensitive_fields,
     write_gate,
 )
+from servicenow_mcp.tools.domains._helpers import (
+    fetch_record_by_number,
+    lookup_record_by_number,
+    parse_field_list,
+    resolve_state,
+    validate_no_empty_changes,
+    validate_number_prefix,
+)
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
@@ -54,12 +62,12 @@ def register_tools(
 
         q = ServiceNowQuery()
         if state:
-            resolved = await choices.resolve("sc_request", "state", state.lower()) if choices else state
+            resolved = await resolve_state("sc_request", state, choices)
             q = q.equals_if("state", resolved, True)
         q = q.equals_if("requested_for", requested_for, bool(requested_for))
         q = q.equals_if("assignment_group", assignment_group, bool(assignment_group))
         query = q.build()
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -82,30 +90,12 @@ def register_tools(
         """
         check_table_access("sc_request")
 
-        if not number.upper().startswith("REQ"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid request number: {number}. Must start with REQ prefix.",
-            )
+        err = validate_number_prefix(number, "REQ", "request", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="sc_request",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                display_values=True,
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Request {number} not found.",
-                )
-            masked = mask_sensitive_fields(result["records"][0])
-            return format_response(data=masked, correlation_id=correlation_id)
+            return await fetch_record_by_number(client, "sc_request", number, "Request", correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -125,15 +115,11 @@ def register_tools(
         """
         check_table_access("sc_req_item")
 
-        if not number.upper().startswith("REQ"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid request number: {number}. Must start with REQ prefix.",
-            )
+        err = validate_number_prefix(number, "REQ", "request", correlation_id)
+        if err:
+            return err
 
-        field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+        field_list = parse_field_list(fields)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -156,30 +142,12 @@ def register_tools(
         """
         check_table_access("sc_req_item")
 
-        if not number.upper().startswith("RITM"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid request item number: {number}. Must start with RITM prefix.",
-            )
+        err = validate_number_prefix(number, "RITM", "request item", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="sc_req_item",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                display_values=True,
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Request item {number} not found.",
-                )
-            masked = mask_sensitive_fields(result["records"][0])
-            return format_response(data=masked, correlation_id=correlation_id)
+            return await fetch_record_by_number(client, "sc_req_item", number, "Request item", correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -205,45 +173,26 @@ def register_tools(
         if blocked:
             return blocked
 
-        if not number.upper().startswith("RITM"):
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error=f"Invalid request item number: {number}. Must start with RITM prefix.",
-            )
+        err = validate_number_prefix(number, "RITM", "request item", correlation_id)
+        if err:
+            return err
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.query_records(
-                table="sc_req_item",
-                query=ServiceNowQuery().equals("number", number.upper()).build(),
-                limit=1,
-            )
-            if not result["records"]:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error=f"Request item {number} not found.",
-                )
-
-            sys_id = result["records"][0]["sys_id"]
+            sys_id, err = await lookup_record_by_number(client, "sc_req_item", number, "Request item", correlation_id)
+            if err:
+                return err
 
             changes = {}
             if state:
-                changes["state"] = await choices.resolve("sc_req_item", "state", state.lower()) if choices else state
+                changes["state"] = await resolve_state("sc_req_item", state, choices)
             if assignment_group:
                 changes["assignment_group"] = assignment_group
             if assigned_to:
                 changes["assigned_to"] = assigned_to
 
-            if not changes:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="No fields to update provided.",
-                )
+            err = validate_no_empty_changes(changes, correlation_id)
+            if err:
+                return err
 
             updated = await client.update_record("sc_req_item", sys_id, changes)
             masked = mask_sensitive_fields(updated)

--- a/src/servicenow_mcp/tools/metadata.py
+++ b/src/servicenow_mcp/tools/metadata.py
@@ -45,6 +45,19 @@ SCRIPT_TABLES: list[str] = [
 ]
 
 
+def _resolve_artifact_table(artifact_type: str) -> str:
+    """Resolve artifact_type to its ServiceNow table name.
+
+    Raises:
+        ValueError: If artifact_type is not in ARTIFACT_TABLES.
+    """
+    table = ARTIFACT_TABLES.get(artifact_type)
+    if table is None:
+        valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
+        raise ValueError(f"Unknown artifact_type '{artifact_type}'. Valid types: {valid_types}")
+    return table
+
+
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """Register metadata tools on the MCP server."""
     query_store: QueryTokenStore = mcp._sn_query_store  # type: ignore[attr-defined]
@@ -67,10 +80,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 Leave empty for no additional filter.
             limit: Maximum number of artifacts to return.
         """
-        table = ARTIFACT_TABLES.get(artifact_type)
-        if table is None:
-            valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
-            raise ValueError(f"Unknown artifact type '{artifact_type}'. Valid types: {valid_types}")
+        table = _resolve_artifact_table(artifact_type)
 
         check_table_access(table)
 
@@ -110,10 +120,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             artifact_type: The type of artifact (business_rule, script_include, etc.).
             sys_id: The sys_id of the artifact to retrieve.
         """
-        table = ARTIFACT_TABLES.get(artifact_type)
-        if table is None:
-            valid_types = ", ".join(sorted(ARTIFACT_TABLES.keys()))
-            raise ValueError(f"Unknown artifact type '{artifact_type}'. Valid types: {valid_types}")
+        table = _resolve_artifact_table(artifact_type)
 
         check_table_access(table)
 

--- a/src/servicenow_mcp/tools/testing.py
+++ b/src/servicenow_mcp/tools/testing.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import time
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
@@ -29,6 +30,32 @@ logger = logging.getLogger(__name__)
 ATF_POLL_INTERVAL = 5
 ATF_MAX_POLL_DURATION = 300
 
+_PASS_STATUSES: frozenset[str] = frozenset({"success", "passed"})
+
+
+def _is_pass(record: dict[str, Any]) -> bool:
+    """Return True if the record status indicates a passing result."""
+    return record.get("status", "").lower() in _PASS_STATUSES
+
+
+def _validate_exclusive_ids(test_id: str, suite_id: str, correlation_id: str) -> str | None:
+    """Return error if not exactly one of test_id/suite_id is provided, else None."""
+    if not test_id and not suite_id:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="Must provide exactly one of test_id or suite_id.",
+        )
+    if test_id and suite_id:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="Must provide exactly one of test_id or suite_id, not both.",
+        )
+    return None
+
 
 def _atf_execution_gate(settings: Settings, correlation_id: str) -> str | None:
     """Gate ATF execution tools - running tests creates result records."""
@@ -41,6 +68,122 @@ def _atf_execution_gate(settings: Settings, correlation_id: str) -> str | None:
             error=reason,
         )
     return None
+
+
+async def _atf_run_and_poll(
+    client: ServiceNowClient,
+    run_id: str,
+    is_suite: bool,
+    poll: bool,
+    poll_interval: int,
+    max_poll_duration: int,
+    correlation_id: str,
+) -> str:
+    """Run an ATF test or suite and optionally poll for completion.
+
+    Args:
+        client: Active ServiceNow client.
+        run_id: The sys_id of the test or suite to run.
+        is_suite: True for suite execution, False for test.
+        poll: If True, poll until completion.
+        poll_interval: Seconds between polls (pre-clamped).
+        max_poll_duration: Max seconds to poll (pre-clamped).
+        correlation_id: Request correlation ID.
+    """
+    id_key = "suite_id" if is_suite else "test_id"
+
+    result = await client.atf_run(run_id, is_suite=is_suite)
+    snboq_id = result.get("snboqId") or result.get("snboq_id") or result.get("executionId", "")
+
+    if not snboq_id:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="ATF execution started but no execution ID returned.",
+        )
+
+    if not poll:
+        return format_response(
+            data={
+                "execution_id": snboq_id,
+                "status": "started",
+                id_key: run_id,
+                "polling": False,
+            },
+            correlation_id=correlation_id,
+        )
+
+    start_time = time.monotonic()
+    terminal_states = {"completed", "failure", "error", "cancelled"}
+    state = "unknown"
+    progress = 0
+
+    while (time.monotonic() - start_time) < max_poll_duration:
+        progress_result = await client.atf_progress(snboq_id)
+        state = progress_result.get("state", "").lower()
+        progress = progress_result.get("progress", 0)
+
+        if state in terminal_states:
+            return format_response(
+                data={
+                    "execution_id": snboq_id,
+                    "status": state,
+                    "progress": progress,
+                    id_key: run_id,
+                },
+                correlation_id=correlation_id,
+            )
+
+        await asyncio.sleep(poll_interval)
+
+    return format_response(
+        data={
+            "execution_id": snboq_id,
+            "status": "polling_timeout",
+            "progress": progress,
+            id_key: run_id,
+            "last_known_state": state,
+        },
+        correlation_id=correlation_id,
+        warnings=[f"Polling timeout after {max_poll_duration}s. Use atf_progress with execution_id to check status."],
+    )
+
+
+def _compute_flakiness(records: list[dict[str, Any]]) -> tuple[int, bool]:
+    """Compute transition count and flaky flag from ordered result records.
+
+    Returns:
+        A tuple of (transition_count, is_flaky).
+    """
+    transitions = 0
+    for i in range(1, len(records)):
+        if _is_pass(records[i - 1]) != _is_pass(records[i]):
+            transitions += 1
+
+    flaky = transitions >= 3 or (transitions >= 2 and len(records) < 10)
+    return transitions, flaky
+
+
+def _compute_trend(records: list[dict[str, Any]]) -> str:
+    """Compute pass-rate trend from ordered result records.
+
+    Returns one of: 'improving', 'degrading', 'stable', 'insufficient_data'.
+    """
+    total = len(records)
+    if total < 4:
+        return "insufficient_data"
+
+    mid = total // 2
+    first_pass_rate = sum(1 for r in records[:mid] if _is_pass(r)) / mid
+    second_pass_rate = sum(1 for r in records[mid:] if _is_pass(r)) / (total - mid)
+
+    diff = second_pass_rate - first_pass_rate
+    if diff > 0.05:
+        return "improving"
+    if diff < -0.05:
+        return "degrading"
+    return "stable"
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -211,21 +354,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             suite_id: The sys_id of a test suite (sys_atf_test_suite). Mutually exclusive with test_id.
             limit: Maximum results to return (default 10).
         """
-        if not test_id and not suite_id:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="Must provide exactly one of test_id or suite_id.",
-            )
-
-        if test_id and suite_id:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="Must provide exactly one of test_id or suite_id, not both.",
-            )
+        err = _validate_exclusive_ids(test_id, suite_id, correlation_id)
+        if err:
+            return err
 
         if test_id:
             check_table_access("sys_atf_test_result")
@@ -304,63 +435,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         clamped_max_duration = max(10, min(max_poll_duration, ATF_MAX_POLL_DURATION))
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.atf_run(test_id, is_suite=False)
-            snboq_id = result.get("snboqId") or result.get("snboq_id") or result.get("executionId", "")
-
-            if not snboq_id:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="ATF execution started but no execution ID returned.",
-                )
-
-            if not poll:
-                return format_response(
-                    data={
-                        "execution_id": snboq_id,
-                        "status": "started",
-                        "test_id": test_id,
-                        "polling": False,
-                    },
-                    correlation_id=correlation_id,
-                )
-
-            start_time = time.monotonic()
-            terminal_states = {"completed", "failure", "error", "cancelled"}
-            state = "unknown"
-            progress = 0
-
-            while (time.monotonic() - start_time) < clamped_max_duration:
-                progress_result = await client.atf_progress(snboq_id)
-                state = progress_result.get("state", "").lower()
-                progress = progress_result.get("progress", 0)
-
-                if state in terminal_states:
-                    return format_response(
-                        data={
-                            "execution_id": snboq_id,
-                            "status": state,
-                            "progress": progress,
-                            "test_id": test_id,
-                        },
-                        correlation_id=correlation_id,
-                    )
-
-                await asyncio.sleep(clamped_interval)
-
-            return format_response(
-                data={
-                    "execution_id": snboq_id,
-                    "status": "polling_timeout",
-                    "progress": progress,
-                    "test_id": test_id,
-                    "last_known_state": state,
-                },
+            return await _atf_run_and_poll(
+                client,
+                test_id,
+                is_suite=False,
+                poll=poll,
+                poll_interval=clamped_interval,
+                max_poll_duration=clamped_max_duration,
                 correlation_id=correlation_id,
-                warnings=[
-                    f"Polling timeout after {clamped_max_duration}s. Use atf_progress with execution_id to check status."
-                ],
             )
 
     @mcp.tool()
@@ -391,63 +473,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         clamped_max_duration = max(10, min(max_poll_duration, ATF_MAX_POLL_DURATION))
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.atf_run(suite_id, is_suite=True)
-            snboq_id = result.get("snboqId") or result.get("snboq_id") or result.get("executionId", "")
-
-            if not snboq_id:
-                return format_response(
-                    data=None,
-                    correlation_id=correlation_id,
-                    status="error",
-                    error="ATF execution started but no execution ID returned.",
-                )
-
-            if not poll:
-                return format_response(
-                    data={
-                        "execution_id": snboq_id,
-                        "status": "started",
-                        "suite_id": suite_id,
-                        "polling": False,
-                    },
-                    correlation_id=correlation_id,
-                )
-
-            start_time = time.monotonic()
-            terminal_states = {"completed", "failure", "error", "cancelled"}
-            state = "unknown"
-            progress = 0
-
-            while (time.monotonic() - start_time) < clamped_max_duration:
-                progress_result = await client.atf_progress(snboq_id)
-                state = progress_result.get("state", "").lower()
-                progress = progress_result.get("progress", 0)
-
-                if state in terminal_states:
-                    return format_response(
-                        data={
-                            "execution_id": snboq_id,
-                            "status": state,
-                            "progress": progress,
-                            "suite_id": suite_id,
-                        },
-                        correlation_id=correlation_id,
-                    )
-
-                await asyncio.sleep(clamped_interval)
-
-            return format_response(
-                data={
-                    "execution_id": snboq_id,
-                    "status": "polling_timeout",
-                    "progress": progress,
-                    "suite_id": suite_id,
-                    "last_known_state": state,
-                },
+            return await _atf_run_and_poll(
+                client,
+                suite_id,
+                is_suite=True,
+                poll=poll,
+                poll_interval=clamped_interval,
+                max_poll_duration=clamped_max_duration,
                 correlation_id=correlation_id,
-                warnings=[
-                    f"Polling timeout after {clamped_max_duration}s. Use atf_progress with execution_id to check status."
-                ],
             )
 
     @mcp.tool()
@@ -470,21 +503,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             days: How many days of history to analyze (default 30).
             limit: Maximum results to fetch (default 50).
         """
-        if not test_id and not suite_id:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="Must provide exactly one of test_id or suite_id.",
-            )
-
-        if test_id and suite_id:
-            return format_response(
-                data=None,
-                correlation_id=correlation_id,
-                status="error",
-                error="Must provide exactly one of test_id or suite_id, not both.",
-            )
+        err = _validate_exclusive_ids(test_id, suite_id, correlation_id)
+        if err:
+            return err
 
         if test_id:
             check_table_access("sys_atf_test_result")
@@ -523,42 +544,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 warnings=["No execution results found in the specified time window."],
             )
 
-        pass_count = sum(1 for r in records if r.get("status", "").lower() in {"success", "passed"})
+        pass_count = sum(1 for r in records if _is_pass(r))
         fail_count = total_runs - pass_count
         pass_rate = pass_count / total_runs if total_runs > 0 else 0.0
 
-        transitions = 0
-        for i in range(1, len(records)):
-            prev_status = records[i - 1].get("status", "").lower()
-            curr_status = records[i].get("status", "").lower()
-            prev_pass = prev_status in {"success", "passed"}
-            curr_pass = curr_status in {"success", "passed"}
-            if prev_pass != curr_pass:
-                transitions += 1
-
-        flaky = transitions >= 3 or (transitions >= 2 and total_runs < 10)
-
-        if total_runs >= 4:
-            mid = total_runs // 2
-            first_half = records[:mid]
-            second_half = records[mid:]
-
-            first_pass_rate = sum(1 for r in first_half if r.get("status", "").lower() in {"success", "passed"}) / len(
-                first_half
-            )
-            second_pass_rate = sum(
-                1 for r in second_half if r.get("status", "").lower() in {"success", "passed"}
-            ) / len(second_half)
-
-            diff = second_pass_rate - first_pass_rate
-            if diff > 0.05:
-                trend = "improving"
-            elif diff < -0.05:
-                trend = "degrading"
-            else:
-                trend = "stable"
-        else:
-            trend = "insufficient_data"
+        transitions, flaky = _compute_flakiness(records)
+        trend = _compute_trend(records)
 
         last_run = records[-1] if records else None
 

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -156,7 +156,7 @@ def _apply_between(
     """Apply the between operator (requires start and end)."""
     start = condition.get("start") or condition.get("value")
     end = condition.get("end", "")
-    if not start or not end:
+    if start is None or start == "" or end is None or end == "":
         return format_response(
             data=None,
             correlation_id=correlation_id,
@@ -174,7 +174,7 @@ def _apply_datepart(
     part = condition.get("part", "")
     dp_operator = condition.get("dp_operator") or condition.get("value", "")
     dp_value = condition.get("dp_value", "")
-    if not part or not dp_operator or not dp_value:
+    if part is None or part == "" or dp_operator is None or dp_operator == "" or dp_value is None or dp_value == "":
         return format_response(
             data=None,
             correlation_id=correlation_id,
@@ -186,7 +186,7 @@ def _apply_datepart(
 
 
 def _apply_new_query(
-    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+    query: ServiceNowQuery, _field: str, _operator: str, _condition: dict[str, Any], _correlation_id: str
 ) -> str | None:
     """Apply the new_query separator."""
     query.new_query()
@@ -213,7 +213,7 @@ def _apply_rl_query(
 
 
 def _apply_order_by(
-    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+    query: ServiceNowQuery, field: str, _operator: str, condition: dict[str, Any], _correlation_id: str
 ) -> str | None:
     """Apply the order_by operator."""
     descending = bool(condition.get("descending", False))

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -156,7 +156,7 @@ def _apply_between(
     """Apply the between operator (requires start and end)."""
     start = condition.get("start") or condition.get("value")
     end = condition.get("end", "")
-    if not start or not end:
+    if start is None or start == "" or end is None or end == "":
         return format_response(
             data=None,
             correlation_id=correlation_id,
@@ -174,7 +174,7 @@ def _apply_datepart(
     part = condition.get("part", "")
     dp_operator = condition.get("dp_operator") or condition.get("value", "")
     dp_value = condition.get("dp_value", "")
-    if not part or not dp_operator or not dp_value:
+    if part is None or part == "" or dp_operator is None or dp_operator == "" or dp_value is None or dp_value == "":
         return format_response(
             data=None,
             correlation_id=correlation_id,

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -61,6 +61,227 @@ _FIELD_OPERATORS = {
     "not_same_as",
 }
 
+_ALL_VALID_OPERATORS = sorted(
+    _UNARY_OPERATORS
+    | _TIME_OPERATORS
+    | _BINARY_OPERATORS
+    | _OR_BINARY_OPERATORS
+    | _LIST_OPERATORS
+    | _FIELD_OPERATORS
+    | {"order_by", "between", "datepart", "new_query", "rl_query"}
+)
+
+
+def _require_value(
+    condition: dict[str, Any],
+    operator: str,
+    correlation_id: str,
+    message: str | None = None,
+) -> tuple[Any, str | None]:
+    """Return (value, None) if condition has a non-None 'value', else (None, error_response)."""
+    value = condition.get("value")
+    if value is None:
+        msg = message or f"Operator '{operator}' requires a 'value'."
+        return None, format_response(data=None, correlation_id=correlation_id, status="error", error=msg)
+    return value, None
+
+
+def _apply_unary(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply a unary operator (no value needed)."""
+    getattr(query, operator)(field)
+    return None
+
+
+def _apply_time(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply a time operator (requires integer value)."""
+    value, err = _require_value(
+        condition, operator, correlation_id, f"Time operator '{operator}' requires an integer 'value'."
+    )
+    if err:
+        return err
+    getattr(query, operator)(field, int(value))
+    return None
+
+
+def _apply_binary(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply a binary or OR-binary operator (requires string value)."""
+    value, err = _require_value(condition, operator, correlation_id)
+    if err:
+        return err
+    getattr(query, operator)(field, str(value))
+    return None
+
+
+def _apply_list(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply a list operator (requires list value)."""
+    value = condition.get("value")
+    if value is None or not isinstance(value, list):
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Operator '{operator}' requires a 'value' that is a list of strings.",
+        )
+    getattr(query, operator)(field, [str(v) for v in value])
+    return None
+
+
+def _apply_field(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply a field comparison operator (requires other_field)."""
+    other_field = condition.get("other_field") or condition.get("value")
+    if not other_field:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Operator '{operator}' requires 'other_field' (or 'value' as the other field name).",
+        )
+    getattr(query, operator)(field, str(other_field))
+    return None
+
+
+def _apply_between(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply the between operator (requires start and end)."""
+    start = condition.get("start") or condition.get("value")
+    end = condition.get("end", "")
+    if not start or not end:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="Operator 'between' requires 'start' and 'end' values (or 'value' for start).",
+        )
+    query.between(field, str(start), str(end))
+    return None
+
+
+def _apply_datepart(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply the datepart operator (requires part, dp_operator, dp_value)."""
+    part = condition.get("part", "")
+    dp_operator = condition.get("dp_operator") or condition.get("value", "")
+    dp_value = condition.get("dp_value", "")
+    if not part or not dp_operator or not dp_value:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="Operator 'datepart' requires 'part', 'dp_operator', and 'dp_value'.",
+        )
+    query.datepart(field, str(part), str(dp_operator), str(dp_value))
+    return None
+
+
+def _apply_new_query(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply the new_query separator."""
+    query.new_query()
+    return None
+
+
+def _apply_rl_query(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply the rl_query operator (requires related_table, related_field, rl_operator)."""
+    related_table = condition.get("related_table", "")
+    related_field = condition.get("related_field") or field
+    rl_operator = condition.get("rl_operator", "")
+    rl_value = condition.get("value", "")
+    if not related_table or not related_field or not rl_operator:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error="Operator 'rl_query' requires 'related_table', 'related_field' (or 'field'), and 'rl_operator'.",
+        )
+    query.rl_query(str(related_table), str(related_field), str(rl_operator), str(rl_value))
+    return None
+
+
+def _apply_order_by(
+    query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
+) -> str | None:
+    """Apply the order_by operator."""
+    descending = bool(condition.get("descending", False))
+    query.order_by(field, descending=descending)
+    return None
+
+
+def _get_handler(operator: str) -> Any | None:
+    """Look up the handler function for an operator, or None if unknown."""
+    if operator in _UNARY_OPERATORS:
+        return _apply_unary
+    if operator in _TIME_OPERATORS:
+        return _apply_time
+    if operator in _BINARY_OPERATORS or operator in _OR_BINARY_OPERATORS:
+        return _apply_binary
+    if operator in _LIST_OPERATORS:
+        return _apply_list
+    if operator in _FIELD_OPERATORS:
+        return _apply_field
+    # Single-operator handlers
+    return {
+        "between": _apply_between,
+        "datepart": _apply_datepart,
+        "new_query": _apply_new_query,
+        "rl_query": _apply_rl_query,
+        "order_by": _apply_order_by,
+    }.get(operator)
+
+
+def _apply_condition(
+    query: ServiceNowQuery,
+    condition: dict[str, Any],
+    correlation_id: str,
+) -> str | None:
+    """Process a single condition object and apply it to the query.
+
+    Returns None on success, or a formatted error response string on failure.
+    """
+    operator = condition.get("operator", "")
+    field = condition.get("field", "")
+
+    if not operator:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Each condition requires 'operator'. Got: {condition}",
+        )
+
+    if operator != "new_query" and not field:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Operator '{operator}' requires a 'field'. Got: {condition}",
+        )
+
+    handler = _get_handler(operator)
+    if handler is None:
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Unknown operator '{operator}'. Valid operators: {_ALL_VALID_OPERATORS}",
+        )
+
+    return handler(query, field, operator, condition, correlation_id)
+
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """Register utility tools on the MCP server."""
@@ -117,133 +338,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
             query = ServiceNowQuery()
             for condition in parsed:
-                operator = condition.get("operator", "")
-                field = condition.get("field", "")
-                value = condition.get("value")
-
-                if not operator:
-                    return format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=f"Each condition requires 'operator'. Got: {condition}",
-                    )
-
-                if operator != "new_query" and not field:
-                    return format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=f"Operator '{operator}' requires a 'field'. Got: {condition}",
-                    )
-
-                if operator in _UNARY_OPERATORS:
-                    getattr(query, operator)(field)
-                elif operator in _TIME_OPERATORS:
-                    if value is None:
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error=f"Time operator '{operator}' requires an integer 'value'.",
-                        )
-                    getattr(query, operator)(field, int(value))
-                elif operator in _BINARY_OPERATORS or operator in _OR_BINARY_OPERATORS:
-                    if value is None:
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error=f"Operator '{operator}' requires a 'value'.",
-                        )
-                    getattr(query, operator)(field, str(value))
-                elif operator in _LIST_OPERATORS:
-                    if value is None or not isinstance(value, list):
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error=f"Operator '{operator}' requires a 'value' that is a list of strings.",
-                        )
-                    getattr(query, operator)(field, [str(v) for v in value])
-                elif operator in _FIELD_OPERATORS:
-                    other_field = condition.get("other_field") or condition.get("value")
-                    if not other_field:
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error=f"Operator '{operator}' requires 'other_field' (or 'value' as the other field name).",
-                        )
-                    getattr(query, operator)(field, str(other_field))
-                elif operator == "between":
-                    start = condition.get("start") or condition.get("value")
-                    end = condition.get("end", "")
-                    if not start or not end:
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error="Operator 'between' requires 'start' and 'end' values (or 'value' for start).",
-                        )
-                    query.between(field, str(start), str(end))
-                elif operator == "datepart":
-                    part = condition.get("part", "")
-                    dp_operator = condition.get("dp_operator") or condition.get("value", "")
-                    dp_value = condition.get("dp_value", "")
-                    if not part or not dp_operator or not dp_value:
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error="Operator 'datepart' requires 'part', 'dp_operator', and 'dp_value'.",
-                        )
-                    query.datepart(field, str(part), str(dp_operator), str(dp_value))
-                elif operator == "new_query":
-                    query.new_query()
-                elif operator == "rl_query":
-                    related_table = condition.get("related_table", "")
-                    related_field = condition.get("related_field") or field
-                    rl_operator = condition.get("rl_operator", "")
-                    rl_value = condition.get("value", "")
-                    if not related_table or not related_field or not rl_operator:
-                        return format_response(
-                            data=None,
-                            correlation_id=correlation_id,
-                            status="error",
-                            error="Operator 'rl_query' requires 'related_table', 'related_field' (or 'field'), and 'rl_operator'.",
-                        )
-                    query.rl_query(
-                        str(related_table),
-                        str(related_field),
-                        str(rl_operator),
-                        str(rl_value),
-                    )
-                elif operator == "order_by":
-                    descending = bool(condition.get("descending", False))
-                    query.order_by(field, descending=descending)
-                else:
-                    valid = sorted(
-                        _UNARY_OPERATORS
-                        | _TIME_OPERATORS
-                        | _BINARY_OPERATORS
-                        | _OR_BINARY_OPERATORS
-                        | _LIST_OPERATORS
-                        | _FIELD_OPERATORS
-                        | {
-                            "order_by",
-                            "between",
-                            "datepart",
-                            "new_query",
-                            "rl_query",
-                        }
-                    )
-                    return format_response(
-                        data=None,
-                        correlation_id=correlation_id,
-                        status="error",
-                        error=f"Unknown operator '{operator}'. Valid operators: {valid}",
-                    )
+                err = _apply_condition(query, condition, correlation_id)
+                if err:
+                    return err
 
             built = query.build()
             query_token = query_store.create({"query": built})

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -103,7 +103,16 @@ def _apply_time(
     )
     if err:
         return err
-    getattr(query, operator)(field, int(value))
+    try:
+        int_value = int(value)
+    except (ValueError, TypeError):
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Time operator '{operator}' requires an integer 'value', got: {value!r}",
+        )
+    getattr(query, operator)(field, int_value)
     return None
 
 
@@ -158,7 +167,7 @@ def _apply_between(
     if start is None:
         start = condition.get("value")
     end = condition.get("end")
-    if start is None or end is None:
+    if start is None or start == "" or end is None or end == "":
         return format_response(
             data=None,
             correlation_id=correlation_id,
@@ -178,7 +187,7 @@ def _apply_datepart(
     if dp_operator is None:
         dp_operator = condition.get("value")
     dp_value = condition.get("dp_value")
-    if not part or not dp_operator or dp_value is None:
+    if part is None or part == "" or dp_operator is None or dp_operator == "" or dp_value is None or dp_value == "":
         return format_response(
             data=None,
             correlation_id=correlation_id,
@@ -267,12 +276,28 @@ def _apply_condition(
             error=f"Each condition requires 'operator'. Got: {condition}",
         )
 
+    if not isinstance(operator, str):
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Condition 'operator' must be a string, got {type(operator).__name__}",
+        )
+
     if operator != "new_query" and not field:
         return format_response(
             data=None,
             correlation_id=correlation_id,
             status="error",
             error=f"Operator '{operator}' requires a 'field'. Got: {condition}",
+        )
+
+    if operator != "new_query" and not isinstance(field, str):
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Condition 'field' must be a string, got {type(field).__name__}",
         )
 
     handler = _get_handler(operator)

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -154,9 +154,11 @@ def _apply_between(
     query: ServiceNowQuery, field: str, operator: str, condition: dict[str, Any], correlation_id: str
 ) -> str | None:
     """Apply the between operator (requires start and end)."""
-    start = condition.get("start") or condition.get("value")
-    end = condition.get("end", "")
-    if start is None or start == "" or end is None or end == "":
+    start = condition.get("start")
+    if start is None:
+        start = condition.get("value")
+    end = condition.get("end")
+    if start is None or end is None:
         return format_response(
             data=None,
             correlation_id=correlation_id,
@@ -172,9 +174,11 @@ def _apply_datepart(
 ) -> str | None:
     """Apply the datepart operator (requires part, dp_operator, dp_value)."""
     part = condition.get("part", "")
-    dp_operator = condition.get("dp_operator") or condition.get("value", "")
-    dp_value = condition.get("dp_value", "")
-    if part is None or part == "" or dp_operator is None or dp_operator == "" or dp_value is None or dp_value == "":
+    dp_operator = condition.get("dp_operator")
+    if dp_operator is None:
+        dp_operator = condition.get("value")
+    dp_value = condition.get("dp_value")
+    if not part or not dp_operator or dp_value is None:
         return format_response(
             data=None,
             correlation_id=correlation_id,

--- a/src/servicenow_mcp/tools/utility.py
+++ b/src/servicenow_mcp/tools/utility.py
@@ -337,7 +337,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 )
 
             query = ServiceNowQuery()
-            for condition in parsed:
+            for idx, condition in enumerate(parsed):
+                if not isinstance(condition, dict):
+                    return format_response(
+                        data=None,
+                        correlation_id=correlation_id,
+                        status="error",
+                        error=f"conditions[{idx}] must be a JSON object, got {type(condition).__name__}",
+                    )
                 err = _apply_condition(query, condition, correlation_id)
                 if err:
                     return err

--- a/tests/domains/test_helpers.py
+++ b/tests/domains/test_helpers.py
@@ -1,0 +1,194 @@
+"""Tests for shared domain tool helpers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from toon_format import decode as toon_decode
+
+from servicenow_mcp.tools.domains._helpers import (
+    fetch_record_by_number,
+    lookup_record_by_number,
+    parse_field_list,
+    resolve_state,
+    validate_int_range,
+    validate_no_empty_changes,
+    validate_number_prefix,
+    validate_required_string,
+)
+
+
+CID = "test-correlation-id"
+
+
+class TestValidateNumberPrefix:
+    def test_valid_prefix_returns_none(self) -> None:
+        assert validate_number_prefix("INC0010001", "INC", "incident", CID) is None
+
+    def test_valid_prefix_case_insensitive(self) -> None:
+        assert validate_number_prefix("inc0010001", "INC", "incident", CID) is None
+
+    def test_invalid_prefix_returns_error(self) -> None:
+        raw = validate_number_prefix("PRB001", "INC", "incident", CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert result["status"] == "error"
+        assert "Must start with INC prefix" in result["error"]["message"]
+
+    def test_error_includes_entity_label(self) -> None:
+        raw = validate_number_prefix("INC001", "CHG", "change request", CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert "Invalid change request number" in result["error"]["message"]
+
+
+class TestLookupRecordByNumber:
+    @pytest.mark.asyncio()
+    async def test_found_returns_sys_id(self) -> None:
+        client = AsyncMock()
+        client.query_records.return_value = {"records": [{"sys_id": "abc123"}]}
+        sys_id, error = await lookup_record_by_number(client, "incident", "INC001", "Incident", CID)
+        assert sys_id == "abc123"
+        assert error is None
+
+    @pytest.mark.asyncio()
+    async def test_not_found_returns_error(self) -> None:
+        client = AsyncMock()
+        client.query_records.return_value = {"records": []}
+        sys_id, error = await lookup_record_by_number(client, "incident", "INC001", "Incident", CID)
+        assert sys_id == ""
+        assert error is not None
+        result = toon_decode(error)
+        assert result["status"] == "error"
+        assert "Incident INC001 not found" in result["error"]["message"]
+
+    @pytest.mark.asyncio()
+    async def test_number_uppercased_in_query(self) -> None:
+        client = AsyncMock()
+        client.query_records.return_value = {"records": [{"sys_id": "xyz"}]}
+        await lookup_record_by_number(client, "incident", "inc001", "Incident", CID)
+        call_kwargs = client.query_records.call_args[1]
+        assert "INC001" in call_kwargs["query"]
+
+
+class TestFetchRecordByNumber:
+    @pytest.mark.asyncio()
+    async def test_found_returns_masked_record(self) -> None:
+        client = AsyncMock()
+        client.query_records.return_value = {"records": [{"sys_id": "abc", "short_description": "test"}]}
+        raw = await fetch_record_by_number(client, "incident", "INC001", "Incident", CID)
+        result = toon_decode(raw)
+        assert result["status"] == "success"
+        assert result["data"]["short_description"] == "test"
+
+    @pytest.mark.asyncio()
+    async def test_not_found_returns_error(self) -> None:
+        client = AsyncMock()
+        client.query_records.return_value = {"records": []}
+        raw = await fetch_record_by_number(client, "incident", "INC001", "Incident", CID)
+        result = toon_decode(raw)
+        assert result["status"] == "error"
+        assert "Incident INC001 not found" in result["error"]["message"]
+
+    @pytest.mark.asyncio()
+    async def test_uses_display_values(self) -> None:
+        client = AsyncMock()
+        client.query_records.return_value = {"records": [{"sys_id": "abc"}]}
+        await fetch_record_by_number(client, "incident", "INC001", "Incident", CID)
+        call_kwargs = client.query_records.call_args[1]
+        assert call_kwargs["display_values"] is True
+
+
+class TestValidateIntRange:
+    def test_in_range_returns_none(self) -> None:
+        assert validate_int_range(2, "urgency", 1, 4, CID) is None
+
+    def test_at_min_returns_none(self) -> None:
+        assert validate_int_range(1, "urgency", 1, 4, CID) is None
+
+    def test_at_max_returns_none(self) -> None:
+        assert validate_int_range(4, "urgency", 1, 4, CID) is None
+
+    def test_below_min_returns_error(self) -> None:
+        raw = validate_int_range(0, "urgency", 1, 4, CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert result["status"] == "error"
+        assert "urgency must be between 1 and 4, got 0" in result["error"]["message"]
+
+    def test_above_max_returns_error(self) -> None:
+        raw = validate_int_range(5, "impact", 1, 4, CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert "impact must be between 1 and 4, got 5" in result["error"]["message"]
+
+
+class TestValidateRequiredString:
+    def test_valid_returns_none(self) -> None:
+        assert validate_required_string("hello", "short_description", CID) is None
+
+    def test_empty_returns_error(self) -> None:
+        raw = validate_required_string("", "short_description", CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert result["status"] == "error"
+        assert "short_description is required and cannot be empty" in result["error"]["message"]
+
+    def test_whitespace_only_returns_error(self) -> None:
+        raw = validate_required_string("   ", "close_code", CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert "close_code is required and cannot be empty" in result["error"]["message"]
+
+    def test_none_like_empty(self) -> None:
+        # In practice callers pass str, but test the falsy path
+        raw = validate_required_string("", "cause_notes", CID)
+        assert raw is not None
+
+
+class TestValidateNoEmptyChanges:
+    def test_non_empty_returns_none(self) -> None:
+        assert validate_no_empty_changes({"state": "2"}, CID) is None
+
+    def test_empty_returns_error(self) -> None:
+        raw = validate_no_empty_changes({}, CID)
+        assert raw is not None
+        result = toon_decode(raw)
+        assert result["status"] == "error"
+        assert "No fields to update provided" in result["error"]["message"]
+
+
+class TestParseFieldList:
+    def test_comma_separated(self) -> None:
+        assert parse_field_list("number,state,priority") == ["number", "state", "priority"]
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_field_list(" number , state ") == ["number", "state"]
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_field_list("") is None
+
+    def test_only_commas_returns_empty_list(self) -> None:
+        # This matches current behavior: [f.strip() for f in ",,,".split(",") if f.strip()] == []
+        assert parse_field_list(",,,") == []
+
+
+class TestResolveState:
+    @pytest.mark.asyncio()
+    async def test_with_choices_resolves(self) -> None:
+        choices = MagicMock()
+        choices.resolve = AsyncMock(return_value="6")
+        result = await resolve_state("incident", "resolved", choices)
+        assert result == "6"
+        choices.resolve.assert_called_once_with("incident", "state", "resolved")
+
+    @pytest.mark.asyncio()
+    async def test_without_choices_returns_passthrough(self) -> None:
+        result = await resolve_state("incident", "resolved", None)
+        assert result == "resolved"
+
+    @pytest.mark.asyncio()
+    async def test_lowercases_state(self) -> None:
+        choices = MagicMock()
+        choices.resolve = AsyncMock(return_value="1")
+        await resolve_state("incident", "Open", choices)
+        choices.resolve.assert_called_once_with("incident", "state", "open")


### PR DESCRIPTION
## Input Validation Hardening

Five verified bugs fixed across three tool modules:

### utility.py
- **_apply_between / _apply_datepart**: Truthiness checks rejected valid zero values (0, "0"). Changed to explicit `None`/`""` checks so numeric zeros are accepted while empty strings are properly rejected.
- **_apply_time**: `int(value)` could raise unhandled `ValueError` on non-integer strings. Now returns a structured error response instead of propagating the exception.
- **_apply_condition**: Added type validation for `operator` and `field` parameters. Non-string values now get clear error messages instead of confusing "Unknown operator" errors.

### documentation.py
- **Loop detector**: Only matched `while` loops. Added `_FOR_BLOCK_RE` to also detect `for` loops. Fixed brace binding logic to properly find the loop body (paren-balancing to find closing `)`, then locate block start). Added single-statement body support for brace-less loops.

### knowledge.py
- **_collect_non_empty**: Whitespace-only strings like `"   "` were treated as non-empty. Now strips values and only includes entries with non-empty stripped content.