### PR TITLE
feat: add attachment MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## 📋 Project Overview
 
-- Python 3.12+ async MCP server for ServiceNow schema access, record inspection, debugging, and change intelligence.
+- Python 3.12+ async MCP server for ServiceNow schema access, record inspection, attachment operations, debugging, and change intelligence.
 - Package manager: **uv** (not pip/poetry). Build system: hatchling.
 - Source layout: `src/servicenow_mcp/` (src-layout). Entry point: `servicenow_mcp.server:main`.
 - Config via `pydantic-settings` loading env vars from `.env` / `.env.local`.
@@ -204,6 +204,13 @@ Error response example:
 return format_response(data=None, correlation_id=correlation_id, status="error", error="Something failed")
 ```
 
+### Attachment Payloads
+
+- Attachment tool set: `attachment_list`, `attachment_get`, `attachment_download`, `attachment_download_by_name`, `attachment_upload`, `attachment_delete`.
+- `attachment_upload` accepts `content_base64` and decodes it before upload.
+- `attachment_download` and `attachment_download_by_name` return attachment metadata plus `content_base64`.
+- Attachment transfers are limited by `MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024`.
+
 ## 🛡 Policy Layer
 
 ### Table Access
@@ -385,7 +392,7 @@ async def explain(client, element_id) -> dict:
 - `_ensure_client() -> httpx.AsyncClient` - raises `RuntimeError` if not initialized (not assert).
 - Timeout: 30s.
 - Uses `validate_identifier()` for table/field names.
-- 30+ API methods covering: records, metadata, aggregation, CRUD, CMDB, email, import sets, reports, code search, service catalog, ATF.
+- 30+ API methods covering: records, attachments, metadata, aggregation, CRUD, CMDB, email, import sets, reports, code search, service catalog, ATF.
 
 ## ⚙️ Configuration (Settings)
 
@@ -412,30 +419,32 @@ async def explain(client, element_id) -> dict:
 
 ## 📦 Packages & Tool Groups
 
-14 named packages with 17 tool groups total (18 registered modules, but `testing` is disabled in `full`).
+14 named packages with 19 tool groups total (20 registered modules, but `testing` is disabled in `full`).
 
 ### Preset Packages
 
 | Package              | Groups | Description                                     |
 | -------------------- | ------ | ----------------------------------------------- |
-| `full`                 | 17     | Default - all standard tool groups              |
-| `core_readonly`        | 3      | Read-only core tools (table, record, metadata)  |
+| `full`                 | 19     | Default - all standard tool groups              |
+| `core_readonly`        | 4      | Read-only core tools (table, record, attachment, metadata) |
 | `none`                 | 0      | No tools loaded                                 |
-| `itil`                 | 14     | ITIL process tools                              |
-| `developer`            | 10     | Development-focused tools                       |
-| `readonly`             | 9      | Read-only operations                            |
-| `analyst`              | 7      | Analysis and reporting                          |
-| `incident_management`  | 7      | Incident lifecycle tools                        |
-| `change_management`    | 6      | Change request tools                            |
-| `cmdb`                 | 4      | CMDB management tools                           |
-| `problem_management`   | 7      | Problem lifecycle tools                         |
-| `request_management`   | 6      | Request/RITM tools                              |
-| `knowledge_management` | 4      | Knowledge base tools                            |
-| `service_catalog`      | 4      | Service catalog tools                           |
+| `itil`                 | 15     | ITIL process tools                              |
+| `developer`            | 12     | Development-focused tools                       |
+| `readonly`             | 10     | Read-only operations                            |
+| `analyst`              | 8      | Analysis and reporting                          |
+| `incident_management`  | 9      | Incident lifecycle tools                        |
+| `change_management`    | 8      | Change request tools                            |
+| `cmdb`                 | 6      | CMDB management tools                           |
+| `problem_management`   | 9      | Problem lifecycle tools                         |
+| `request_management`   | 8      | Request/RITM tools                              |
+| `knowledge_management` | 6      | Knowledge base tools                            |
+| `service_catalog`      | 6      | Service catalog tools                           |
 
 ### Custom Packages
 
 Comma-separated group names are supported as a custom package value. Validated to ensure no collisions with preset package names.
+
+Readonly-style packages include only `attachment`. Write-capable packages include both `attachment` and `attachment_write`.
 
 ## 🔀 Async Patterns
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-devtools-mcp?color=00c9a7&style=flat-square" alt="PyPI version"></a>
   <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-devtools-mcp?style=flat-square" alt="Python versions"></a>
   <a href="https://github.com/xerrion/servicenow-devtools-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/xerrion/servicenow-devtools-mcp?style=flat-square" alt="License"></a>
-  <img src="https://img.shields.io/badge/tools-92-00d4ff?style=flat-square" alt="Tool count">
+  <img src="https://img.shields.io/badge/tools-98-00d4ff?style=flat-square" alt="Tool count">
 </p>
 
 # servicenow-devtools-mcp
@@ -17,6 +17,7 @@ A developer & debug-focused [Model Context Protocol (MCP)](https://modelcontextp
 
 - :mag: **Table & Schema Access** -- describe tables with enriched metadata (sys_db_object + sys_documentation), query records, compute aggregates, build structured queries
 - :link: **Record Access** -- fetch individual records, find incoming and outgoing references for any record
+- :paperclip: **Attachment Access** -- list metadata, inspect details, download content as `content_base64`, upload via `content_base64`, and delete attachments
 - :package: **Change Intelligence** -- inspect update sets, diff artifact versions, audit trails, generate release notes
 - :bug: **Debug & Trace** -- trace record timelines, flow executions, email chains, integration errors, import set runs, field mutations
 - :test_tube: **Record Write** -- create, update, delete records with direct or preview-then-apply patterns
@@ -138,7 +139,7 @@ uvx servicenow-devtools-mcp
 ## ServiceNow MCP Server Setup
 
 You have access to a ServiceNow MCP server (`servicenow-devtools-mcp`) that provides
-92 tools for interacting with a ServiceNow instance.
+98 tools for interacting with a ServiceNow instance.
 
 ### Installation
 
@@ -176,13 +177,19 @@ uvx servicenow-devtools-mcp
 }
 ```
 
-### Available Tools (100 total)
+### Available Tools (98 total)
 
 **Table (4):** table_describe, table_query, table_aggregate, build_query
   - Describe table schema with enriched metadata (sys_db_object + sys_documentation), query with encoded queries, compute stats, build structured queries
 
 **Record (3):** record_get, rel_references_to, rel_references_from
   - Fetch records by sys_id, find what references a record, find what a record references
+
+**Attachment (4):** attachment_list, attachment_get, attachment_download, attachment_download_by_name
+  - List attachment metadata, fetch a single attachment record, and download content as `content_base64`
+
+**Attachment Write (2):** attachment_upload, attachment_delete
+  - Upload attachments with `content_base64` and delete attachments by sys_id
 
 **Metadata (4):** meta_list_artifacts, meta_get_artifact, meta_find_references, meta_what_writes
   - List/inspect platform artifacts (business rules, script includes, etc.), find cross-references, find writers to a table
@@ -239,6 +246,7 @@ uvx servicenow-devtools-mcp
 - Row limits: User-supplied limit parameters capped at MAX_ROW_LIMIT (default 100)
 - Large tables: syslog, sys_audit, etc. require date-bounded filters
 - Write gating: All write operations blocked when SERVICENOW_ENV contains "prod" or "production"
+- Attachments: uploads accept `content_base64`; download tools return `content_base64`
 - Mandatory field validation: record creation validates all required fields are present before submission
 - Standardized responses: Tools return TOON-serialized envelopes with correlation_id, status, data, and optionally pagination and warnings
 ````
@@ -287,6 +295,26 @@ The `build_query` tool returns a reusable `query_token` that can be passed to `t
 | `record_get` | Fetch a single record by sys_id | `table`, `sys_id`, `fields?`, `display_values?` |
 | `rel_references_to` | Find records in other tables that reference a given record | `table`, `sys_id` |
 | `rel_references_from` | Find what a record references via its reference fields | `table`, `sys_id` |
+
+### :paperclip: Attachment
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `attachment_list` | List attachment metadata with optional table, record, and file filters | `table_name?`, `table_sys_id?`, `file_name?`, `limit?`, `offset?`, `order_by?` |
+| `attachment_get` | Fetch attachment metadata by attachment sys_id | `sys_id` |
+| `attachment_download` | Download attachment content by attachment sys_id | `sys_id` |
+| `attachment_download_by_name` | Download attachment content by source record and file name | `table_name`, `table_sys_id`, `file_name` |
+
+Download tools return attachment metadata plus `content_base64`.
+
+### :paperclip: Attachment Write
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `attachment_upload` | Upload a new attachment using base64-encoded content | `table_name`, `table_sys_id`, `file_name`, `content_base64`, `content_type?`, `encryption_context?`, `creation_time?` |
+| `attachment_delete` | Delete an attachment by attachment sys_id | `sys_id` |
+
+Uploads accept `content_base64` and follow the same write gating rules as other mutation tools.
 
 ### :package: Metadata
 
@@ -469,19 +497,19 @@ Control which tools are loaded using the `MCP_TOOL_PACKAGE` environment variable
 
 | Package | Groups | Description |
 |---|---|---|
-| `full` (default) | 17 | All tool groups -- 100 tools total |
-| `itil` | 14 | ITIL process tools (incidents, changes, problems, requests + platform tools) |
-| `developer` | 10 | Development-focused (table, record, debug, investigations, workflows) |
-| `readonly` | 9 | Read-only operations (no record writes) |
-| `analyst` | 7 | Analysis and reporting (table, record, investigations, docs, workflows) |
-| `incident_management` | 7 | Incident lifecycle with supporting tools |
-| `problem_management` | 7 | Problem lifecycle with supporting tools |
-| `change_management` | 6 | Change request management with change intelligence |
-| `request_management` | 6 | Request and RITM management |
-| `cmdb` | 4 | CMDB management with relationships |
-| `knowledge_management` | 4 | Knowledge base tools |
-| `service_catalog` | 4 | Service catalog tools |
-| `core_readonly` | 3 | Read-only core tools (table, record, metadata) |
+| `full` (default) | 19 | All tool groups -- 98 tools total |
+| `itil` | 15 | ITIL process tools (incidents, changes, problems, requests + platform tools) |
+| `developer` | 12 | Development-focused (table, record, attachments, debug, investigations, workflows) |
+| `readonly` | 10 | Read-only operations, including attachment read tools |
+| `analyst` | 8 | Analysis and reporting (table, record, attachments, investigations, docs, workflows) |
+| `incident_management` | 9 | Incident lifecycle with supporting tools and attachment writes |
+| `problem_management` | 9 | Problem lifecycle with supporting tools and attachment writes |
+| `change_management` | 8 | Change request management with change intelligence and attachment writes |
+| `request_management` | 8 | Request and RITM management with attachment writes |
+| `cmdb` | 6 | CMDB management with relationships and attachment writes |
+| `knowledge_management` | 6 | Knowledge base tools with attachment writes |
+| `service_catalog` | 6 | Service catalog tools with attachment writes |
+| `core_readonly` | 4 | Read-only core tools (table, record, attachment, metadata) |
 | `none` | 0 | Only `list_tool_packages` -- minimal/testing |
 
 ### Custom Packages
@@ -492,7 +520,9 @@ You can also specify a comma-separated list of tool group names to create a cust
 MCP_TOOL_PACKAGE="table,record,debug,domain_incident"
 ```
 
-Available tool groups: `table`, `record`, `record_write`, `metadata`, `changes`, `debug`, `investigations`, `documentation`, `workflow`, `flow_designer`, `testing`, `domain_incident`, `domain_change`, `domain_problem`, `domain_cmdb`, `domain_request`, `domain_knowledge`, `domain_service_catalog`.
+Readonly-style packages include only `attachment`. Write-capable packages include both `attachment` and `attachment_write`.
+
+Available tool groups: `table`, `record`, `attachment`, `record_write`, `attachment_write`, `metadata`, `changes`, `debug`, `investigations`, `documentation`, `workflow`, `flow_designer`, `testing`, `domain_incident`, `domain_change`, `domain_problem`, `domain_cmdb`, `domain_request`, `domain_knowledge`, `domain_service_catalog`.
 
 ---
 

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -2,6 +2,7 @@
 
 import uuid
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -15,7 +16,7 @@ from servicenow_mcp.errors import (
     ServiceNowMCPError,
 )
 from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT
-from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
+from servicenow_mcp.utils import ServiceNowQuery, validate_identifier, validate_sys_id
 
 
 _ATF_PLUGIN_ERROR = "ATF Cloud Runner plugin (sn_atf_tg) may not be installed"
@@ -67,11 +68,38 @@ class ServiceNowClient:
         validate_identifier(table)
         return f"{self._settings.servicenow_instance_url}/api/now/stats/{table}"
 
+    def _attachment_url(self, sys_id: str | None = None) -> str:
+        """Build the Attachment API URL."""
+        base = f"{self._settings.servicenow_instance_url}/api/now/attachment"
+        if sys_id is None:
+            return base
+        validate_sys_id(sys_id)
+        return f"{base}/{sys_id}"
+
+    def _attachment_file_url(self, sys_id: str | None = None) -> str:
+        """Build the Attachment content/upload URL."""
+        if sys_id is None:
+            return f"{self._attachment_url()}/file"
+        return f"{self._attachment_url(sys_id)}/file"
+
+    def _attachment_file_by_name_url(self, table_sys_id: str, file_name: str) -> str:
+        """Build the Attachment by-name download URL."""
+        validate_sys_id(table_sys_id)
+        return f"{self._attachment_url()}/{table_sys_id}/{quote(file_name, safe='')}/file"
+
     async def _headers(self) -> dict[str, str]:
         """Build request headers including auth and correlation ID."""
         headers = await self._auth_provider.get_headers()
         headers["X-Correlation-ID"] = str(uuid.uuid4())
         return headers
+
+    @staticmethod
+    def _parse_total_count(response: httpx.Response) -> int:
+        """Parse X-Total-Count header, defaulting to 0 when absent or invalid."""
+        try:
+            return int(response.headers.get("X-Total-Count", "0"))
+        except (TypeError, ValueError):
+            return 0
 
     def _raise_for_status(self, response: httpx.Response) -> None:
         """Map HTTP status codes to custom exceptions."""
@@ -155,13 +183,115 @@ class ServiceNowClient:
             params=params,
         )
         self._raise_for_status(response)
-
-        try:
-            total_count = int(response.headers.get("X-Total-Count", "0"))
-        except (ValueError, TypeError):
-            total_count = 0
         records = self._extract_result(response.json())
-        return {"records": records, "count": total_count}
+        return {"records": records, "count": self._parse_total_count(response)}
+
+    async def list_attachments(
+        self,
+        query: str = "",
+        limit: int = 100,
+        offset: int = 0,
+        order_by: str | None = None,
+    ) -> dict[str, Any]:
+        """List attachment metadata using the Attachment API."""
+        http = self._ensure_client()
+        params: dict[str, str] = {
+            "sysparm_limit": str(limit),
+        }
+        if query:
+            params["sysparm_query"] = query
+        if offset:
+            params["sysparm_offset"] = str(offset)
+        if order_by:
+            params["sysparm_query"] = (
+                f"{query}^{ServiceNowQuery().order_by(order_by).build()}"
+                if query
+                else ServiceNowQuery().order_by(order_by).build()
+            )
+
+        response = await http.get(
+            self._attachment_url(),
+            headers=await self._headers(),
+            params=params,
+        )
+        self._raise_for_status(response)
+        records = self._extract_result(response.json())
+        return {"records": records, "count": self._parse_total_count(response)}
+
+    async def get_attachment(self, sys_id: str) -> dict[str, Any]:
+        """Fetch a single attachment metadata record."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._attachment_url(sys_id),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def upload_attachment(
+        self,
+        table_name: str,
+        table_sys_id: str,
+        file_name: str,
+        content: bytes,
+        content_type: str = "application/octet-stream",
+        encryption_context: str | None = None,
+        creation_time: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload binary content as an attachment."""
+        http = self._ensure_client()
+        validate_identifier(table_name)
+        validate_sys_id(table_sys_id)
+        params: dict[str, str] = {
+            "table_name": table_name,
+            "table_sys_id": table_sys_id,
+            "file_name": file_name,
+        }
+        if encryption_context:
+            params["encryption_context"] = encryption_context
+        if creation_time:
+            params["creation_time"] = creation_time
+
+        headers = await self._headers()
+        headers["Content-Type"] = content_type
+        response = await http.post(
+            self._attachment_file_url(),
+            headers=headers,
+            params=params,
+            content=content,
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def download_attachment(self, sys_id: str) -> bytes:
+        """Download attachment content by attachment sys_id."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._attachment_file_url(sys_id),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return response.content
+
+    async def download_attachment_by_name(self, table_sys_id: str, file_name: str) -> bytes:
+        """Download attachment content by record sys_id and file name."""
+        http = self._ensure_client()
+        response = await http.get(
+            self._attachment_file_by_name_url(table_sys_id, file_name),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return response.content
+
+    async def delete_attachment(self, sys_id: str) -> bool:
+        """Delete an attachment by sys_id."""
+        http = self._ensure_client()
+        response = await http.delete(
+            self._attachment_url(sys_id),
+            headers=await self._headers(),
+        )
+        self._raise_for_status(response)
+        return True
 
     async def get_metadata(self, table: str) -> list[dict[str, Any]]:
         """Fetch dictionary metadata for a table from sys_dictionary."""
@@ -461,13 +591,8 @@ class ServiceNowClient:
             params=params,
         )
         self._raise_for_status(response)
-
-        try:
-            total_count = int(response.headers.get("X-Total-Count", "0"))
-        except (ValueError, TypeError):
-            total_count = 0
         records = self._extract_result(response.json())
-        return {"records": records, "count": total_count}
+        return {"records": records, "count": self._parse_total_count(response)}
 
     async def cmdb_get_instance(
         self,

--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -3,7 +3,9 @@
 _TOOL_GROUP_MODULES: dict[str, str] = {
     "table": "servicenow_mcp.tools.table",
     "record": "servicenow_mcp.tools.record",
+    "attachment": "servicenow_mcp.tools.attachment",
     "record_write": "servicenow_mcp.tools.record_write",
+    "attachment_write": "servicenow_mcp.tools.attachment_write",
     "testing": "servicenow_mcp.tools.testing",
     "metadata": "servicenow_mcp.tools.metadata",
     "changes": "servicenow_mcp.tools.changes",
@@ -27,12 +29,15 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "core_readonly": [
         "table",
         "record",
+        "attachment",
         "metadata",
     ],
     "full": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         # "testing",  # ATF - disabled
         "metadata",
         "changes",
@@ -53,7 +58,9 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "itil": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "metadata",
         "changes",
         "debug",
@@ -68,7 +75,9 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "developer": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "metadata",
         "changes",
         "debug",
@@ -80,6 +89,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "readonly": [
         "table",
         "record",
+        "attachment",
         "metadata",
         "changes",
         "debug",
@@ -91,6 +101,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "analyst": [
         "table",
         "record",
+        "attachment",
         "metadata",
         "investigations",
         "documentation",
@@ -100,7 +111,9 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "incident_management": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_incident",
         "debug",
         "workflow",
@@ -109,7 +122,9 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "change_management": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_change",
         "changes",
         "flow_designer",
@@ -117,13 +132,17 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "cmdb": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_cmdb",
     ],
     "problem_management": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_problem",
         "debug",
         "workflow",
@@ -132,7 +151,9 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "request_management": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_request",
         "workflow",
         "flow_designer",
@@ -140,13 +161,17 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
     "knowledge_management": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_knowledge",
     ],
     "service_catalog": [
         "table",
         "record",
+        "attachment",
         "record_write",
+        "attachment_write",
         "domain_service_catalog",
     ],
 }

--- a/src/servicenow_mcp/tools/_attachment_common.py
+++ b/src/servicenow_mcp/tools/_attachment_common.py
@@ -10,15 +10,19 @@ from servicenow_mcp.utils import resolve_ref_value, validate_identifier, validat
 MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
 
 
-def ensure_attachment_size_within_limit(content: bytes, *, operation: str) -> None:
-    """Raise ValueError when attachment bytes exceed the supported MCP transfer limit."""
-    size_bytes = len(content)
+def ensure_attachment_size_value_within_limit(size_bytes: int, *, operation: str) -> None:
+    """Raise ValueError when an attachment size exceeds the supported MCP transfer limit."""
     if size_bytes <= MAX_ATTACHMENT_BYTES:
         return
     raise ValueError(
         f"Attachment {operation} size {size_bytes} bytes exceeds the maximum supported size of "
         f"{MAX_ATTACHMENT_BYTES} bytes"
     )
+
+
+def ensure_attachment_size_within_limit(content: bytes, *, operation: str) -> None:
+    """Raise ValueError when attachment bytes exceed the supported MCP transfer limit."""
+    ensure_attachment_size_value_within_limit(len(content), operation=operation)
 
 
 def decode_content_base64(content_base64: str) -> bytes:
@@ -61,6 +65,22 @@ def get_attachment_table_sys_id(metadata: dict[str, Any]) -> str:
     table_sys_id = get_attachment_field(metadata, "table_sys_id")
     validate_sys_id(table_sys_id)
     return table_sys_id
+
+
+def get_attachment_size_bytes(metadata: dict[str, Any]) -> int:
+    """Return and validate the attachment size from metadata."""
+    raw_size = resolve_ref_value(metadata.get("size_bytes", ""))
+    if raw_size == "":
+        raise ValueError("Attachment metadata is missing required field 'size_bytes'")
+
+    try:
+        size_bytes = int(raw_size)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Attachment metadata field 'size_bytes' must be an integer") from exc
+
+    if size_bytes < 0:
+        raise ValueError("Attachment metadata field 'size_bytes' must be non-negative")
+    return size_bytes
 
 
 def build_attachment_download_payload(metadata: dict[str, Any], content: bytes) -> dict[str, Any]:

--- a/src/servicenow_mcp/tools/_attachment_common.py
+++ b/src/servicenow_mcp/tools/_attachment_common.py
@@ -1,0 +1,76 @@
+"""Shared attachment helpers for validation, metadata parsing and size limits."""
+
+import base64
+import binascii
+from typing import Any
+
+from servicenow_mcp.utils import resolve_ref_value, validate_identifier, validate_sys_id
+
+
+MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
+
+
+def ensure_attachment_size_within_limit(content: bytes, *, operation: str) -> None:
+    """Raise ValueError when attachment bytes exceed the supported MCP transfer limit."""
+    size_bytes = len(content)
+    if size_bytes <= MAX_ATTACHMENT_BYTES:
+        return
+    raise ValueError(
+        f"Attachment {operation} size {size_bytes} bytes exceeds the maximum supported size of "
+        f"{MAX_ATTACHMENT_BYTES} bytes"
+    )
+
+
+def decode_content_base64(content_base64: str) -> bytes:
+    """Decode validated base64 attachment content into raw bytes."""
+    try:
+        return base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Invalid base64 content") from exc
+
+
+def encode_content_base64(content: bytes) -> str:
+    """Encode attachment bytes for MCP transport."""
+    return base64.b64encode(content).decode("ascii")
+
+
+def get_attachment_field(metadata: dict[str, Any], field_name: str) -> str:
+    """Return a required attachment metadata field as a normalized string."""
+    value = resolve_ref_value(metadata.get(field_name, ""))
+    if value:
+        return value
+    raise ValueError(f"Attachment metadata is missing required field '{field_name}'")
+
+
+def get_attachment_sys_id(metadata: dict[str, Any]) -> str:
+    """Return and validate the attachment sys_id from metadata."""
+    sys_id = get_attachment_field(metadata, "sys_id")
+    validate_sys_id(sys_id)
+    return sys_id
+
+
+def get_attachment_table_name(metadata: dict[str, Any]) -> str:
+    """Return and validate the source table name from attachment metadata."""
+    table_name = get_attachment_field(metadata, "table_name")
+    validate_identifier(table_name)
+    return table_name
+
+
+def get_attachment_table_sys_id(metadata: dict[str, Any]) -> str:
+    """Return and validate the source record sys_id from attachment metadata."""
+    table_sys_id = get_attachment_field(metadata, "table_sys_id")
+    validate_sys_id(table_sys_id)
+    return table_sys_id
+
+
+def build_attachment_download_payload(metadata: dict[str, Any], content: bytes) -> dict[str, Any]:
+    """Build a stable attachment download response payload."""
+    return {
+        "sys_id": get_attachment_sys_id(metadata),
+        "table_name": get_attachment_table_name(metadata),
+        "table_sys_id": get_attachment_table_sys_id(metadata),
+        "file_name": get_attachment_field(metadata, "file_name"),
+        "content_type": resolve_ref_value(metadata.get("content_type", "")),
+        "size_bytes": len(content),
+        "content_base64": encode_content_base64(content),
+    }

--- a/src/servicenow_mcp/tools/_attachment_common.py
+++ b/src/servicenow_mcp/tools/_attachment_common.py
@@ -29,7 +29,7 @@ def decode_content_base64(content_base64: str) -> bytes:
     """Decode validated base64 attachment content into raw bytes."""
     try:
         return base64.b64decode(content_base64, validate=True)
-    except (binascii.Error, ValueError) as exc:
+    except binascii.Error as exc:
         raise ValueError("Invalid base64 content") from exc
 
 

--- a/src/servicenow_mcp/tools/_attachment_common.py
+++ b/src/servicenow_mcp/tools/_attachment_common.py
@@ -75,7 +75,7 @@ def get_attachment_size_bytes(metadata: dict[str, Any]) -> int:
 
     try:
         size_bytes = int(raw_size)
-    except (TypeError, ValueError) as exc:
+    except ValueError as exc:
         raise ValueError("Attachment metadata field 'size_bytes' must be an integer") from exc
 
     if size_bytes < 0:

--- a/src/servicenow_mcp/tools/attachment.py
+++ b/src/servicenow_mcp/tools/attachment.py
@@ -52,7 +52,7 @@ async def _get_attachment_metadata_by_name_checked(
     table_name: str,
     table_sys_id: str,
     file_name: str,
-) -> tuple[dict[str, Any], list[str] | None]:
+) -> tuple[dict[str, Any], str, list[str] | None]:
     """Resolve attachment metadata by logical identity before downloading content."""
     query = _build_attachment_query(table_name, table_sys_id, file_name)
     result = await client.query_records(
@@ -68,12 +68,12 @@ async def _get_attachment_metadata_by_name_checked(
         )
 
     metadata = records[0]
-    get_attachment_sys_id(metadata)
+    attachment_sys_id = get_attachment_sys_id(metadata)
     check_table_access(get_attachment_table_name(metadata))
 
     if len(records) == 1:
-        return metadata, None
-    return metadata, ["Multiple attachments matched; returned the earliest created attachment"]
+        return metadata, attachment_sys_id, None
+    return metadata, attachment_sys_id, ["Multiple attachments matched; returned the earliest created attachment"]
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -185,15 +185,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         """
         validate_identifier(table_name)
         validate_sys_id(table_sys_id)
+        check_table_access(table_name)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            metadata, warnings = await _get_attachment_metadata_by_name_checked(
+            metadata, attachment_sys_id, warnings = await _get_attachment_metadata_by_name_checked(
                 client,
                 table_name,
                 table_sys_id,
                 file_name,
             )
-            content: bytes = await client.download_attachment(get_attachment_sys_id(metadata))
+            content: bytes = await client.download_attachment(attachment_sys_id)
 
         ensure_attachment_size_within_limit(content, operation="download")
         return format_response(

--- a/src/servicenow_mcp/tools/attachment.py
+++ b/src/servicenow_mcp/tools/attachment.py
@@ -1,0 +1,203 @@
+"""Attachment read tools for ServiceNow attachments."""
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.config import Settings
+from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.errors import NotFoundError
+from servicenow_mcp.policy import check_table_access, enforce_query_safety
+from servicenow_mcp.utils import ServiceNowQuery, format_response, validate_identifier, validate_sys_id
+
+from ._attachment_common import (
+    build_attachment_download_payload,
+    ensure_attachment_size_within_limit,
+    get_attachment_sys_id,
+    get_attachment_table_name,
+)
+
+
+TOOL_NAMES: list[str] = [
+    "attachment_list",
+    "attachment_get",
+    "attachment_download",
+    "attachment_download_by_name",
+]
+
+
+def _build_attachment_query(table_name: str, table_sys_id: str, file_name: str) -> str:
+    """Build a sys_attachment metadata query from validated filters."""
+    query = ServiceNowQuery()
+    if table_name:
+        query.equals("table_name", table_name)
+    if table_sys_id:
+        query.equals("table_sys_id", table_sys_id)
+    if file_name:
+        query.equals("file_name", file_name)
+    return query.build()
+
+
+async def _get_attachment_metadata_checked(client: ServiceNowClient, sys_id: str) -> dict[str, Any]:
+    """Fetch attachment metadata and enforce real-table read access."""
+    metadata = await client.get_attachment(sys_id)
+    check_table_access(get_attachment_table_name(metadata))
+    return metadata
+
+
+async def _get_attachment_metadata_by_name_checked(
+    client: ServiceNowClient,
+    table_name: str,
+    table_sys_id: str,
+    file_name: str,
+) -> tuple[dict[str, Any], list[str] | None]:
+    """Resolve attachment metadata by logical identity before downloading content."""
+    query = _build_attachment_query(table_name, table_sys_id, file_name)
+    result = await client.query_records(
+        "sys_attachment",
+        query,
+        fields=["sys_id", "table_name", "table_sys_id", "file_name", "content_type", "size_bytes"],
+        limit=2,
+    )
+    records = result["records"]
+    if not records:
+        raise NotFoundError(
+            f"Attachment '{file_name}' was not found for table '{table_name}' and record '{table_sys_id}'"
+        )
+
+    metadata = records[0]
+    get_attachment_sys_id(metadata)
+    check_table_access(get_attachment_table_name(metadata))
+
+    if len(records) == 1:
+        return metadata, None
+    return metadata, ["Multiple attachments matched; returned the earliest created attachment"]
+
+
+def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """Register attachment read tools on the MCP server."""
+
+    @mcp.tool()
+    @tool_handler
+    async def attachment_list(
+        table_name: str = "",
+        table_sys_id: str = "",
+        file_name: str = "",
+        limit: int = 20,
+        offset: int = 0,
+        order_by: str = "sys_created_on",
+        *,
+        correlation_id: str = "",
+    ) -> str:
+        """List attachment metadata records with optional filters.
+
+        Args:
+            table_name: Optional table name to filter attachments by.
+            table_sys_id: Optional source record sys_id to filter attachments by.
+            file_name: Optional attachment file name to filter by.
+            limit: Maximum number of attachments to return.
+            offset: Number of matching attachments to skip.
+            order_by: Field to sort by.
+        """
+        if table_name:
+            validate_identifier(table_name)
+            check_table_access(table_name)
+        if table_sys_id:
+            validate_sys_id(table_sys_id)
+        if order_by:
+            validate_identifier(order_by)
+
+        query = _build_attachment_query(table_name, table_sys_id, file_name)
+        if order_by:
+            order_query = ServiceNowQuery().order_by(order_by).build()
+            query = f"{query}^{order_query}" if query else order_query
+        safety = enforce_query_safety("sys_attachment", query, limit, settings)
+        effective_limit = safety["limit"]
+        warnings = [f"Limit capped at {effective_limit}"] if effective_limit < limit else None
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.list_attachments(
+                query,
+                effective_limit,
+                offset,
+            )
+
+        return format_response(
+            data=result["records"],
+            correlation_id=correlation_id,
+            pagination={
+                "offset": offset,
+                "limit": effective_limit,
+                "total": result["count"],
+            },
+            warnings=warnings,
+        )
+
+    @mcp.tool()
+    @tool_handler
+    async def attachment_get(sys_id: str, *, correlation_id: str = "") -> str:
+        """Fetch attachment metadata by attachment sys_id.
+
+        Args:
+            sys_id: The sys_id of the attachment.
+        """
+        validate_sys_id(sys_id)
+        async with ServiceNowClient(settings, auth_provider) as client:
+            metadata = await _get_attachment_metadata_checked(client, sys_id)
+        return format_response(data=metadata, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def attachment_download(sys_id: str, *, correlation_id: str = "") -> str:
+        """Download attachment content by attachment sys_id.
+
+        Args:
+            sys_id: The sys_id of the attachment to download.
+        """
+        validate_sys_id(sys_id)
+        async with ServiceNowClient(settings, auth_provider) as client:
+            metadata = await _get_attachment_metadata_checked(client, sys_id)
+            content: bytes = await client.download_attachment(sys_id)
+
+        ensure_attachment_size_within_limit(content, operation="download")
+        return format_response(
+            data=build_attachment_download_payload(metadata, content),
+            correlation_id=correlation_id,
+        )
+
+    @mcp.tool()
+    @tool_handler
+    async def attachment_download_by_name(
+        table_name: str,
+        table_sys_id: str,
+        file_name: str,
+        *,
+        correlation_id: str = "",
+    ) -> str:
+        """Download attachment content by source record and file name.
+
+        Args:
+            table_name: The source table name.
+            table_sys_id: The source record sys_id.
+            file_name: The attachment file name.
+        """
+        validate_identifier(table_name)
+        validate_sys_id(table_sys_id)
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            metadata, warnings = await _get_attachment_metadata_by_name_checked(
+                client,
+                table_name,
+                table_sys_id,
+                file_name,
+            )
+            content: bytes = await client.download_attachment(get_attachment_sys_id(metadata))
+
+        ensure_attachment_size_within_limit(content, operation="download")
+        return format_response(
+            data=build_attachment_download_payload(metadata, content),
+            correlation_id=correlation_id,
+            warnings=warnings,
+        )

--- a/src/servicenow_mcp/tools/attachment.py
+++ b/src/servicenow_mcp/tools/attachment.py
@@ -45,6 +45,74 @@ def _build_attachment_query(table_name: str, table_sys_id: str, file_name: str) 
     return query.build()
 
 
+def _validate_attachment_list_inputs(table_name: str, table_sys_id: str, order_by: str) -> None:
+    """Validate attachment list filters before querying ServiceNow."""
+    if table_name:
+        validate_identifier(table_name)
+        check_table_access(table_name)
+    if table_sys_id:
+        validate_sys_id(table_sys_id)
+    if order_by:
+        validate_identifier(order_by)
+
+
+def _append_attachment_order_by(query: str, order_by: str) -> str:
+    """Append an order-by clause to an attachment query when requested."""
+    if not order_by:
+        return query
+
+    order_query = ServiceNowQuery().order_by(order_by).build()
+    return f"{query}^{order_query}" if query else order_query
+
+
+def _filter_and_mask_attachment_records(
+    records: list[dict[str, Any]],
+    *,
+    table_name: str,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return visible attachment records and whether any were omitted by policy."""
+    if table_name:
+        return [mask_sensitive_fields(record) for record in records], False
+
+    visible_records: list[dict[str, Any]] = []
+    blocked_tables: set[str] = set()
+    for record in records:
+        record_table_name = get_attachment_table_name(record)
+        if record_table_name in blocked_tables:
+            continue
+        try:
+            check_table_access(record_table_name)
+        except PolicyError:
+            blocked_tables.add(record_table_name)
+            continue
+        visible_records.append(mask_sensitive_fields(record))
+
+    return visible_records, bool(blocked_tables)
+
+
+def _build_attachment_list_metadata(
+    *,
+    requested_limit: int,
+    effective_limit: int,
+    offset: int,
+    visible_total: int,
+    omitted_by_policy: bool,
+) -> tuple[dict[str, int], list[str] | None]:
+    """Build stable pagination and warnings for attachment list responses."""
+    warnings: list[str] = []
+    if effective_limit < requested_limit:
+        warnings.append(f"Limit capped at {effective_limit}")
+    if omitted_by_policy:
+        warnings.append("Some attachments were omitted due to table access policy")
+
+    pagination = {
+        "offset": offset,
+        "limit": effective_limit,
+        "total": visible_total,
+    }
+    return pagination, warnings or None
+
+
 def _require_bytes_content(content: object) -> bytes:
     """Return attachment content only when the client result is binary."""
     if not isinstance(content, bytes):
@@ -67,8 +135,7 @@ async def _get_attachment_metadata_by_name_checked(
 ) -> tuple[dict[str, Any], str, list[str] | None]:
     """Resolve attachment metadata by logical identity before downloading content."""
     query = _build_attachment_query(table_name, table_sys_id, file_name)
-    order_query = ServiceNowQuery().order_by("sys_created_on").build()
-    query = f"{query}^{order_query}" if query else order_query
+    query = _append_attachment_order_by(query, "sys_created_on")
     result = await client.query_records(
         "sys_attachment",
         query,
@@ -115,23 +182,11 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             offset: Number of matching attachments to skip.
             order_by: Field to sort by.
         """
-        if table_name:
-            validate_identifier(table_name)
-            check_table_access(table_name)
-        if table_sys_id:
-            validate_sys_id(table_sys_id)
-        if order_by:
-            validate_identifier(order_by)
+        _validate_attachment_list_inputs(table_name, table_sys_id, order_by)
 
-        query = _build_attachment_query(table_name, table_sys_id, file_name)
-        if order_by:
-            order_query = ServiceNowQuery().order_by(order_by).build()
-            query = f"{query}^{order_query}" if query else order_query
+        query = _append_attachment_order_by(_build_attachment_query(table_name, table_sys_id, file_name), order_by)
         safety = enforce_query_safety("sys_attachment", query, limit, settings)
         effective_limit = safety["limit"]
-        warnings: list[str] = []
-        if effective_limit < limit:
-            warnings.append(f"Limit capped at {effective_limit}")
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.list_attachments(
@@ -140,35 +195,21 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 offset,
             )
 
-        allowed_records: list[dict[str, Any]] = []
-        blocked_tables: set[str] = set()
-        for record in result["records"]:
-            record_table_name = get_attachment_table_name(record)
-            if table_name:
-                allowed_records.append(record)
-                continue
-            if record_table_name in blocked_tables:
-                continue
-            try:
-                check_table_access(record_table_name)
-            except PolicyError:
-                blocked_tables.add(record_table_name)
-                continue
-            allowed_records.append(record)
-
-        if blocked_tables:
-            warnings.append("Some attachments were omitted due to table access policy")
-
-        masked_records = [mask_sensitive_fields(record) for record in allowed_records]
+        masked_records, omitted_by_policy = _filter_and_mask_attachment_records(
+            result["records"], table_name=table_name
+        )
+        pagination, warnings = _build_attachment_list_metadata(
+            requested_limit=limit,
+            effective_limit=effective_limit,
+            offset=offset,
+            visible_total=len(masked_records),
+            omitted_by_policy=omitted_by_policy,
+        )
         return format_response(
             data=masked_records,
             correlation_id=correlation_id,
-            pagination={
-                "offset": offset,
-                "limit": effective_limit,
-                "total": len(masked_records),
-            },
-            warnings=warnings or None,
+            pagination=pagination,
+            warnings=warnings,
         )
 
     @mcp.tool()

--- a/src/servicenow_mcp/tools/attachment.py
+++ b/src/servicenow_mcp/tools/attachment.py
@@ -1,5 +1,6 @@
 """Attachment read tools for ServiceNow attachments."""
 
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -8,16 +9,20 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.errors import NotFoundError
-from servicenow_mcp.policy import check_table_access, enforce_query_safety
-from servicenow_mcp.utils import ServiceNowQuery, format_response, validate_identifier, validate_sys_id
-
-from ._attachment_common import (
+from servicenow_mcp.errors import NotFoundError, PolicyError
+from servicenow_mcp.policy import check_table_access, enforce_query_safety, mask_sensitive_fields
+from servicenow_mcp.tools._attachment_common import (
     build_attachment_download_payload,
+    ensure_attachment_size_value_within_limit,
     ensure_attachment_size_within_limit,
+    get_attachment_size_bytes,
     get_attachment_sys_id,
     get_attachment_table_name,
 )
+from servicenow_mcp.utils import ServiceNowQuery, format_response, validate_identifier, validate_sys_id
+
+
+logger = logging.getLogger(__name__)
 
 
 TOOL_NAMES: list[str] = [
@@ -40,6 +45,13 @@ def _build_attachment_query(table_name: str, table_sys_id: str, file_name: str) 
     return query.build()
 
 
+def _require_bytes_content(content: object) -> bytes:
+    """Return attachment content only when the client result is binary."""
+    if not isinstance(content, bytes):
+        raise TypeError("Attachment download content must be bytes")
+    return content
+
+
 async def _get_attachment_metadata_checked(client: ServiceNowClient, sys_id: str) -> dict[str, Any]:
     """Fetch attachment metadata and enforce real-table read access."""
     metadata = await client.get_attachment(sys_id)
@@ -55,6 +67,8 @@ async def _get_attachment_metadata_by_name_checked(
 ) -> tuple[dict[str, Any], str, list[str] | None]:
     """Resolve attachment metadata by logical identity before downloading content."""
     query = _build_attachment_query(table_name, table_sys_id, file_name)
+    order_query = ServiceNowQuery().order_by("sys_created_on").build()
+    query = f"{query}^{order_query}" if query else order_query
     result = await client.query_records(
         "sys_attachment",
         query,
@@ -115,7 +129,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             query = f"{query}^{order_query}" if query else order_query
         safety = enforce_query_safety("sys_attachment", query, limit, settings)
         effective_limit = safety["limit"]
-        warnings = [f"Limit capped at {effective_limit}"] if effective_limit < limit else None
+        warnings: list[str] = []
+        if effective_limit < limit:
+            warnings.append(f"Limit capped at {effective_limit}")
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.list_attachments(
@@ -124,15 +140,35 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 offset,
             )
 
+        allowed_records: list[dict[str, Any]] = []
+        blocked_tables: set[str] = set()
+        for record in result["records"]:
+            record_table_name = get_attachment_table_name(record)
+            if table_name:
+                allowed_records.append(record)
+                continue
+            if record_table_name in blocked_tables:
+                continue
+            try:
+                check_table_access(record_table_name)
+            except PolicyError:
+                blocked_tables.add(record_table_name)
+                continue
+            allowed_records.append(record)
+
+        if blocked_tables:
+            warnings.append("Some attachments were omitted due to table access policy")
+
+        masked_records = [mask_sensitive_fields(record) for record in allowed_records]
         return format_response(
-            data=result["records"],
+            data=masked_records,
             correlation_id=correlation_id,
             pagination={
                 "offset": offset,
                 "limit": effective_limit,
-                "total": result["count"],
+                "total": len(masked_records),
             },
-            warnings=warnings,
+            warnings=warnings or None,
         )
 
     @mcp.tool()
@@ -146,7 +182,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         validate_sys_id(sys_id)
         async with ServiceNowClient(settings, auth_provider) as client:
             metadata = await _get_attachment_metadata_checked(client, sys_id)
-        return format_response(data=metadata, correlation_id=correlation_id)
+        return format_response(data=mask_sensitive_fields(metadata), correlation_id=correlation_id)
 
     @mcp.tool()
     @tool_handler
@@ -159,11 +195,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         validate_sys_id(sys_id)
         async with ServiceNowClient(settings, auth_provider) as client:
             metadata = await _get_attachment_metadata_checked(client, sys_id)
-            content: bytes = await client.download_attachment(sys_id)
+            ensure_attachment_size_value_within_limit(get_attachment_size_bytes(metadata), operation="download")
+            content = _require_bytes_content(await client.download_attachment(sys_id))
 
         ensure_attachment_size_within_limit(content, operation="download")
+        masked_metadata = mask_sensitive_fields(metadata)
         return format_response(
-            data=build_attachment_download_payload(metadata, content),
+            data=build_attachment_download_payload(masked_metadata, content),
             correlation_id=correlation_id,
         )
 
@@ -194,11 +232,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 table_sys_id,
                 file_name,
             )
-            content: bytes = await client.download_attachment(attachment_sys_id)
+            ensure_attachment_size_value_within_limit(get_attachment_size_bytes(metadata), operation="download")
+            content = _require_bytes_content(await client.download_attachment(attachment_sys_id))
 
         ensure_attachment_size_within_limit(content, operation="download")
+        masked_metadata = mask_sensitive_fields(metadata)
         return format_response(
-            data=build_attachment_download_payload(metadata, content),
+            data=build_attachment_download_payload(masked_metadata, content),
             correlation_id=correlation_id,
             warnings=warnings,
         )

--- a/src/servicenow_mcp/tools/attachment_write.py
+++ b/src/servicenow_mcp/tools/attachment_write.py
@@ -33,8 +33,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         file_name: str,
         content_base64: str,
         content_type: str = "application/octet-stream",
-        encryption_context: str = "",
-        creation_time: str = "",
+        encryption_context: str | None = None,
+        creation_time: str | None = None,
         *,
         correlation_id: str = "",
     ) -> str:

--- a/src/servicenow_mcp/tools/attachment_write.py
+++ b/src/servicenow_mcp/tools/attachment_write.py
@@ -1,0 +1,100 @@
+"""Attachment write tools for ServiceNow attachments."""
+
+from mcp.server.fastmcp import FastMCP
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.config import Settings
+from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.policy import check_table_access, write_gate
+from servicenow_mcp.utils import format_response, validate_identifier, validate_sys_id
+
+from ._attachment_common import (
+    decode_content_base64,
+    ensure_attachment_size_within_limit,
+    get_attachment_table_name,
+)
+
+
+TOOL_NAMES: list[str] = [
+    "attachment_upload",
+    "attachment_delete",
+]
+
+
+def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """Register attachment write tools on the MCP server."""
+
+    @mcp.tool()
+    @tool_handler
+    async def attachment_upload(
+        table_name: str,
+        table_sys_id: str,
+        file_name: str,
+        content_base64: str,
+        content_type: str = "application/octet-stream",
+        encryption_context: str = "",
+        creation_time: str = "",
+        *,
+        correlation_id: str = "",
+    ) -> str:
+        """Upload a new attachment using base64-encoded content.
+
+        Args:
+            table_name: The table to attach the file to.
+            table_sys_id: The sys_id of the source record.
+            file_name: The attachment file name.
+            content_base64: Base64-encoded attachment content.
+            content_type: MIME type for the upload.
+            encryption_context: Optional encryption context.
+            creation_time: Optional custom attachment creation time.
+        """
+        validate_identifier(table_name)
+        validate_sys_id(table_sys_id)
+        check_table_access(table_name)
+
+        blocked = write_gate(table_name, settings, correlation_id)
+        if blocked:
+            return blocked
+
+        content = decode_content_base64(content_base64)
+        ensure_attachment_size_within_limit(content, operation="upload")
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.upload_attachment(
+                table_name=table_name,
+                table_sys_id=table_sys_id,
+                file_name=file_name,
+                content=content,
+                content_type=content_type,
+                encryption_context=encryption_context,
+                creation_time=creation_time,
+            )
+
+        return format_response(data=result, correlation_id=correlation_id)
+
+    @mcp.tool()
+    @tool_handler
+    async def attachment_delete(sys_id: str, *, correlation_id: str = "") -> str:
+        """Delete an attachment by attachment sys_id.
+
+        Args:
+            sys_id: The sys_id of the attachment to delete.
+        """
+        validate_sys_id(sys_id)
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            metadata = await client.get_attachment(sys_id)
+            table_name = get_attachment_table_name(metadata)
+            check_table_access(table_name)
+
+            blocked = write_gate(table_name, settings, correlation_id)
+            if blocked:
+                return blocked
+
+            await client.delete_attachment(sys_id)
+
+        return format_response(
+            data={"sys_id": sys_id, "table_name": table_name, "deleted": True},
+            correlation_id=correlation_id,
+        )

--- a/src/servicenow_mcp/tools/attachment_write.py
+++ b/src/servicenow_mcp/tools/attachment_write.py
@@ -1,5 +1,7 @@
 """Attachment write tools for ServiceNow attachments."""
 
+import logging
+
 from mcp.server.fastmcp import FastMCP
 
 from servicenow_mcp.auth import BasicAuthProvider
@@ -7,13 +9,15 @@ from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import check_table_access, write_gate
-from servicenow_mcp.utils import format_response, validate_identifier, validate_sys_id
-
-from ._attachment_common import (
+from servicenow_mcp.tools._attachment_common import (
     decode_content_base64,
     ensure_attachment_size_within_limit,
     get_attachment_table_name,
 )
+from servicenow_mcp.utils import format_response, validate_identifier, validate_sys_id
+
+
+logger = logging.getLogger(__name__)
 
 
 TOOL_NAMES: list[str] = [

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -15,20 +15,20 @@ pytestmark = pytest.mark.integration
 # Expected tool counts per package (verified in Wave FINAL F3).
 # +1 for the always-registered list_tool_packages tool.
 EXPECTED_TOOL_COUNTS: dict[str, int] = {
-    "full": 92,
-    "core_readonly": 12,
+    "full": 98,
+    "core_readonly": 16,
     "none": 1,
-    "itil": 68,
-    "developer": 48,
-    "readonly": 41,
-    "analyst": 31,
-    "incident_management": 40,
-    "change_management": 33,
-    "cmdb": 20,
-    "problem_management": 39,
-    "request_management": 33,
-    "knowledge_management": 20,
-    "service_catalog": 27,
+    "itil": 74,
+    "developer": 54,
+    "readonly": 45,
+    "analyst": 35,
+    "incident_management": 46,
+    "change_management": 39,
+    "cmdb": 26,
+    "problem_management": 45,
+    "request_management": 39,
+    "knowledge_management": 26,
+    "service_catalog": 33,
 }
 
 

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,6 +1,7 @@
 """Tests for attachment MCP tools."""
 
 import base64
+import importlib
 from typing import Any
 
 import httpx
@@ -10,13 +11,15 @@ import respx
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 from servicenow_mcp.policy import DENIED_TABLES
-from servicenow_mcp.tools._attachment_common import MAX_ATTACHMENT_BYTES
 from tests.helpers import decode_response, get_tool_functions
 
 
 BASE_URL = "https://test.service-now.com"
 ATTACHMENT_SYS_ID = "a" * 32
 TABLE_SYS_ID = "b" * 32
+_attachment_common: Any = importlib.import_module("servicenow_mcp.tools._attachment_common")
+attachment: Any = importlib.import_module("servicenow_mcp.tools.attachment")
+MAX_ATTACHMENT_BYTES = _attachment_common.MAX_ATTACHMENT_BYTES
 
 
 @pytest.fixture()
@@ -229,6 +232,56 @@ class TestAttachmentReadTools:
         assert "exceeds the maximum supported size" in result["error"]["message"]
         assert not download_route.called
 
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_by_name_not_found_returns_error(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Returns a stable not-found error when no metadata matches the logical attachment identity."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_attachment").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download_by_name"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "was not found" in result["error"]["message"]
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_by_name_warns_when_multiple_matches_exist(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Returns the earliest attachment plus a warning when metadata lookup finds multiple matches."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_attachment").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [_metadata(), _metadata(sys_id="c" * 32)]},
+                headers={"X-Total-Count": "2"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"hello")
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download_by_name"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
+        assert result["warnings"] == ["Multiple attachments matched; returned the earliest created attachment"]
+
 
 class TestAttachmentWriteTools:
     """Tests for attachment write tools."""
@@ -325,3 +378,83 @@ class TestAttachmentWriteTools:
 
         assert result["status"] == "error"
         assert "production" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_delete_blocked_in_prod(self, prod_settings: Settings, prod_auth_provider: BasicAuthProvider) -> None:
+        """Blocks deletes in production environments after reading attachment metadata."""
+        delete_route = respx.delete(
+            f"{prod_settings.servicenow_instance_url}/api/now/attachment/{ATTACHMENT_SYS_ID}"
+        ).mock(return_value=httpx.Response(204))
+        respx.get(f"{prod_settings.servicenow_instance_url}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(200, json={"result": _metadata()})
+        )
+
+        tools = _register_write_tools(prod_settings, prod_auth_provider)
+        raw = await tools["attachment_delete"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "production" in result["error"]["message"].lower()
+        assert not delete_route.called
+
+
+class TestAttachmentHelperFunctions:
+    """Tests for small attachment helper branches."""
+
+    def test_get_attachment_size_bytes_rejects_missing_value(self) -> None:
+        """Missing size metadata fails fast."""
+        with pytest.raises(ValueError, match="missing required field 'size_bytes'"):
+            _attachment_common.get_attachment_size_bytes(_metadata(size_bytes=""))
+
+    def test_get_attachment_size_bytes_rejects_non_integer_value(self) -> None:
+        """Malformed size metadata fails fast."""
+        with pytest.raises(ValueError, match="must be an integer"):
+            _attachment_common.get_attachment_size_bytes(_metadata(size_bytes="not-a-number"))
+
+    def test_get_attachment_size_bytes_rejects_negative_value(self) -> None:
+        """Negative size metadata fails fast."""
+        with pytest.raises(ValueError, match="must be non-negative"):
+            _attachment_common.get_attachment_size_bytes(_metadata(size_bytes="-1"))
+
+    def test_get_attachment_field_rejects_missing_value(self) -> None:
+        """Missing required metadata fields fail fast."""
+        metadata = _metadata()
+        metadata["file_name"] = ""
+
+        with pytest.raises(ValueError, match="missing required field 'file_name'"):
+            _attachment_common.get_attachment_field(metadata, "file_name")
+
+    def test_append_attachment_order_by_returns_original_query_when_blank(self) -> None:
+        """Blank ordering leaves attachment queries unchanged."""
+        assert attachment._append_attachment_order_by("table_name=incident", "") == "table_name=incident"
+
+    def test_filter_and_mask_attachment_records_skips_repeated_blocked_table_without_warning_noise(self) -> None:
+        """Once a table is denied, later attachments from the same table are skipped immediately."""
+        denied_table = next(iter(DENIED_TABLES))
+
+        records, omitted = attachment._filter_and_mask_attachment_records(
+            [_metadata(table_name=denied_table), _metadata(table_name=denied_table, sys_id="c" * 32)],
+            table_name="",
+        )
+
+        assert records == []
+        assert omitted is True
+
+    def test_build_attachment_list_metadata_includes_limit_cap_warning(self) -> None:
+        """Pagination metadata includes the limit cap warning when safety reduces the limit."""
+        pagination, warnings = attachment._build_attachment_list_metadata(
+            requested_limit=50,
+            effective_limit=20,
+            offset=5,
+            visible_total=3,
+            omitted_by_policy=False,
+        )
+
+        assert pagination == {"offset": 5, "limit": 20, "total": 3}
+        assert warnings == ["Limit capped at 20"]
+
+    def test_require_bytes_content_rejects_non_bytes(self) -> None:
+        """Download payloads only accept binary content."""
+        with pytest.raises(TypeError, match="must be bytes"):
+            attachment._require_bytes_content("hello")

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -47,7 +47,9 @@ def _register_write_tools(settings: Settings, auth_provider: BasicAuthProvider) 
     return get_tool_functions(mcp)
 
 
-def _metadata(*, table_name: str = "incident", sys_id: str = ATTACHMENT_SYS_ID) -> dict[str, str]:
+def _metadata(
+    *, table_name: str = "incident", sys_id: str = ATTACHMENT_SYS_ID, size_bytes: str = "5"
+) -> dict[str, str]:
     """Build a representative attachment metadata payload."""
     return {
         "sys_id": sys_id,
@@ -55,7 +57,7 @@ def _metadata(*, table_name: str = "incident", sys_id: str = ATTACHMENT_SYS_ID) 
         "table_sys_id": TABLE_SYS_ID,
         "file_name": "hello.txt",
         "content_type": "text/plain",
-        "size_bytes": "5",
+        "size_bytes": size_bytes,
     }
 
 
@@ -82,6 +84,32 @@ class TestAttachmentReadTools:
         assert result["data"][0]["sys_id"] == ATTACHMENT_SYS_ID
         assert result["pagination"]["total"] == 1
         assert route.called
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_list_filters_denied_tables_without_table_filter(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Omits denied-table attachments instead of failing the full response."""
+        denied_table = next(iter(DENIED_TABLES))
+        respx.get(f"{BASE_URL}/api/now/attachment").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [_metadata(table_name="incident"), _metadata(table_name=denied_table, sys_id="c" * 32)]
+                },
+                headers={"X-Total-Count": "2"},
+            )
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_list"]()
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert [record["table_name"] for record in result["data"]] == ["incident"]
+        assert result["pagination"]["total"] == 1
+        assert "Some attachments were omitted due to table access policy" in result["warnings"]
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -146,6 +174,8 @@ class TestAttachmentReadTools:
         assert result["status"] == "success"
         assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
         assert query_route.called
+        assert query_route.calls.last is not None
+        assert "ORDERBYsys_created_on" in query_route.calls.last.request.url.params["sysparm_query"]
         assert download_route.called
         assert not by_name_route.called
 
@@ -180,11 +210,14 @@ class TestAttachmentReadTools:
     @pytest.mark.asyncio()
     @respx.mock
     async def test_oversized_download_rejection(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Rejects downloads larger than the MCP attachment transfer limit."""
+        """Rejects downloads larger than the MCP attachment transfer limit before fetch."""
         respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
-            return_value=httpx.Response(200, json={"result": _metadata()})
+            return_value=httpx.Response(
+                200,
+                json={"result": _metadata(size_bytes=str(MAX_ATTACHMENT_BYTES + 1))},
+            )
         )
-        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+        download_route = respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
             return_value=httpx.Response(200, content=b"x" * (MAX_ATTACHMENT_BYTES + 1))
         )
 
@@ -194,6 +227,7 @@ class TestAttachmentReadTools:
 
         assert result["status"] == "error"
         assert "exceeds the maximum supported size" in result["error"]["message"]
+        assert not download_route.called
 
 
 class TestAttachmentWriteTools:

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,0 +1,293 @@
+"""Tests for attachment MCP tools."""
+
+import base64
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.config import Settings
+from servicenow_mcp.policy import DENIED_TABLES
+from servicenow_mcp.tools._attachment_common import MAX_ATTACHMENT_BYTES
+from tests.helpers import decode_response, get_tool_functions
+
+
+BASE_URL = "https://test.service-now.com"
+ATTACHMENT_SYS_ID = "a" * 32
+TABLE_SYS_ID = "b" * 32
+
+
+@pytest.fixture()
+def auth_provider(settings: Settings) -> BasicAuthProvider:
+    """Create a BasicAuthProvider from test settings."""
+    return BasicAuthProvider(settings)
+
+
+def _register_read_tools(settings: Settings, auth_provider: BasicAuthProvider) -> dict[str, Any]:
+    """Register attachment read tools on a fresh MCP server."""
+    from mcp.server.fastmcp import FastMCP
+
+    from servicenow_mcp.tools.attachment import register_tools
+
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider)
+    return get_tool_functions(mcp)
+
+
+def _register_write_tools(settings: Settings, auth_provider: BasicAuthProvider) -> dict[str, Any]:
+    """Register attachment write tools on a fresh MCP server."""
+    from mcp.server.fastmcp import FastMCP
+
+    from servicenow_mcp.tools.attachment_write import register_tools
+
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider)
+    return get_tool_functions(mcp)
+
+
+def _metadata(*, table_name: str = "incident", sys_id: str = ATTACHMENT_SYS_ID) -> dict[str, str]:
+    """Build a representative attachment metadata payload."""
+    return {
+        "sys_id": sys_id,
+        "table_name": table_name,
+        "table_sys_id": TABLE_SYS_ID,
+        "file_name": "hello.txt",
+        "content_type": "text/plain",
+        "size_bytes": "5",
+    }
+
+
+class TestAttachmentReadTools:
+    """Tests for attachment read tools."""
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_list_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Lists attachment metadata via the attachment API."""
+        route = respx.get(f"{BASE_URL}/api/now/attachment").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [_metadata()]},
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_list"](table_name="incident", table_sys_id=TABLE_SYS_ID, file_name="hello.txt")
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"][0]["sys_id"] == ATTACHMENT_SYS_ID
+        assert result["pagination"]["total"] == 1
+        assert route.called
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_get_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Returns attachment metadata after metadata-first policy checks."""
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(200, json={"result": _metadata()})
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_get"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["table_name"] == "incident"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_success_with_base64(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Downloads binary content and returns a base64 payload."""
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(200, json={"result": _metadata()})
+        )
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"hello")
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
+        assert result["data"]["content_base64"] == base64.b64encode(b"hello").decode("ascii")
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_by_name_success_uses_metadata_sys_id(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Downloads by file name through metadata resolution, not caller path trust."""
+        query_route = respx.get(f"{BASE_URL}/api/now/table/sys_attachment").mock(
+            return_value=httpx.Response(200, json={"result": [_metadata()]}, headers={"X-Total-Count": "1"})
+        )
+        download_route = respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"hello")
+        )
+        by_name_route = respx.get(f"{BASE_URL}/api/now/attachment/{TABLE_SYS_ID}/hello.txt/file").mock(
+            return_value=httpx.Response(500)
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download_by_name"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
+        assert query_route.called
+        assert download_route.called
+        assert not by_name_route.called
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_by_name_blocks_denied_table_via_metadata_lookup(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Denied tables are blocked after metadata resolution before download occurs."""
+        denied_table = next(iter(DENIED_TABLES))
+        respx.get(f"{BASE_URL}/api/now/table/sys_attachment").mock(
+            return_value=httpx.Response(
+                200, json={"result": [_metadata(table_name=denied_table)]}, headers={"X-Total-Count": "1"}
+            )
+        )
+        download_route = respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"hello")
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download_by_name"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "denied" in result["error"]["message"].lower()
+        assert not download_route.called
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_oversized_download_rejection(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Rejects downloads larger than the MCP attachment transfer limit."""
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(200, json={"result": _metadata()})
+        )
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"x" * (MAX_ATTACHMENT_BYTES + 1))
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "exceeds the maximum supported size" in result["error"]["message"]
+
+
+class TestAttachmentWriteTools:
+    """Tests for attachment write tools."""
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_upload_success_with_base64(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Uploads decoded base64 content through the attachment API."""
+        route = respx.post(f"{BASE_URL}/api/now/attachment/file").mock(
+            return_value=httpx.Response(201, json={"result": _metadata()})
+        )
+
+        tools = _register_write_tools(settings, auth_provider)
+        raw = await tools["attachment_upload"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+            content_base64=base64.b64encode(b"hello").decode("ascii"),
+            content_type="text/plain",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
+        assert route.calls.last is not None
+        assert route.calls.last.request.content == b"hello"
+
+    @pytest.mark.asyncio()
+    async def test_attachment_upload_invalid_base64_error_envelope(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Rejects invalid base64 input before any HTTP call."""
+        tools = _register_write_tools(settings, auth_provider)
+        raw = await tools["attachment_upload"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+            content_base64="not-base64!",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "invalid base64" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio()
+    async def test_oversized_upload_rejection(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Rejects uploads larger than the MCP attachment transfer limit."""
+        tools = _register_write_tools(settings, auth_provider)
+        oversized_content = base64.b64encode(b"x" * (MAX_ATTACHMENT_BYTES + 1)).decode("ascii")
+
+        raw = await tools["attachment_upload"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+            content_base64=oversized_content,
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "exceeds the maximum supported size" in result["error"]["message"]
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_delete_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Deletes an attachment after metadata-first policy and write-gate checks."""
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(200, json={"result": _metadata()})
+        )
+        delete_route = respx.delete(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(204)
+        )
+
+        tools = _register_write_tools(settings, auth_provider)
+        raw = await tools["attachment_delete"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["deleted"] is True
+        assert delete_route.called
+
+    @pytest.mark.asyncio()
+    async def test_upload_blocked_in_prod(self, prod_settings: Settings, prod_auth_provider: BasicAuthProvider) -> None:
+        """Blocks uploads in production environments."""
+        tools = _register_write_tools(prod_settings, prod_auth_provider)
+        raw = await tools["attachment_upload"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+            content_base64=base64.b64encode(b"hello").decode("ascii"),
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        assert "production" in result["error"]["message"].lower()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1158,6 +1158,24 @@ class TestUrlBuilderValidation:
         url = client._table_url("incident")
         assert "incident" in url
 
+    def test_attachment_url_rejects_invalid_sys_id(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """_attachment_url raises ValueError for invalid attachment sys_id."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid sys_id"):
+            client._attachment_url("invalid-sys-id")
+
+    def test_attachment_by_name_url_rejects_invalid_table_sys_id(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """_attachment_file_by_name_url raises ValueError for invalid table_sys_id."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        client = ServiceNowClient(settings, auth_provider)
+        with pytest.raises(ValueError, match="Invalid sys_id"):
+            client._attachment_file_by_name_url("bad-id", "hello.txt")
+
 
 class TestATFCloudRunner404:
     """Test ATF Cloud Runner methods raise NotFoundError with plugin hint on 404."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,7 @@
 """Tests for ServiceNow REST client."""
 
+from typing import Any
+
 import httpx
 import pytest
 import respx
@@ -265,6 +267,130 @@ class TestServiceNowClientQueryRecords:
 
         assert route.calls.last is not None
         assert "sysparm_display_value" not in str(route.calls.last.request.url)
+
+
+class TestServiceNowClientAttachmentMethods:
+    """Test attachment-specific client helpers."""
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_list_attachments_with_query_offset_and_order_by(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Builds attachment list params with filters, offset, and ordering."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/attachment").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "invalid"})
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            client_any: Any = client
+            result = await client_any.list_attachments(
+                query="table_name=incident", limit=10, offset=5, order_by="sys_id"
+            )
+
+        assert result == {"records": [], "count": 0}
+        assert route.calls.last is not None
+        params = route.calls.last.request.url.params
+        assert params["sysparm_limit"] == "10"
+        assert params["sysparm_offset"] == "5"
+        assert params["sysparm_query"] == "table_name=incident^ORDERBYsys_id"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_list_attachments_with_order_by_only(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Builds attachment ordering query even without a base filter."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/attachment").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            client_any: Any = client
+            await client_any.list_attachments(query="", order_by="sys_created_on")
+
+        assert route.calls.last is not None
+        params = route.calls.last.request.url.params
+        assert "sysparm_offset" not in params
+        assert params["sysparm_query"] == "ORDERBYsys_created_on"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_upload_attachment_omits_optional_params_when_none(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Leaves optional upload params out when callers pass None."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.post(f"{BASE_URL}/api/now/attachment/file").mock(
+            return_value=httpx.Response(201, json={"result": {"sys_id": "abc"}})
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            client_any: Any = client
+            await client_any.upload_attachment(
+                table_name="incident",
+                table_sys_id="b" * 32,
+                file_name="hello.txt",
+                content=b"hello",
+                encryption_context=None,
+                creation_time=None,
+            )
+
+        assert route.calls.last is not None
+        params = route.calls.last.request.url.params
+        assert "encryption_context" not in params
+        assert "creation_time" not in params
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_upload_attachment_includes_optional_params_when_present(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Passes optional upload params through when callers provide them."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.post(f"{BASE_URL}/api/now/attachment/file").mock(
+            return_value=httpx.Response(201, json={"result": {"sys_id": "abc"}})
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            client_any: Any = client
+            await client_any.upload_attachment(
+                table_name="incident",
+                table_sys_id="b" * 32,
+                file_name="hello.txt",
+                content=b"hello",
+                encryption_context="ctx",
+                creation_time="2026-03-11 10:00:00",
+            )
+
+        assert route.calls.last is not None
+        params = route.calls.last.request.url.params
+        assert params["encryption_context"] == "ctx"
+        assert params["creation_time"] == "2026-03-11 10:00:00"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_download_attachment_by_name_success(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Downloads attachment content by record sys_id and file name."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/attachment/{'b' * 32}/hello%20world.txt/file").mock(
+            return_value=httpx.Response(200, content=b"hello")
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            content = await client.download_attachment_by_name("b" * 32, "hello world.txt")
+
+        assert content == b"hello"
+        assert route.called
 
 
 class TestServiceNowClientGetMetadata:

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -116,7 +116,9 @@ class TestPackageRegistry:
         expected = [
             "table",
             "record",
+            "attachment",
             "record_write",
+            "attachment_write",
             "metadata",
             "changes",
             "debug",
@@ -129,7 +131,7 @@ class TestPackageRegistry:
             "domain_request",
         ]
         assert groups == expected
-        assert len(groups) == 13
+        assert len(groups) == 15
 
     def test_get_package_developer(self) -> None:
         """get_package returns correct groups for developer preset."""
@@ -139,7 +141,29 @@ class TestPackageRegistry:
         expected = [
             "table",
             "record",
+            "attachment",
             "record_write",
+            "attachment_write",
+            "metadata",
+            "changes",
+            "debug",
+            "investigations",
+            "documentation",
+            "workflow",
+            "flow_designer",
+        ]
+        assert groups == expected
+        assert len(groups) == 12
+
+    def test_get_package_readonly(self) -> None:
+        """get_package returns correct groups for readonly preset."""
+        from servicenow_mcp.packages import get_package
+
+        groups = get_package("readonly")
+        expected = [
+            "table",
+            "record",
+            "attachment",
             "metadata",
             "changes",
             "debug",
@@ -151,25 +175,6 @@ class TestPackageRegistry:
         assert groups == expected
         assert len(groups) == 10
 
-    def test_get_package_readonly(self) -> None:
-        """get_package returns correct groups for readonly preset."""
-        from servicenow_mcp.packages import get_package
-
-        groups = get_package("readonly")
-        expected = [
-            "table",
-            "record",
-            "metadata",
-            "changes",
-            "debug",
-            "investigations",
-            "documentation",
-            "workflow",
-            "flow_designer",
-        ]
-        assert groups == expected
-        assert len(groups) == 9
-
     def test_get_package_analyst(self) -> None:
         """get_package returns correct groups for analyst preset."""
         from servicenow_mcp.packages import get_package
@@ -178,6 +183,7 @@ class TestPackageRegistry:
         expected = [
             "table",
             "record",
+            "attachment",
             "metadata",
             "investigations",
             "documentation",
@@ -185,7 +191,7 @@ class TestPackageRegistry:
             "flow_designer",
         ]
         assert groups == expected
-        assert len(groups) == 7
+        assert len(groups) == 8
 
     def test_list_packages_includes_itil(self) -> None:
         """list_packages includes itil preset."""
@@ -216,13 +222,15 @@ class TestPackageRegistry:
         assert "analyst" in packages
 
     def test_full_package_unchanged(self) -> None:
-        """full package still returns all groups unchanged."""
+        """full package returns all groups including attachment support."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("full")
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
+        assert "attachment_write" in groups
         assert "metadata" in groups
         assert "changes" in groups
         assert "debug" in groups
@@ -231,7 +239,7 @@ class TestPackageRegistry:
         assert "workflow" in groups
         assert "flow_designer" in groups
         assert "testing" not in groups
-        assert len(groups) == 17
+        assert len(groups) == 19
 
 
 class TestCommaSeparatedGroups:
@@ -355,11 +363,13 @@ class TestDomainPackages:
         assert "domain_incident" in groups
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
+        assert "attachment_write" in groups
         assert "debug" in groups
         assert "workflow" in groups
         assert "flow_designer" in groups
-        assert len(groups) == 7
+        assert len(groups) == 9
 
     def test_change_management_package(self) -> None:
         """change_management package includes correct groups."""
@@ -369,10 +379,12 @@ class TestDomainPackages:
         assert "domain_change" in groups
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
+        assert "attachment_write" in groups
         assert "changes" in groups
         assert "flow_designer" in groups
-        assert len(groups) == 6
+        assert len(groups) == 8
 
     def test_cmdb_package(self) -> None:
         """cmdb package includes correct groups."""
@@ -382,8 +394,10 @@ class TestDomainPackages:
         assert "domain_cmdb" in groups
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
-        assert len(groups) == 4
+        assert "attachment_write" in groups
+        assert len(groups) == 6
 
     def test_problem_management_package(self) -> None:
         """problem_management package includes correct groups."""
@@ -393,11 +407,13 @@ class TestDomainPackages:
         assert "domain_problem" in groups
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
+        assert "attachment_write" in groups
         assert "debug" in groups
         assert "workflow" in groups
         assert "flow_designer" in groups
-        assert len(groups) == 7
+        assert len(groups) == 9
 
     def test_request_management_package(self) -> None:
         """request_management package includes correct groups."""
@@ -407,10 +423,12 @@ class TestDomainPackages:
         assert "domain_request" in groups
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
+        assert "attachment_write" in groups
         assert "workflow" in groups
         assert "flow_designer" in groups
-        assert len(groups) == 6
+        assert len(groups) == 8
 
     def test_knowledge_management_package(self) -> None:
         """knowledge_management package includes correct groups."""
@@ -420,8 +438,10 @@ class TestDomainPackages:
         assert "domain_knowledge" in groups
         assert "table" in groups
         assert "record" in groups
+        assert "attachment" in groups
         assert "record_write" in groups
-        assert len(groups) == 4
+        assert "attachment_write" in groups
+        assert len(groups) == 6
 
     def test_full_package_includes_all_domain_groups(self) -> None:
         """full package includes exactly 7 domain groups."""
@@ -478,43 +498,43 @@ class TestDomainPackages:
         assert groups == ["domain_incident", "domain_change", "record"]
 
     def test_backward_compatibility_full_package_count(self) -> None:
-        """full package has 17 total groups (10 core + 7 domain)."""
+        """full package has 19 total groups including attachment support."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("full")
-        assert len(groups) == 17
+        assert len(groups) == 19
 
     def test_backward_compatibility_itil_package_count(self) -> None:
-        """itil package has 13 total groups (9 original + 4 domain)."""
+        """itil package has 15 total groups including attachment support."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("itil")
-        assert len(groups) == 13
+        assert len(groups) == 15
 
     def test_developer_package_unchanged(self) -> None:
-        """developer package has 10 groups (no domain groups)."""
+        """developer package has 12 groups and no domain groups."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("developer")
-        assert len(groups) == 10
+        assert len(groups) == 12
         domain_groups = [g for g in groups if g.startswith("domain_")]
         assert len(domain_groups) == 0
 
     def test_readonly_package_unchanged(self) -> None:
-        """readonly package has 9 groups (no domain groups)."""
+        """readonly package has 10 groups and no domain groups."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("readonly")
-        assert len(groups) == 9
+        assert len(groups) == 10
         domain_groups = [g for g in groups if g.startswith("domain_")]
         assert len(domain_groups) == 0
 
     def test_analyst_package_unchanged(self) -> None:
-        """analyst package has 7 groups (no domain groups)."""
+        """analyst package has 8 groups and no domain groups."""
         from servicenow_mcp.packages import get_package
 
         groups = get_package("analyst")
-        assert len(groups) == 7
+        assert len(groups) == 8
         domain_groups = [g for g in groups if g.startswith("domain_")]
         assert len(domain_groups) == 0
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -58,6 +58,48 @@ class TestCreateMcpServer:
         assert "record_get" in tool_names
         assert "table_query" in tool_names
 
+    def test_readonly_includes_attachment_read_tools_but_not_write_tools(self) -> None:
+        """readonly package includes attachment read tools and excludes write tools."""
+        from servicenow_mcp.server import create_mcp_server
+
+        env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "s3cret",
+            "MCP_TOOL_PACKAGE": "readonly",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            mcp_server = create_mcp_server()
+
+        tool_names = get_tool_names(mcp_server)
+        assert "attachment_list" in tool_names
+        assert "attachment_get" in tool_names
+        assert "attachment_download" in tool_names
+        assert "attachment_download_by_name" in tool_names
+        assert "attachment_upload" not in tool_names
+        assert "attachment_delete" not in tool_names
+
+    def test_full_includes_attachment_read_and_write_tools(self) -> None:
+        """full package includes both attachment read and write tools."""
+        from servicenow_mcp.server import create_mcp_server
+
+        env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "s3cret",
+            "MCP_TOOL_PACKAGE": "full",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            mcp_server = create_mcp_server()
+
+        tool_names = get_tool_names(mcp_server)
+        assert "attachment_list" in tool_names
+        assert "attachment_get" in tool_names
+        assert "attachment_download" in tool_names
+        assert "attachment_download_by_name" in tool_names
+        assert "attachment_upload" in tool_names
+        assert "attachment_delete" in tool_names
+
     def test_none_package_has_only_list_packages(self) -> None:
         """'none' package only has the list_tool_packages tool."""
         from servicenow_mcp.server import create_mcp_server

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,7 @@ class TestCreateMcpServer:
         env = {
             "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
             "SERVICENOW_USERNAME": "admin",
-            "SERVICENOW_PASSWORD": "s3cret",
+            "SERVICENOW_PASSWORD": "s3cret",  # NOSONAR - intentional test-only fixture credential
             "MCP_TOOL_PACKAGE": "none",
         }
         with patch.dict("os.environ", env, clear=True):
@@ -30,7 +30,7 @@ class TestCreateMcpServer:
         env = {
             "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
             "SERVICENOW_USERNAME": "admin",
-            "SERVICENOW_PASSWORD": "s3cret",
+            "SERVICENOW_PASSWORD": "s3cret",  # NOSONAR - intentional test-only fixture credential
             "MCP_TOOL_PACKAGE": "none",
         }
         with patch.dict("os.environ", env, clear=True):


### PR DESCRIPTION
## Summary
- add ServiceNow attachment client support and MCP attachment tools
- add separate `attachment` and `attachment_write` tool groups
- add tests for attachment flows, package wiring, and server loading
- update README and AGENTS for the new attachment feature

## What changed
### New tools
- `attachment_list`
- `attachment_get`
- `attachment_download`
- `attachment_download_by_name`
- `attachment_upload`
- `attachment_delete`

### Implementation
- added attachment API methods in `ServiceNowClient`
- added shared attachment size guard helpers
- enforced metadata-first policy checks for attachment access
- enforced write gating for upload and delete
- used base64 for MCP upload/download payloads
- added package registry entries for `attachment` and `attachment_write`

### Security and correctness
- fixed authorization flow for `attachment_download_by_name` by resolving metadata first
- added 10 MB attachment size limit for upload/download
- added client-side boundary validation for attachment sys_ids and table sys_ids

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest --no-cov -q`

## Notes
- readonly-style packages include only `attachment`
- write-capable packages include both `attachment` and `attachment_write`
- uploads accept `content_base64`
- downloads return `content_base64`
