### PR TITLE
docs: complete documentation overhaul

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below to help us investigate.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Configure the server with...
+        2. Call the tool...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages or tool output if available.
+    validations:
+      required: true
+  - type: dropdown
+    id: mcp-client
+    attributes:
+      label: MCP Client
+      description: Which MCP client are you using?
+      options:
+        - Claude Desktop
+        - VS Code Copilot
+        - Cursor
+        - OpenCode
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Server Version
+      description: "Output of `pip show servicenow-devtools-mcp` or check pyproject.toml"
+      placeholder: "e.g., 0.9.0"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: "Output of `python --version`"
+      placeholder: "e.g., 3.12.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: servicenow-release
+    attributes:
+      label: ServiceNow Release
+      description: Which ServiceNow release is your instance running?
+      options:
+        - Xanadu
+        - Yokohama
+        - Washington DC
+        - Vancouver
+        - Utah
+        - Other / Unknown
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or log output

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/Xerrion/servicenow-devtools-mcp/security/advisories/new
+    about: Report a security vulnerability privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,40 @@
+name: Documentation Issue
+description: Report a documentation problem or suggest an improvement
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the documentation!
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: Documentation Area
+      description: Which documentation needs attention?
+      options:
+        - README
+        - Wiki
+        - INSTALL.md (AI Installation Guide)
+        - Code Comments / Docstrings
+        - CHANGELOG
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's wrong or missing? Include a link to the specific page/section if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: How should it be fixed or improved?
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for improving the server? We'd love to hear it!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? What workflow is missing or painful?
+      placeholder: "I'm frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe how you'd like this to work
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other solutions have you considered?
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the server does this relate to?
+      options:
+        - Core (table, record, query)
+        - Attachments
+        - Change Intelligence
+        - Debug & Trace
+        - Investigations
+        - Documentation Generation
+        - Domain Tools (incident, change, problem, etc.)
+        - CMDB
+        - Service Catalog
+        - Configuration / Settings
+        - Safety & Policy
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or examples

--- a/.github/ISSUE_TEMPLATE/tool_request.yml
+++ b/.github/ISSUE_TEMPLATE/tool_request.yml
@@ -1,0 +1,77 @@
+name: Tool Request
+description: Request a new MCP tool
+title: "[Tool]: "
+labels: ["tool-request", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want a new MCP tool added to the server? Describe the tool and how it would be used.
+  - type: input
+    id: tool-name
+    attributes:
+      label: Suggested Tool Name
+      description: "Following the naming convention (e.g., `debug_email_trace`, `incident_list`)"
+      placeholder: "e.g., cmdb_dependency_map"
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: What would an AI agent use this tool for? Describe the workflow.
+      placeholder: "When debugging a CI outage, the agent needs to..."
+    validations:
+      required: true
+  - type: textarea
+    id: servicenow-api
+    attributes:
+      label: ServiceNow API
+      description: Which ServiceNow REST API(s) or tables would this tool use?
+      placeholder: |
+        - Table API: /api/now/table/cmdb_rel_ci
+        - Or a specific REST endpoint
+  - type: textarea
+    id: parameters
+    attributes:
+      label: Suggested Parameters
+      description: What parameters should this tool accept?
+      placeholder: |
+        - ci_sys_id (required): The CI to map dependencies for
+        - depth (optional, default 2): How many levels deep
+  - type: textarea
+    id: output
+    attributes:
+      label: Expected Output
+      description: What should the tool return?
+  - type: dropdown
+    id: tool-group
+    attributes:
+      label: Tool Group
+      description: Which existing tool group would this belong to?
+      options:
+        - table
+        - record
+        - attachment
+        - metadata
+        - changes (Change Intelligence)
+        - debug (Debug & Trace)
+        - investigations
+        - documentation
+        - workflow
+        - flow_designer
+        - domain_incident
+        - domain_change
+        - domain_problem
+        - domain_cmdb
+        - domain_request
+        - domain_knowledge
+        - domain_service_catalog
+        - New group needed
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, ServiceNow documentation links, or examples

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -224,6 +224,8 @@ Custom packages are also supported via comma-separated group names, e.g. `MCP_TO
 - **Mandatory field validation** - Record creation validates all required fields before submission.
 - **Standardized responses** - Tools return TOON-serialized envelopes with `correlation_id`, `status`, `data`, and optionally `pagination` and `warnings`.
 
+These guardrails operate on a best-effort basis and do not guarantee complete prevention of unintended actions. Always validate behavior in your specific environment and follow your organization's security policies.
+
 ---
 
 ## Response Format

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,231 @@
+# ServiceNow MCP Server - AI Installation Guide
+
+This is a developer and debug-focused MCP server for ServiceNow platform introspection, change intelligence, debugging, investigations, and documentation generation. It provides a comprehensive suite of tools organized into multiple tool groups covering schema exploration, record management, ITIL processes, CMDB, service catalog, and more.
+
+---
+
+## Installation
+
+Run directly with uvx (no install required):
+
+```
+uvx servicenow-devtools-mcp
+```
+
+Or install via pip:
+
+```
+pip install servicenow-devtools-mcp
+```
+
+---
+
+## Required Environment Variables
+
+- `SERVICENOW_INSTANCE_URL` - Full URL of the ServiceNow instance (must start with `https://`), e.g. `https://dev12345.service-now.com`
+- `SERVICENOW_USERNAME` - ServiceNow user with admin or appropriate roles
+- `SERVICENOW_PASSWORD` - Password for the user
+
+---
+
+## Optional Environment Variables
+
+- `MCP_TOOL_PACKAGE` - Which tools to load (default: `"full"`). 14 preset packages available - see Tool Packages section.
+- `SERVICENOW_ENV` - Environment label: `"dev"` (default), `"test"`, `"staging"`, `"prod"`. Write operations are blocked when set to `"prod"` or `"production"`.
+- `MAX_ROW_LIMIT` - Max records per query (default: 100, max: 10000).
+- `LARGE_TABLE_NAMES_CSV` - Tables requiring date-bounded queries (default: `syslog,sys_audit,sys_log_transaction,sys_email_log`).
+- `SCRIPT_ALLOWED_ROOT` - Constrains `script_path` file reads to this directory tree. Required when using artifact_write tools with `script_path`. File must be UTF-8, <= 1 MB.
+- `SENTRY_DSN` - Sentry DSN for error reporting. Sentry activates when this is set.
+- `SENTRY_ENVIRONMENT` - Sentry environment label. Falls back to `SERVICENOW_ENV` when empty.
+
+---
+
+## MCP Client Configuration (stdio transport)
+
+```json
+{
+  "command": "uvx",
+  "args": ["servicenow-devtools-mcp"],
+  "env": {
+    "SERVICENOW_INSTANCE_URL": "<instance_url>",
+    "SERVICENOW_USERNAME": "<username>",
+    "SERVICENOW_PASSWORD": "<password>",
+    "MCP_TOOL_PACKAGE": "full",
+    "SERVICENOW_ENV": "dev"
+  }
+}
+```
+
+---
+
+## Available Tools
+
+### Table
+
+`table_describe`, `table_query`, `table_aggregate`, `build_query`
+
+Describe table schema with enriched metadata (sys_db_object + sys_documentation), query with encoded queries, compute aggregate stats, and build structured queries. The `build_query` tool returns a reusable `query_token` that can be passed to other query-accepting tools.
+
+### Record
+
+`record_get`, `rel_references_to`, `rel_references_from`
+
+Fetch records by sys_id, find what references a record, and find what a record references.
+
+### Attachment
+
+`attachment_list`, `attachment_get`, `attachment_download`, `attachment_download_by_name`
+
+List attachment metadata, fetch a single attachment record, and download content as `content_base64`.
+
+### Attachment Write
+
+`attachment_upload`, `attachment_delete`
+
+Upload attachments with `content_base64` and delete attachments by sys_id.
+
+### Metadata
+
+`meta_list_artifacts`, `meta_get_artifact`, `meta_find_references`, `meta_what_writes`
+
+List and inspect platform artifacts (business rules, script includes, etc.), find cross-references across script tables, and find writers to a table.
+
+### Change Intelligence
+
+`changes_updateset_inspect`, `changes_diff_artifact`, `changes_last_touched`, `changes_release_notes`
+
+Inspect update sets, diff artifact versions, view audit trail, and generate release notes.
+
+### Debug & Trace
+
+`debug_trace`, `debug_flow_execution`, `debug_email_trace`, `debug_integration_health`, `debug_importset_run`, `debug_field_mutation_story`
+
+Build event timelines, inspect flow executions, trace emails, check integration errors, inspect import sets, and trace field mutations.
+
+### Record Write
+
+`record_create`, `record_preview_create`, `record_update`, `record_preview_update`, `record_delete`, `record_preview_delete`, `record_apply`
+
+Create, update, and delete records directly or via a preview-then-apply confirmation pattern.
+
+### Artifact Write
+
+`artifact_create`, `artifact_update`
+
+Create and update platform artifacts (business rules, script includes, client scripts, etc.) with optional local script file injection via `script_path`.
+
+### Investigations
+
+`investigate_run`, `investigate_explain`
+
+Modules: `stale_automations`, `deprecated_apis`, `table_health`, `acl_conflicts`, `error_analysis`, `slow_transactions`, `performance_bottlenecks`.
+
+### Documentation
+
+`docs_logic_map`, `docs_artifact_summary`, `docs_test_scenarios`, `docs_review_notes`
+
+Generate automation maps, artifact summaries with dependencies, test scenario suggestions, and code review findings.
+
+### Workflow Analysis
+
+`workflow_contexts`, `workflow_map`, `workflow_status`, `workflow_activity_detail`, `workflow_version_list`
+
+List workflow contexts for a record, map workflow structure, inspect execution status, and view activity details.
+
+### Flow Designer
+
+`flow_list`, `flow_get`, `flow_map`, `flow_action_detail`, `flow_execution_list`, `flow_execution_detail`, `flow_snapshot_list`, `workflow_migration_analysis`
+
+List, inspect, and map Flow Designer flows. View action details, execution history, published snapshots, and analyze legacy workflows for migration readiness.
+
+### Incident Management
+
+`incident_list`, `incident_get`, `incident_create`, `incident_update`, `incident_resolve`, `incident_add_comment`
+
+Full incident lifecycle: list, fetch, create, update, resolve, and add comments/work notes.
+
+### Change Management
+
+`change_list`, `change_get`, `change_create`, `change_update`, `change_tasks`, `change_add_comment`
+
+Manage change requests: list, fetch, create, update, view tasks, and add comments/work notes.
+
+### Problem Management
+
+`problem_list`, `problem_get`, `problem_create`, `problem_update`, `problem_root_cause`
+
+Problem lifecycle: list, fetch, create, update, and document root cause analysis.
+
+### CMDB
+
+`cmdb_list`, `cmdb_get`, `cmdb_relationships`, `cmdb_classes`, `cmdb_health`
+
+Browse CIs, inspect relationships, list CI classes, and check CMDB health by operational status.
+
+### Request Management
+
+`request_list`, `request_get`, `request_items`, `request_item_get`, `request_item_update`
+
+Manage service requests and RITMs: list, fetch, view items, and update request items.
+
+### Knowledge Management
+
+`knowledge_search`, `knowledge_get`, `knowledge_create`, `knowledge_update`, `knowledge_feedback`
+
+Search, read, create, and update knowledge articles and submit feedback/ratings.
+
+### Service Catalog
+
+`sc_catalogs_list`, `sc_catalog_get`, `sc_categories_list`, `sc_category_get`, `sc_items_list`, `sc_item_get`, `sc_item_variables`, `sc_order_now`, `sc_add_to_cart`, `sc_cart_get`, `sc_cart_submit`, `sc_cart_checkout`
+
+Browse catalogs, categories, and items. View item variables, order directly, manage cart, and checkout.
+
+### Core
+
+`list_tool_packages`
+
+List available tool packages and their contents.
+
+---
+
+## Tool Packages
+
+The server supports 14 preset tool packages to control which tools are loaded. The `full` package (default) loads all standard tool groups. Use `list_tool_packages` to see available packages and their contents at runtime.
+
+| Package | Description |
+|---|---|
+| `full` (default) | All standard tool groups |
+| `itil` | ITIL process tools (incidents, changes, problems, requests + platform tools) |
+| `developer` | Development-focused (table, record, attachments, debug, investigations, workflows) |
+| `readonly` | Read-only operations only |
+| `analyst` | Analysis and reporting (table, record, attachments, investigations, docs, workflows) |
+| `incident_management` | Incident lifecycle with supporting tools |
+| `problem_management` | Problem lifecycle with supporting tools |
+| `change_management` | Change request management with change intelligence |
+| `request_management` | Request and RITM management |
+| `cmdb` | CMDB management with relationships |
+| `knowledge_management` | Knowledge base tools |
+| `service_catalog` | Service catalog tools |
+| `core_readonly` | Minimal read-only core (table, record, attachment, metadata) |
+| `none` | Only `list_tool_packages` - for testing |
+
+Custom packages are also supported via comma-separated group names, e.g. `MCP_TOOL_PACKAGE="table,record,debug,domain_incident"`.
+
+---
+
+## Safety Guardrails
+
+- **Table deny list** - Sensitive tables (`sys_user_has_password`, `oauth_credential`, `sys_credentials`, and others) are blocked from queries.
+- **Sensitive fields** - Password, token, and secret fields are masked with `***MASKED***` in responses.
+- **Row limits** - User-supplied limit parameters are capped at `MAX_ROW_LIMIT` (default 100).
+- **Large tables** - `syslog`, `sys_audit`, and other high-volume tables require date-bounded filters.
+- **Write gating** - All write operations are blocked when `SERVICENOW_ENV` is set to `"prod"` or `"production"`. There is no override.
+- **Attachment limits** - Uploads accept `content_base64`; download tools return `content_base64`. Max attachment size is 10 MB.
+- **Mandatory field validation** - Record creation validates all required fields before submission.
+- **Standardized responses** - Tools return TOON-serialized envelopes with `correlation_id`, `status`, `data`, and optionally `pagination` and `warnings`.
+
+---
+
+## Response Format
+
+All tools return responses in TOON format (not JSON). When parsing tool output programmatically, use `toon_decode` from the `toon-format` package, not `json.loads`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ You can also create custom packages with comma-separated group names (e.g. `MCP_
 - **Write gating** - all write operations blocked when `SERVICENOW_ENV` is set to `prod` or `production`
 - **Row limits and large table protection** - prevents runaway queries with configurable caps and mandatory date filters
 
+These guardrails reduce risk but are not a guarantee - always validate in a sub-production environment.
+
 See the [Safety & Policy](https://github.com/Xerrion/servicenow-devtools-mcp/wiki) wiki page for complete details.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -3,47 +3,18 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-devtools-mcp?color=00c9a7&style=flat-square" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-devtools-mcp?style=flat-square" alt="Python versions"></a>
-  <a href="https://github.com/xerrion/servicenow-devtools-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/xerrion/servicenow-devtools-mcp?style=flat-square" alt="License"></a>
-  <img src="https://img.shields.io/badge/tools-100-00d4ff?style=flat-square" alt="Tool count">
+  <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-devtools-mcp" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-devtools-mcp" alt="Python versions"></a>
+  <a href="https://github.com/Xerrion/servicenow-devtools-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Xerrion/servicenow-devtools-mcp" alt="License"></a>
 </p>
 
 # servicenow-devtools-mcp
 
-A developer & debug-focused [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for ServiceNow. Give your AI agent direct access to your ServiceNow instance for schema exploration, debugging, change intelligence, ITIL process management, and documentation generation.
-
-## Features
-
-- :mag: **Table & Schema Access** -- describe tables with enriched metadata (sys_db_object + sys_documentation), query records, compute aggregates, build structured queries
-- :link: **Record Access** -- fetch individual records, find incoming and outgoing references for any record
-- :paperclip: **Attachment Access** -- list metadata, inspect details, download content as `content_base64`, upload via `content_base64`, and delete attachments
-- :package: **Change Intelligence** -- inspect update sets, diff artifact versions, audit trails, generate release notes
-- :bug: **Debug & Trace** -- trace record timelines, flow executions, email chains, integration errors, import set runs, field mutations
-- :test_tube: **Record Write** -- create, update, delete records with direct or preview-then-apply patterns
-- :wrench: **Artifact Write** -- create and update platform artifacts (business rules, script includes, etc.) with optional local script file injection
-- :mag_right: **Investigations** -- 7 built-in analysis modules (stale automations, deprecated APIs, table health, ACL conflicts, error analysis, slow transactions, performance bottlenecks)
-- :page_facing_up: **Documentation** -- generate logic maps, artifact summaries, test scenarios, code review notes
-- :gear: **Workflow Analysis** -- list workflow versions, inspect contexts, map activity structures, trace execution status
-- :fire_engine: **Incident Management** -- list, create, update, resolve incidents and add comments
-- :arrows_counterclockwise: **Change Management** -- manage change requests, change tasks, and approvals
-- :warning: **Problem Management** -- track problems through root cause analysis to resolution
-- :globe_with_meridians: **CMDB** -- browse configuration items, relationships, classes, and health checks
-- :inbox_tray: **Request Management** -- manage service requests and request items (RITMs)
-- :books: **Knowledge Management** -- search, create, update articles and submit feedback
-- :shopping_cart: **Service Catalog** -- browse catalogs, categories, items, manage cart, and place orders
-- :shield: **Safety** -- table deny lists, sensitive field masking, row limit caps, write gating in production
-
----
+A developer and debug-focused [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for ServiceNow. Provides a comprehensive suite of tools across 20 tool groups for platform introspection, change intelligence, debugging, record management, ITSM workflows, CMDB operations, service catalog, automated investigations, documentation generation, and Flow Designer analysis.
 
 ## Quick Start
 
-```bash
-# No install needed -- run directly with uvx
-uvx servicenow-devtools-mcp
-```
-
-Set three required environment variables (or use a `.env` file):
+**1. Set environment variables:**
 
 ```bash
 export SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
@@ -51,7 +22,13 @@ export SERVICENOW_USERNAME=admin
 export SERVICENOW_PASSWORD=your-password
 ```
 
----
+**2. Run the server:**
+
+```bash
+uvx servicenow-devtools-mcp
+```
+
+**3. Connect your MCP client** (see [Configuration](#configuration) below).
 
 ## Configuration
 
@@ -68,9 +45,7 @@ Add to `~/.config/opencode/opencode.json`:
       "environment": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password",
-        "MCP_TOOL_PACKAGE": "full",
-        "SERVICENOW_ENV": "dev"
+        "SERVICENOW_PASSWORD": "your-password"
       }
     }
   }
@@ -79,7 +54,7 @@ Add to `~/.config/opencode/opencode.json`:
 
 ### Claude Desktop
 
-Add to your Claude Desktop config (`claude_desktop_config.json`):
+Add to `claude_desktop_config.json`:
 
 ```json
 {
@@ -90,18 +65,16 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
       "env": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password",
-        "MCP_TOOL_PACKAGE": "full",
-        "SERVICENOW_ENV": "dev"
+        "SERVICENOW_PASSWORD": "your-password"
       }
     }
   }
 }
 ```
 
-### VS Code / Cursor (Copilot MCP)
+### VS Code / Cursor
 
-Add to `.vscode/mcp.json` in your workspace:
+Add to `.vscode/mcp.json`:
 
 ```json
 {
@@ -112,9 +85,7 @@ Add to `.vscode/mcp.json` in your workspace:
       "env": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password",
-        "MCP_TOOL_PACKAGE": "full",
-        "SERVICENOW_ENV": "dev"
+        "SERVICENOW_PASSWORD": "your-password"
       }
     }
   }
@@ -130,534 +101,85 @@ SERVICENOW_PASSWORD=your-password \
 uvx servicenow-devtools-mcp
 ```
 
----
-
-## :robot: Install Instructions for AIs
-
-> Copy the block below and paste it into a conversation with any AI agent that supports MCP tool use. The AI will know how to configure and use this server.
-
-````text
-## ServiceNow MCP Server Setup
-
-You have access to a ServiceNow MCP server (`servicenow-devtools-mcp`) that provides
-100 tools for interacting with a ServiceNow instance.
-
-### Installation
-
-Run via uvx (no install required):
-```
-uvx servicenow-devtools-mcp
-```
-
-### Required Environment Variables
-
-- SERVICENOW_INSTANCE_URL -- Full URL of the ServiceNow instance (e.g. https://dev12345.service-now.com)
-- SERVICENOW_USERNAME -- ServiceNow user with admin or appropriate roles
-- SERVICENOW_PASSWORD -- Password for the user above
-
-### Optional Environment Variables
-
-- MCP_TOOL_PACKAGE -- Which tools to load (default: "full"). See Tool Packages section for all 14 options.
-- SERVICENOW_ENV -- Environment label: "dev" (default), "test", "staging", "prod". Write operations are blocked when set to "prod" or "production".
-- MAX_ROW_LIMIT -- Max records per query (default: 100, max: 10000)
-- LARGE_TABLE_NAMES_CSV -- Tables requiring date-bounded queries (default: syslog,sys_audit,sys_log_transaction,sys_email_log)
-- SCRIPT_ALLOWED_ROOT -- When using artifact_write with script_path, constrains file reads to this directory tree (required for script_path). The file must be an existing regular UTF-8 file of <= 1 MB.
-
-### MCP Client Configuration (stdio transport)
-
-```json
-{
-  "command": "uvx",
-  "args": ["servicenow-devtools-mcp"],
-  "env": {
-    "SERVICENOW_INSTANCE_URL": "<instance_url>",
-    "SERVICENOW_USERNAME": "<username>",
-    "SERVICENOW_PASSWORD": "<password>",
-    "MCP_TOOL_PACKAGE": "full",
-    "SERVICENOW_ENV": "dev"
-  }
-}
-```
-
-### Available Tools (100 total)
-
-**Table (4):** table_describe, table_query, table_aggregate, build_query
-  - Describe table schema with enriched metadata (sys_db_object + sys_documentation), query with encoded queries, compute stats, build structured queries
-
-**Record (3):** record_get, rel_references_to, rel_references_from
-  - Fetch records by sys_id, find what references a record, find what a record references
-
-**Attachment (4):** attachment_list, attachment_get, attachment_download, attachment_download_by_name
-  - List attachment metadata, fetch a single attachment record, and download content as `content_base64`
-
-**Attachment Write (2):** attachment_upload, attachment_delete
-  - Upload attachments with `content_base64` and delete attachments by sys_id
-
-**Metadata (4):** meta_list_artifacts, meta_get_artifact, meta_find_references, meta_what_writes
-  - List/inspect platform artifacts (business rules, script includes, etc.), find cross-references, find writers to a table
-
-**Change Intelligence (4):** changes_updateset_inspect, changes_diff_artifact, changes_last_touched, changes_release_notes
-  - Inspect update sets, diff artifact versions, view audit trail, generate release notes
-
-**Debug & Trace (6):** debug_trace, debug_flow_execution, debug_email_trace, debug_integration_health, debug_importset_run, debug_field_mutation_story
-  - Build event timelines, inspect flow executions, trace emails, check integration errors, inspect import sets, trace field mutations
-
-**Record Write (7):** record_create, record_preview_create, record_update, record_preview_update, record_delete, record_preview_delete, record_apply
-  - Create, update, delete records directly or via preview-then-apply confirmation pattern
-
-**Artifact Write (2):** artifact_create, artifact_update
-  - Create and update platform artifacts (business rules, script includes, client scripts, etc.) with optional local script file injection via script_path
-
-**Investigations (2 dispatchers, 7 modules):** investigate_run, investigate_explain
-  - Modules: stale_automations, deprecated_apis, table_health, acl_conflicts, error_analysis, slow_transactions, performance_bottlenecks
-
-**Documentation (4):** docs_logic_map, docs_artifact_summary, docs_test_scenarios, docs_review_notes
-  - Generate automation maps, artifact summaries with dependencies, test scenario suggestions, code review findings
-
-**Workflow Analysis (5):** workflow_contexts, workflow_map, workflow_status, workflow_activity_detail, workflow_version_list
-  - List workflow contexts for a record, map workflow structure, inspect execution status, view activity details
-
-**Flow Designer (8):** flow_list, flow_get, flow_map, flow_action_detail, flow_execution_list, flow_execution_detail, flow_snapshot_list, workflow_migration_analysis
-  - List, inspect, and map Flow Designer flows. View action details, execution history, published snapshots, and analyze legacy workflows for migration readiness
-
-**Incident Management (6):** incident_list, incident_get, incident_create, incident_update, incident_resolve, incident_add_comment
-  - Full incident lifecycle: list, fetch, create, update, resolve, and add comments/work notes
-
-**Change Management (6):** change_list, change_get, change_create, change_update, change_tasks, change_add_comment
-  - Manage change requests: list, fetch, create, update, view tasks, and add comments/work notes
-
-**Problem Management (5):** problem_list, problem_get, problem_create, problem_update, problem_root_cause
-  - Problem lifecycle: list, fetch, create, update, and document root cause analysis
-
-**CMDB (5):** cmdb_list, cmdb_get, cmdb_relationships, cmdb_classes, cmdb_health
-  - Browse CIs, inspect relationships, list CI classes, check CMDB health by operational status
-
-**Request Management (5):** request_list, request_get, request_items, request_item_get, request_item_update
-  - Manage service requests and RITMs: list, fetch, view items, update request items
-
-**Knowledge Management (5):** knowledge_search, knowledge_get, knowledge_create, knowledge_update, knowledge_feedback
-  - Search, read, create, update knowledge articles and submit feedback/ratings
-
-**Service Catalog (12):** sc_catalogs_list, sc_catalog_get, sc_categories_list, sc_category_get, sc_items_list, sc_item_get, sc_item_variables, sc_order_now, sc_add_to_cart, sc_cart_get, sc_cart_submit, sc_cart_checkout
-  - Browse catalogs, categories, and items. View item variables, order directly, manage cart, and checkout
-
-**Core (1):** list_tool_packages
-  - List available tool packages and their contents
-
-### Safety Guardrails
-
-- Table deny list: sys_user_has_role, sys_user_grmember, and other sensitive tables are blocked
-- Sensitive fields: password, token, secret fields are masked in responses
-- Row limits: User-supplied limit parameters capped at MAX_ROW_LIMIT (default 100)
-- Large tables: syslog, sys_audit, etc. require date-bounded filters
-- Write gating: All write operations blocked when SERVICENOW_ENV contains "prod" or "production"
-- Attachments: uploads accept `content_base64`; download tools return `content_base64`
-- Mandatory field validation: record creation validates all required fields are present before submission
-- Standardized responses: Tools return TOON-serialized envelopes with correlation_id, status, data, and optionally pagination and warnings
-````
-
----
-
 ## Environment Variables
 
 | Variable | Description | Default | Required |
-|---|---|---|---|
-| `SERVICENOW_INSTANCE_URL` | Full URL of your ServiceNow instance (must start with `https://`) | -- | Yes |
-| `SERVICENOW_USERNAME` | ServiceNow username (Basic Auth) | -- | Yes |
-| `SERVICENOW_PASSWORD` | ServiceNow password | -- | Yes |
-| `MCP_TOOL_PACKAGE` | Tool package to load (see [Tool Packages](#tool-packages)) | `full` | No |
-| `SERVICENOW_ENV` | Environment label (`dev`, `test`, `staging`, `prod`) | `dev` | No |
-| `MAX_ROW_LIMIT` | Maximum rows returned per query (range: 1-10000) | `100` | No |
-| `LARGE_TABLE_NAMES_CSV` | Comma-separated tables requiring date filters | `syslog,sys_audit,sys_log_transaction,sys_email_log` | No |
-| `SCRIPT_ALLOWED_ROOT` | Root directory for `script_path` in artifact write tools | `""` (disabled) | Yes (when using `script_path`) |
-| `SENTRY_DSN` | Sentry DSN for error reporting (enables Sentry when set) | `""` | No |
+|----------|-------------|---------|----------|
+| `SERVICENOW_INSTANCE_URL` | Full URL (must start with `https://`) | - | Yes |
+| `SERVICENOW_USERNAME` | ServiceNow username | - | Yes |
+| `SERVICENOW_PASSWORD` | ServiceNow password | - | Yes |
+| `MCP_TOOL_PACKAGE` | Tool package to load | `full` | No |
+| `SERVICENOW_ENV` | Environment label (`dev`/`test`/`staging`/`prod`) | `dev` | No |
+| `MAX_ROW_LIMIT` | Max rows per query (1-10000) | `100` | No |
+| `LARGE_TABLE_NAMES_CSV` | Tables requiring date filters | `syslog,sys_audit,sys_log_transaction,sys_email_log` | No |
+| `SCRIPT_ALLOWED_ROOT` | Root dir for `script_path` in artifact write | `""` (disabled) | When using `script_path` |
+| `SENTRY_DSN` | Sentry DSN for error reporting | `""` | No |
 | `SENTRY_ENVIRONMENT` | Sentry environment label | Falls back to `SERVICENOW_ENV` | No |
 
-The server reads from `.env` and `.env.local` files automatically (`.env.local` takes precedence).
-
----
-
-## Sentry Error Tracking
-
-Opt-in error tracking designed for MCP servers. Since MCP servers run as child processes of AI agents via stdio, the user never sees stdout or stderr - Sentry provides the primary way to get error visibility in production.
-
-### Install with Sentry support
-
-```bash
-uv pip install "servicenow-devtools-mcp[sentry]"
-```
-
-### Enable error tracking
-
-```bash
-# Required - provide a Sentry DSN to activate
-SENTRY_DSN=https://your-key@o123.ingest.sentry.io/456
-
-# Optional - override environment label (defaults to SERVICENOW_ENV)
-SENTRY_ENVIRONMENT=production
-```
-
-| Variable | Description | Default | Required |
-|---|---|---|---|
-| `SENTRY_DSN` | Sentry DSN for error reporting | `""` (disabled) | No |
-| `SENTRY_ENVIRONMENT` | Sentry environment label | Falls back to `SERVICENOW_ENV` | No |
-
-### What gets captured
-
-- **Tool errors** - every unhandled exception in tool execution, with tool name and correlation ID as tags
-- **HTTP errors** - ServiceNow API failures with status code, method, and URL as structured context
-- **Infrastructure failures** - broken tool group imports, persistent `sys_choice` fetch failures, TOON encoding bugs
-
-### Graceful degradation
-
-- Without `sentry-sdk` installed: zero overhead, all functions no-op
-- With package installed but no `SENTRY_DSN` set: no client initialized
-- With package installed and `SENTRY_DSN` set: full error capture active
-
-Performance monitoring is enabled in Sentry with `traces_sample_rate=1.0` (100% sampling) to capture full performance telemetry for this MCP server. Since MCP servers are single-user stdio processes, this is unlikely to cause ingest overhead. For high-throughput deployments, consider reducing the sample rate in code.
-
----
-
-## Tool Reference
-
-### Core
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `list_tool_packages` | List all available tool packages and their tool groups | -- |
-
-### :mag: Table
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `table_describe` | Return enriched field metadata for a table (types, references, choices, sys_db_object, sys_documentation) | `table` |
-| `table_query` | Query a table with encoded query string or query token | `table`, `query_token?`, `fields?`, `limit?`, `offset?`, `order_by?`, `display_values?` |
-| `table_aggregate` | Compute aggregate stats (count, avg, min, max, sum) | `table`, `query_token?`, `group_by?`, `avg_fields?`, `sum_fields?` |
-| `build_query` | Build a ServiceNow encoded query from structured JSON conditions | `conditions` (JSON array) |
-
-The `build_query` tool returns a reusable `query_token` that can be passed to `table_query`, `table_aggregate`, `meta_list_artifacts`, and other query-accepting tools. Supports comparison, string, null, time, date, range, field comparison, reference, change detection, logical, related list, and ordering operators.
-
-### :link: Record
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `record_get` | Fetch a single record by sys_id | `table`, `sys_id`, `fields?`, `display_values?` |
-| `rel_references_to` | Find records in other tables that reference a given record | `table`, `sys_id` |
-| `rel_references_from` | Find what a record references via its reference fields | `table`, `sys_id` |
-
-### :paperclip: Attachment
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `attachment_list` | List attachment metadata with optional table, record, and file filters | `table_name?`, `table_sys_id?`, `file_name?`, `limit?`, `offset?`, `order_by?` |
-| `attachment_get` | Fetch attachment metadata by attachment sys_id | `sys_id` |
-| `attachment_download` | Download attachment content by attachment sys_id | `sys_id` |
-| `attachment_download_by_name` | Download attachment content by source record and file name | `table_name`, `table_sys_id`, `file_name` |
-
-Download tools return attachment metadata plus `content_base64`.
-
-### :paperclip: Attachment Write
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `attachment_upload` | Upload a new attachment using base64-encoded content | `table_name`, `table_sys_id`, `file_name`, `content_base64`, `content_type?`, `encryption_context?`, `creation_time?` |
-| `attachment_delete` | Delete an attachment by attachment sys_id | `sys_id` |
-
-Uploads accept `content_base64` and follow the same write gating rules as other mutation tools.
-
-### :package: Metadata
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `meta_list_artifacts` | List platform artifacts by type (business rules, script includes, etc.) | `artifact_type`, `query_token?`, `limit?` |
-| `meta_get_artifact` | Get full artifact details including script body | `artifact_type`, `sys_id` |
-| `meta_find_references` | Search all script tables for references to a target string | `target`, `limit?` |
-| `meta_what_writes` | Find business rules that write to a table/field | `table`, `field?` |
-
-### :package: Change Intelligence
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `changes_updateset_inspect` | Inspect update set members grouped by type with risk flags | `update_set_id` |
-| `changes_diff_artifact` | Show unified diff between two most recent artifact versions | `table`, `sys_id` |
-| `changes_last_touched` | Show who last touched a record and what changed (sys_audit) | `table`, `sys_id`, `limit?` |
-| `changes_release_notes` | Generate Markdown release notes from an update set | `update_set_id`, `format?` |
-
-### :bug: Debug & Trace
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `debug_trace` | Build merged timeline from sys_audit, syslog, and journal | `record_sys_id`, `table`, `minutes?` |
-| `debug_flow_execution` | Inspect a Flow Designer execution step by step | `context_id` |
-| `debug_email_trace` | Reconstruct email chain for a record | `record_sys_id` |
-| `debug_integration_health` | Summarize recent integration errors (ECC queue or REST) | `kind?`, `hours?` |
-| `debug_importset_run` | Inspect import set run with row-level results | `import_set_sys_id` |
-| `debug_field_mutation_story` | Chronological mutation history of a single field | `table`, `sys_id`, `field`, `limit?` |
-
-### :test_tube: Record Write
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `record_create` | Create a new record in a table | `table`, `data` (JSON string) |
-| `record_preview_create` | Preview a record creation and get a confirmation token | `table`, `data` (JSON string) |
-| `record_update` | Update an existing record | `table`, `sys_id`, `changes` (JSON string) |
-| `record_preview_update` | Preview a record update with field-level diff | `table`, `sys_id`, `changes` (JSON string) |
-| `record_delete` | Delete a record | `table`, `sys_id` |
-| `record_preview_delete` | Preview a deletion showing the record to be removed | `table`, `sys_id` |
-| `record_apply` | Apply a previously previewed action (create, update, or delete) | `preview_token` |
-
-### :wrench: Artifact Write
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `artifact_create` | Create a new platform artifact in ServiceNow | `artifact_type`, `data` (JSON string), `script_path?` |
-| `artifact_update` | Update an existing platform artifact in ServiceNow | `artifact_type`, `sys_id`, `changes` (JSON string), `script_path?` |
-
-Supports 17 artifact types: `business_rule`, `script_include`, `ui_policy`, `ui_action`, `client_script`, `scheduled_job`, `fix_script`, `scripted_rest_resource`, `ui_script`, `processor`, `widget`, `ui_page`, `ui_macro`, `script_action`, `mid_script_include`, `scripted_rest_api`, `notification_script`.
-
-When `script_path` is provided, it must be an absolute filesystem path; relative paths are rejected. Requires `SCRIPT_ALLOWED_ROOT` to be configured. The path must resolve to an existing regular UTF-8 file under that root, and file size must be <= 1 MB. The file content is read and set as the artifact's script field. The script field varies by artifact type (e.g. `script` for business rules, `operation_script` for scripted REST resources, `html` for UI pages).
-
-### :mag_right: Investigations
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `investigate_run` | Run a named investigation module | `investigation`, `params?` (JSON string) |
-| `investigate_explain` | Get detailed explanation for a specific finding | `investigation`, `element_id` |
-
-**Available investigation modules:**
-
-| Module | What it does |
-|---|---|
-| `stale_automations` | Find disabled or unused business rules, flows, and scheduled jobs |
-| `deprecated_apis` | Scan scripts for deprecated ServiceNow API usage |
-| `table_health` | Analyze table size, index coverage, and schema issues |
-| `acl_conflicts` | Detect conflicting or redundant ACL rules |
-| `error_analysis` | Aggregate and categorize recent errors from syslog |
-| `slow_transactions` | Find slow-running transactions from sys_log_transaction |
-| `performance_bottlenecks` | Identify performance issues across flows, queries, and scripts |
-
-### :page_facing_up: Documentation
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `docs_logic_map` | Generate lifecycle logic map of all automations on a table | `table` |
-| `docs_artifact_summary` | Generate artifact summary with dependency analysis | `artifact_type`, `sys_id` |
-| `docs_test_scenarios` | Analyze script and suggest test scenarios | `artifact_type`, `sys_id` |
-| `docs_review_notes` | Scan script for anti-patterns and generate review notes | `artifact_type`, `sys_id` |
-
-### :gear: Workflow Analysis
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `workflow_contexts` | List legacy and Flow Designer contexts running on a record | `record_sys_id`, `table?`, `state?`, `limit?` |
-| `workflow_map` | Show structure of a workflow version (activities, transitions, variables) | `workflow_version_sys_id` |
-| `workflow_status` | Show execution status of a workflow context | `context_sys_id` |
-| `workflow_activity_detail` | Fetch detailed info about a workflow activity | `activity_sys_id` |
-| `workflow_version_list` | List workflow versions defined for a table | `table`, `active_only?`, `limit?` |
-
-### :ocean: Flow Designer
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `flow_list` | List Flow Designer flows and subflows with optional filters | `table?`, `flow_type?`, `status?`, `active_only?`, `limit?` |
-| `flow_get` | Fetch a Flow Designer flow definition with inputs/outputs | `flow_sys_id` |
-| `flow_map` | Map the structure of a flow (action instances and logic blocks) | `flow_sys_id` |
-| `flow_action_detail` | Fetch detailed info about a flow action instance | `action_instance_sys_id` |
-| `flow_execution_list` | List Flow Designer execution contexts with optional filters | `flow_sys_id?`, `source_record?`, `state?`, `limit?` |
-| `flow_execution_detail` | Fetch detailed execution info including ordered log entries | `context_id` |
-| `flow_snapshot_list` | List published snapshots (versions) for a flow | `flow_sys_id`, `limit?` |
-| `workflow_migration_analysis` | Analyze a legacy workflow for Flow Designer migration readiness | `workflow_version_sys_id` |
-
-### :fire_engine: Incident Management
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `incident_list` | List incidents with optional filters | `state?`, `priority?`, `assigned_to?`, `assignment_group?`, `limit?` |
-| `incident_get` | Fetch incident by INC number | `number` |
-| `incident_create` | Create a new incident | `short_description`, `urgency?`, `impact?`, `priority?`, `description?`, `assignment_group?` |
-| `incident_update` | Update an existing incident by INC number | `number`, `state?`, `priority?`, `assigned_to?`, ... |
-| `incident_resolve` | Resolve an incident with close code and notes | `number`, `close_code`, `close_notes` |
-| `incident_add_comment` | Add comment or work note to an incident | `number`, `comment?`, `work_note?` |
-
-### :arrows_counterclockwise: Change Management
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `change_list` | List change requests with optional filters | `state?`, `type?`, `risk?`, `assignment_group?`, `limit?` |
-| `change_get` | Fetch change request by CHG number | `number` |
-| `change_create` | Create a new change request | `short_description`, `type?`, `risk?`, `assignment_group?`, `start_date?`, `end_date?` |
-| `change_update` | Update an existing change request by CHG number | `number`, `state?`, `type?`, `risk?`, ... |
-| `change_tasks` | Get change tasks for a change request | `number`, `limit?` |
-| `change_add_comment` | Add comment or work note to a change request | `number`, `comment?`, `work_note?` |
-
-### :warning: Problem Management
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `problem_list` | List problems with optional filters | `state?`, `priority?`, `assigned_to?`, `assignment_group?`, `limit?` |
-| `problem_get` | Fetch problem by PRB number | `number` |
-| `problem_create` | Create a new problem | `short_description`, `urgency?`, `impact?`, `priority?`, `description?` |
-| `problem_update` | Update an existing problem by PRB number | `number`, `state?`, `priority?`, `assigned_to?`, ... |
-| `problem_root_cause` | Document root cause analysis for a problem | `number`, `cause_notes`, `fix_notes?` |
-
-### :globe_with_meridians: CMDB
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `cmdb_list` | List Configuration Items from CMDB | `ci_class?`, `operational_status?`, `limit?` |
-| `cmdb_get` | Fetch a Configuration Item by name or sys_id | `name_or_sys_id`, `ci_class?` |
-| `cmdb_relationships` | Fetch CMDB relationships for a CI | `name_or_sys_id`, `direction?`, `ci_class?` |
-| `cmdb_classes` | List unique CI classes in CMDB | `limit?` |
-| `cmdb_health` | Check CMDB health by aggregating operational status | `ci_class?` |
-
-### :inbox_tray: Request Management
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `request_list` | List requests with optional filters | `state?`, `requested_for?`, `assignment_group?`, `limit?` |
-| `request_get` | Fetch request by REQ number | `number` |
-| `request_items` | Fetch request items (RITMs) for a request | `number`, `limit?` |
-| `request_item_get` | Fetch request item by RITM number | `number` |
-| `request_item_update` | Update a request item by RITM number | `number`, `state?`, `assignment_group?`, `assigned_to?` |
-
-### :books: Knowledge Management
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `knowledge_search` | Search knowledge articles with fuzzy text matching | `query`, `workflow_state?`, `limit?` |
-| `knowledge_get` | Fetch a knowledge article by KB number or sys_id | `number_or_sys_id` |
-| `knowledge_create` | Create a new knowledge article | `short_description`, `text`, `kb_knowledge_base?`, `workflow_state?` |
-| `knowledge_update` | Update a knowledge article by KB number or sys_id | `number_or_sys_id`, `short_description?`, `text?`, `workflow_state?` |
-| `knowledge_feedback` | Submit feedback (rating or comment) for a knowledge article | `number_or_sys_id`, `rating?`, `comment?` |
-
-### :shopping_cart: Service Catalog
-
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `sc_catalogs_list` | List service catalogs | `limit?`, `text?` |
-| `sc_catalog_get` | Fetch details of a specific catalog | `sys_id` |
-| `sc_categories_list` | List categories for a catalog | `catalog_sys_id`, `top_level_only?`, `limit?` |
-| `sc_category_get` | Fetch details of a catalog category | `sys_id` |
-| `sc_items_list` | List catalog items with optional filters | `text?`, `catalog?`, `category?`, `limit?` |
-| `sc_item_get` | Fetch details of a catalog item | `sys_id` |
-| `sc_item_variables` | Fetch variables (form fields) for a catalog item | `sys_id` |
-| `sc_order_now` | Order a catalog item immediately (bypass cart) | `item_sys_id`, `variables?` |
-| `sc_add_to_cart` | Add a catalog item to the shopping cart | `item_sys_id`, `variables?` |
-| `sc_cart_get` | Retrieve current shopping cart contents | -- |
-| `sc_cart_submit` | Submit the current shopping cart as an order | -- |
-| `sc_cart_checkout` | Checkout the current shopping cart | -- |
-
----
+The server reads from `.env` and `.env.local` files automatically.
+
+## AI Agent Setup
+
+Setting up this server with an AI agent? See the [AI Installation Guide](INSTALL.md) for a copy-paste block that helps AI agents understand and configure this server.
+
+## Key Features
+
+- **Platform introspection** - describe tables, query records, inspect metadata, compute aggregates
+- **Change intelligence** - update set inspection, artifact diffs, audit trails, release notes
+- **Debug and trace** - event timelines, flow execution, email tracing, import sets, field mutations
+- **Record management** - full CRUD with preview-then-apply safety pattern
+- **Artifact management** - create/update business rules, script includes, and 15+ artifact types with local script file support
+- **ITSM workflows** - incident, change, problem lifecycle management
+- **CMDB operations** - browse CIs, relationships, classes, and health checks
+- **Service catalog** - browse, order, cart management, checkout
+- **Knowledge management** - search, create, update articles and feedback
+- **Investigations** - automated analysis of stale automations, deprecated APIs, ACL conflicts, performance bottlenecks
+- **Documentation generation** - logic maps, artifact summaries, test scenarios, review notes
+- **Flow Designer** - inspect flows, actions, executions, snapshots, migration analysis
 
 ## Tool Packages
 
-Control which tools are loaded using the `MCP_TOOL_PACKAGE` environment variable. There are 14 preset packages plus support for custom combinations.
-
-### Preset Packages
+Control which tools are loaded with `MCP_TOOL_PACKAGE`. There are 14 preset packages:
 
 | Package | Groups | Description |
-|---|---|---|
-| `full` (default) | 20 | All standard tool groups (excludes `testing`) -- 100 tools total |
-| `itil` | 16 | ITIL process tools (incidents, changes, problems, requests + platform tools) |
-| `developer` | 13 | Development-focused (table, record, attachments, debug, investigations, workflows) |
-| `readonly` | 10 | Read-only operations, including attachment read tools |
-| `analyst` | 8 | Analysis and reporting (table, record, attachments, investigations, docs, workflows) |
-| `incident_management` | 9 | Incident lifecycle with supporting tools and attachment writes |
-| `problem_management` | 9 | Problem lifecycle with supporting tools and attachment writes |
-| `change_management` | 8 | Change request management with change intelligence and attachment writes |
-| `request_management` | 8 | Request and RITM management with attachment writes |
-| `cmdb` | 6 | CMDB management with relationships and attachment writes |
-| `knowledge_management` | 6 | Knowledge base tools with attachment writes |
-| `service_catalog` | 6 | Service catalog tools with attachment writes |
-| `core_readonly` | 4 | Read-only core tools (table, record, attachment, metadata) |
-| `none` | 0 | Only `list_tool_packages` -- minimal/testing |
+|---------|--------|-------------|
+| `full` | 20 | All standard tools (default) |
+| `core_readonly` | 4 | Read-only core tools |
+| `none` | 0 | No tools loaded |
+| `itil` | 16 | ITIL process tools |
+| `developer` | 13 | Development-focused tools |
+| `readonly` | 10 | Read-only operations |
+| `analyst` | 8 | Analysis and reporting |
+| `incident_management` | 9 | Incident lifecycle |
+| `change_management` | 8 | Change request tools |
+| `cmdb` | 6 | CMDB management |
+| `problem_management` | 9 | Problem lifecycle |
+| `request_management` | 8 | Request/RITM tools |
+| `knowledge_management` | 6 | Knowledge base tools |
+| `service_catalog` | 6 | Service catalog tools |
 
-### Custom Packages
+You can also create custom packages with comma-separated group names (e.g. `MCP_TOOL_PACKAGE="table,record,debug"`). See the [Wiki](https://github.com/Xerrion/servicenow-devtools-mcp/wiki) for full package and tool group details.
 
-You can also specify a comma-separated list of tool group names to create a custom package:
+## Safety
 
-```bash
-MCP_TOOL_PACKAGE="table,record,debug,domain_incident"
-```
+- **Table deny list** - blocks access to sensitive system tables (`sys_user_has_password`, `oauth_credential`, `sys_credentials`, etc.)
+- **Sensitive field masking** - password, token, secret, and similar fields are automatically masked
+- **Write gating** - all write operations blocked when `SERVICENOW_ENV` is set to `prod` or `production`
+- **Row limits and large table protection** - prevents runaway queries with configurable caps and mandatory date filters
 
-Readonly-style packages include only `attachment`. Write-capable packages include both `attachment` and `attachment_write`.
-
-Available tool groups: `table`, `record`, `attachment`, `record_write`, `attachment_write`, `metadata`, `artifact_write`, `changes`, `debug`, `investigations`, `documentation`, `workflow`, `flow_designer`, `testing`, `domain_incident`, `domain_change`, `domain_problem`, `domain_cmdb`, `domain_request`, `domain_knowledge`, `domain_service_catalog`.
-
----
-
-## Safety & Policy
-
-The server includes built-in guardrails that are always active:
-
-- **Table deny list** -- Sensitive tables like `sys_user_has_role`, `sys_user_grmember`, and 6 others are blocked from queries
-- **Sensitive field masking** -- Fields whose names match patterns like `password`, `token`, `secret`, `credential`, `api_key`, or `private_key` are masked with the literal value `***MASKED***` in responses
-- **Row limit caps** -- User-supplied `limit` parameters are capped at `MAX_ROW_LIMIT` (default 100, max 10000). If a larger value is requested, the limit is reduced and a warning is included in the response
-- **Large table protection** -- Tables listed in `LARGE_TABLE_NAMES_CSV` require date-bounded filters in queries to prevent full-table scans
-- **Write gating** -- All write operations (record_write tools and domain create/update tools) are blocked when `SERVICENOW_ENV` contains "prod" or "production". There is no override - use a sub-production instance for write operations
-- **Query safety** -- Structured query validation with identifier checks and internal query limits
-- **Standardized responses** -- Every tool returns a TOON-serialized envelope with `correlation_id`, `status`, and `data`, and may include `pagination` and `warnings` when applicable
-
----
-
-## Example Prompts
-
-Here are some real-world prompts you can use with an AI agent that has this MCP server connected:
-
-> Describe the incident table and show me all the business rules that fire on it.
->
-> List all P1 incidents from the last week and show me who resolved them.
->
-> Trace the full lifecycle of INC0010042 -- show me every field change, comment, and log entry.
->
-> Inspect update set "Q1 Release" and generate release notes. Flag any risky changes.
->
-> Run the stale_automations investigation and explain the top findings.
->
-> Find all scripts that reference the "cmdb_ci_server" table and check them for anti-patterns.
->
-> Create a new incident with priority 1 and short description "Server outage". Show me a preview first.
->
-> Show me the performance bottlenecks investigation and explain any slow transactions found.
->
-> List all open change requests and show me the tasks for CHG0010023.
->
-> Search the knowledge base for "VPN setup" and update the article with the new server address.
->
-> Browse the service catalog for laptop requests and show me the available options.
->
-> Check CMDB health and show me the relationships for our production database server.
-
----
+See the [Safety & Policy](https://github.com/Xerrion/servicenow-devtools-mcp/wiki) wiki page for complete details.
 
 ## Development
 
 ```bash
-# Clone the repository
-git clone https://github.com/xerrion/servicenow-devtools-mcp.git
+git clone https://github.com/Xerrion/servicenow-devtools-mcp.git
 cd servicenow-devtools-mcp
-
-# Install dependencies (including dev tools)
 uv sync --group dev
-
-# Run unit tests (~1165 tests)
-uv run pytest
-
-# Run integration tests (requires .env.local with real credentials)
-uv run pytest -m integration
-
-# Lint and format
-uv run ruff check .
-uv run ruff format .
-
-# Type check
-uv run mypy src/
-
-# Run the server locally
-uv run servicenow-devtools-mcp
+uv run pytest                  # Run tests
+uv run ruff check .            # Lint
+uv run ruff format .           # Format
+uv run mypy src/               # Type check
 ```
-
----
 
 ## License
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -74,15 +74,15 @@
 
   <!-- Tool count pill -->
   <g transform="translate(130, 150)">
-    <rect width="90" height="28" rx="14" fill="#00c9a7" opacity="0.15"/>
-    <rect width="90" height="28" rx="14" fill="none" stroke="#00c9a7" stroke-width="1" opacity="0.4"/>
-    <text x="45" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="13" fill="#00c9a7" text-anchor="middle" font-weight="600">
-      36 Tools
+    <rect width="100" height="28" rx="14" fill="#00c9a7" opacity="0.15"/>
+    <rect width="100" height="28" rx="14" fill="none" stroke="#00c9a7" stroke-width="1" opacity="0.4"/>
+    <text x="50" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="13" fill="#00c9a7" text-anchor="middle" font-weight="600">
+      90+ Tools
     </text>
   </g>
 
   <!-- Category pills -->
-  <g transform="translate(235, 150)">
+  <g transform="translate(245, 150)">
     <rect width="100" height="28" rx="14" fill="#00d4ff" opacity="0.1"/>
     <rect width="100" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.3"/>
     <text x="50" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#00d4ff" text-anchor="middle">
@@ -90,7 +90,7 @@
     </text>
   </g>
 
-  <g transform="translate(350, 150)">
+  <g transform="translate(360, 150)">
     <rect width="70" height="28" rx="14" fill="#00d4ff" opacity="0.1"/>
     <rect width="70" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.3"/>
     <text x="35" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#00d4ff" text-anchor="middle">
@@ -98,7 +98,7 @@
     </text>
   </g>
 
-  <g transform="translate(435, 150)">
+  <g transform="translate(445, 150)">
     <rect width="105" height="28" rx="14" fill="#00d4ff" opacity="0.1"/>
     <rect width="105" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.3"/>
     <text x="52" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#00d4ff" text-anchor="middle">
@@ -106,11 +106,27 @@
     </text>
   </g>
 
-  <g transform="translate(555, 150)">
+  <g transform="translate(565, 150)">
     <rect width="60" height="28" rx="14" fill="#00d4ff" opacity="0.1"/>
     <rect width="60" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.3"/>
     <text x="30" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#00d4ff" text-anchor="middle">
       Docs
+    </text>
+  </g>
+
+  <g transform="translate(640, 150)">
+    <rect width="60" height="28" rx="14" fill="#00d4ff" opacity="0.1"/>
+    <rect width="60" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.3"/>
+    <text x="30" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#00d4ff" text-anchor="middle">
+      ITSM
+    </text>
+  </g>
+
+  <g transform="translate(715, 150)">
+    <rect width="70" height="28" rx="14" fill="#00d4ff" opacity="0.1"/>
+    <rect width="70" height="28" rx="14" fill="none" stroke="#00d4ff" stroke-width="1" opacity="0.3"/>
+    <text x="35" y="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#00d4ff" text-anchor="middle">
+      CMDB
     </text>
   </g>
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,369 @@
+# Architecture
+
+Deep technical architecture of the `servicenow-devtools-mcp` server - an async Python MCP server for ServiceNow platform introspection, change intelligence, debugging, investigations, and documentation generation.
+
+## Overview
+
+The server is built on:
+
+- **FastMCP** - MCP server framework providing tool registration and transport handling
+- **httpx** - Async HTTP client for ServiceNow REST API communication
+- **pydantic-settings** - Configuration management via environment variables
+- **TOON format** - Serialization format optimized for LLM consumption (not raw JSON)
+- **sentry-sdk** - Error tracking for invisible child-process environments
+
+Communication happens over **stdio transport** - the server runs as a child process of an AI agent, meaning the user never sees stdout/stderr directly.
+
+See also: [[Development]] for setup and tooling, [[Telemetry]] for observability.
+
+## Server Bootstrap
+
+The server entry point is `server.py`, which exposes two functions: `create_mcp_server()` (factory) and `main()` (runner).
+
+### `create_mcp_server()` Factory
+
+This function performs a strict initialization sequence:
+
+1. **Create Settings** - `Settings()` loads configuration from environment variables via pydantic-settings (reads `.env` and `.env.local` files)
+2. **Create auth provider** - `create_auth(settings)` returns a `BasicAuthProvider` for ServiceNow API authentication
+3. **Initialize Sentry** - `setup_sentry(settings)` activates error tracking when a DSN is configured
+4. **Set server context** - Attaches instance hostname, environment, production flag, and tool package to Sentry scope
+5. **Create FastMCP instance** - `FastMCP("servicenow-dev-debug")`
+6. **Create shared state** - `QueryTokenStore()` for query token management, `ChoiceRegistry(settings, auth_provider)` for choice label resolution
+7. **Attach state to FastMCP** - `attach_servicenow_state()` stores all shared objects on the FastMCP instance via typed helpers in `mcp_state.py`
+8. **Register `list_tool_packages`** - Always-on tool that returns all available tool packages
+9. **Load tool groups** - Loops through the active package's tool groups, dynamically importing each module via `importlib.import_module()` and calling its `register_tools()` function
+10. **Domain module detection** - Modules with group names prefixed `domain_` receive an additional `choices=choices` keyword argument
+
+### `main()` Runner
+
+```python
+def main() -> None:
+    mcp = create_mcp_server()
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        shutdown_sentry()
+```
+
+The `finally` block ensures Sentry flushes pending events even if the server crashes.
+
+## Tool Registration Pattern
+
+Each tool group lives in its own module under `tools/` (or `tools/domains/` for ITSM domain tools). Every module exports a `register_tools()` function.
+
+### Standard Tools
+
+```python
+def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    @mcp.tool()
+    @tool_handler
+    async def my_tool(param: str, correlation_id: str = "") -> str:
+        validate_identifier(param)
+        check_table_access(param)
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.some_method(param)
+        return format_response(data=result, correlation_id=correlation_id)
+```
+
+### Domain Tools
+
+Domain modules receive an additional `choices` parameter for label-to-value resolution:
+
+```python
+def register_tools(
+    mcp: FastMCP,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    choices: ChoiceRegistry | None = None,
+) -> None:
+    @mcp.tool()
+    @tool_handler
+    async def incident_list(state: str = "", correlation_id: str = "") -> str:
+        if state and choices:
+            state = await choices.resolve("incident", "state", state)
+        ...
+```
+
+### 21 Tool Group Modules
+
+| Group Name | Module Path | Type |
+|---|---|---|
+| `table` | `tools.table` | Standard |
+| `record` | `tools.record` | Standard |
+| `attachment` | `tools.attachment` | Standard |
+| `record_write` | `tools.record_write` | Standard |
+| `attachment_write` | `tools.attachment_write` | Standard |
+| `testing` | `tools.testing` | Standard (disabled in `full`) |
+| `metadata` | `tools.metadata` | Standard |
+| `artifact_write` | `tools.artifact_write` | Standard |
+| `changes` | `tools.changes` | Standard |
+| `debug` | `tools.debug` | Standard |
+| `investigations` | `tools.investigations` | Standard |
+| `documentation` | `tools.documentation` | Standard |
+| `workflow` | `tools.workflow` | Standard |
+| `flow_designer` | `tools.flow_designer` | Standard |
+| `domain_incident` | `tools.domains.incident` | Domain |
+| `domain_change` | `tools.domains.change` | Domain |
+| `domain_cmdb` | `tools.domains.cmdb` | Domain |
+| `domain_problem` | `tools.domains.problem` | Domain |
+| `domain_request` | `tools.domains.request` | Domain |
+| `domain_knowledge` | `tools.domains.knowledge` | Domain |
+| `domain_service_catalog` | `tools.domains.service_catalog` | Domain |
+
+## The `@tool_handler` Decorator
+
+Located in `decorators.py`, this is the central pattern - every tool function uses it. The decorator stacks as `@mcp.tool()` (outer) then `@tool_handler` (inner).
+
+### What It Does
+
+1. **Auto-generates `correlation_id`** - Calls `generate_correlation_id()` which returns a UUID4 string
+2. **Sets Sentry tags** - `tool.name` and `tool.correlation_id` for filtering in the Sentry UI
+3. **Sets Sentry context** - Structured `"tool"` context with name, correlation_id, and sanitized args (excluding `correlation_id` itself from the args dict)
+4. **Wraps in `safe_tool_call()`** - Error handling boundary that catches exceptions and returns serialized error envelopes
+5. **Hides `correlation_id` from schema** - Overrides `__signature__` to remove the `correlation_id` parameter so FastMCP does not expose it in the tool schema
+6. **Deletes `__wrapped__`** - Removes the attribute set by `functools.wraps` so that `inspect.signature()` uses the overridden `__signature__` instead of following `__wrapped__` back to the original function
+
+### How `correlation_id` Flows
+
+```
+MCP Client calls tool (no correlation_id)
+  -> @tool_handler generates UUID4
+    -> Sets Sentry tags and context
+    -> Injects correlation_id as kwarg to original function
+    -> Original function uses it in format_response()
+    -> Response envelope includes correlation_id for tracing
+```
+
+## Error Handling Flow
+
+### Exception Hierarchy
+
+```
+ServiceNowMCPError(Exception)       # Root - has status_code attribute
+    |-- AuthError                    # HTTP 401
+    |-- ForbiddenError               # HTTP 403
+    |-- NotFoundError                # HTTP 404
+    |-- ServerError                  # HTTP 5xx
+    |-- PolicyError                  # HTTP 403 (policy violations)
+          |-- QuerySafetyError       # HTTP 403 (unsafe queries)
+```
+
+### `safe_tool_call()` Error Boundary
+
+Located at the end of `utils.py`, this function wraps every tool invocation:
+
+```python
+async def safe_tool_call(fn, correlation_id) -> str:
+    try:
+        return await fn()
+    except ForbiddenError as e:
+        sentry_capture(e)
+        return format_response(
+            data=None, correlation_id=correlation_id,
+            status="error", error=f"Access denied by ServiceNow ACL: {e}",
+        )
+    except Exception as e:
+        sentry_capture(e)
+        return format_response(
+            data=None, correlation_id=correlation_id,
+            status="error", error=str(e),
+        )
+```
+
+Key properties:
+
+- **Tool functions never raise to MCP** - all exceptions become serialized response envelopes
+- **Both paths capture to Sentry** - every error is tracked
+- **`ForbiddenError` gets special treatment** - ACL denials produce a specific error message
+- **No manual try/except needed** - tool functions rely entirely on this wrapper
+
+## ServiceNow Client
+
+`ServiceNowClient` in `client.py` is an async context manager wrapping `httpx.AsyncClient`:
+
+- **Timeout**: 30 seconds
+- **`_ensure_client()`**: Raises `RuntimeError` (not assert) if the client is used outside the context manager
+- **`_raise_for_status()`**: Maps HTTP status codes to custom exceptions and sets Sentry `"http"` context with `status_code`, `method`, and `url` before raising
+- **An extensive set of async methods** covering: records, attachments, metadata, aggregation, CRUD, CMDB, email, import sets, reports, code search, service catalog, ATF, and more
+- **Input validation**: Uses `validate_identifier()` for table and field names
+
+### HTTP Status Mapping
+
+| HTTP Status | Exception |
+|---|---|
+| 401 | `AuthError` |
+| 403 | `ForbiddenError` |
+| 404 | `NotFoundError` |
+| 500+ | `ServerError` |
+| 400+ (other) | `ServiceNowMCPError` |
+
+## TOON Serialization
+
+All tool output uses **TOON format** - not raw JSON. TOON is an LLM-optimized serialization format.
+
+### `serialize(data)` in `utils.py`
+
+```python
+def serialize(data: Any) -> str:
+    try:
+        return toon_encode(data)
+    except Exception as e:
+        logger.warning("TOON encoding failed, falling back to JSON", exc_info=True)
+        sentry_capture(e)
+        return json.dumps(data, indent=2)
+```
+
+Falls back to JSON if TOON encoding fails, capturing the failure to Sentry.
+
+### `format_response()` Envelope
+
+Builds a standardized response envelope and serializes it:
+
+```python
+format_response(
+    data=...,               # Any serializable data
+    correlation_id=...,     # Auto-injected by @tool_handler
+    status="success",       # "success" or "error"
+    error=None,             # str | dict | None
+    pagination=None,        # dict | None
+    warnings=None,          # list | None
+) -> str                    # Returns serialized TOON string
+```
+
+The envelope always contains `correlation_id`, `status`, and `data`. Optional fields (`error`, `pagination`, `warnings`) are included only when provided. Error strings are wrapped as `{"message": error}` dicts.
+
+### Parsing Tool Output
+
+```python
+# CORRECT - use toon_decode
+from toon_format import decode as toon_decode
+result = toon_decode(raw_output)
+
+# WRONG - will fail on TOON-formatted output
+import json
+result = json.loads(raw_output)
+```
+
+## State Management
+
+Located in `state.py`, two token store classes provide in-memory state with automatic expiry.
+
+### Base Class: `_BaseTokenStore`
+
+- **UUID keys** - Every stored payload gets a unique UUID4 token
+- **TTL expiry** - Default 300 seconds, using `time.monotonic()` timestamps
+- **Max size** - 1000 entries, raises `RuntimeError` when full
+- **Lazy cleanup** - Expired entries swept on `create()` calls
+- **Methods**: `create(payload) -> str`, `get(token) -> dict | None`
+
+### `PreviewTokenStore` (Single-Use)
+
+Used for the record write preview/apply pattern. Adds a `consume(token)` method that retrieves the payload and deletes the token in one operation.
+
+### `QueryTokenStore` (Reusable)
+
+Used for the `build_query` -> query-consuming tools workflow. Tokens remain valid within their TTL and can be retrieved multiple times via `get()`.
+
+### Token Flow Example
+
+```
+build_query tool -> QueryTokenStore.create({"query": "state=1^priority=2"})
+                 -> returns token "abc-123"
+
+record_list tool -> resolve_query_token("abc-123", store, correlation_id)
+                 -> returns "state=1^priority=2"
+                 -> token still valid for reuse
+```
+
+## ChoiceRegistry
+
+Located in `choices.py`, provides lazy-loaded choice label resolution backed by the ServiceNow `sys_choice` table.
+
+### Initialization
+
+- Created in `create_mcp_server()` but data is **not** fetched until first use
+- Uses `asyncio.Lock` with a double-check pattern for thread-safe initialization
+- Fetches all choice records from `sys_choice` on first access
+- Falls back to hardcoded `_DEFAULTS` on fetch failure (captured to Sentry)
+
+### 6 Default Table/Field Mappings
+
+| Table | Field |
+|---|---|
+| `incident` | `state` |
+| `change_request` | `state` |
+| `problem` | `state` |
+| `cmdb_ci` | `operational_status` |
+| `sc_request` | `state` |
+| `sc_req_item` | `state` |
+
+### Label Normalization
+
+Labels are normalized to lowercase with spaces replaced by underscores:
+
+- `"New"` -> `"new"`
+- `"In Progress"` -> `"in_progress"`
+- `"On Hold"` -> `"on_hold"`
+
+### API
+
+```python
+# Resolve a label to its ServiceNow value (or passthrough if not found)
+await choices.resolve("incident", "state", "open")
+
+# Get all choices for a table/field pair
+choices.get_choices("incident", "state")  # Returns dict[str, str]
+```
+
+## Source Layout
+
+```
+src/servicenow_mcp/
+    server.py              # Entry point, bootstrap
+    config.py              # Settings (pydantic-settings)
+    auth.py                # Basic Auth provider
+    client.py              # ServiceNow HTTP client
+    decorators.py          # @tool_handler decorator
+    utils.py               # Serialization, query builder, validation
+    errors.py              # Exception hierarchy
+    policy.py              # Table access, field sensitivity, query safety
+    state.py               # PreviewTokenStore, QueryTokenStore
+    choices.py             # Choice label resolution (sys_choice)
+    sentry.py              # Sentry error tracking integration
+    packages.py            # Tool package registry (14 presets)
+    mcp_state.py           # Typed FastMCP state attachment helpers
+    types.py               # Type aliases
+    investigation_helpers.py  # Shared investigation utilities
+    investigations/        # 7 investigation modules
+        stale_automations.py
+        deprecated_apis.py
+        table_health.py
+        acl_conflicts.py
+        error_analysis.py
+        slow_transactions.py
+        performance_bottlenecks.py
+    tools/                 # Tool group modules
+        table.py
+        record.py
+        record_write.py
+        attachment.py
+        attachment_write.py
+        artifact_write.py
+        metadata.py
+        changes.py
+        debug.py
+        investigations.py
+        documentation.py
+        workflow.py
+        flow_designer.py
+        testing.py
+        domains/           # Domain-specific tools (ITSM)
+            incident.py
+            change.py
+            cmdb.py
+            problem.py
+            request.py
+            knowledge.py
+            service_catalog.py
+```

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -1,0 +1,151 @@
+# Configuration
+
+All configuration is handled through environment variables, loaded via [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). No configuration files or CLI flags are needed beyond environment variables.
+
+---
+
+## Environment Variables
+
+| Variable | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `SERVICENOW_INSTANCE_URL` | string | Yes | - | Full URL of the ServiceNow instance (must start with `https://`, trailing slash stripped automatically) |
+| `SERVICENOW_USERNAME` | string | Yes | - | ServiceNow username for Basic Auth |
+| `SERVICENOW_PASSWORD` | string (secret) | Yes | - | ServiceNow password (stored as `SecretStr`, masked in logs and debug output) |
+| `MCP_TOOL_PACKAGE` | string | No | `"full"` | Which tool package to load. See [[Tool-Packages]] for all preset and custom options |
+| `SERVICENOW_ENV` | string | No | `"dev"` | Environment label. Write operations blocked when set to `"prod"` or `"production"` |
+| `MAX_ROW_LIMIT` | integer | No | `100` | Maximum records returned per query (valid range: 1-10000) |
+| `LARGE_TABLE_NAMES_CSV` | string | No | `"syslog,sys_audit,sys_log_transaction,sys_email_log"` | Comma-separated list of tables considered "large" and requiring date-bounded queries |
+| `SCRIPT_ALLOWED_ROOT` | string | No | `""` (disabled) | Root directory for local script file reads via `script_path` in artifact write tools. When set, all script paths must resolve under this directory |
+| `SENTRY_DSN` | string | No | `""` (disabled) | Sentry DSN for error tracking. Sentry activates when this is set. See [[Telemetry]] |
+| `SENTRY_ENVIRONMENT` | string | No | Falls back to `SERVICENOW_ENV` | Sentry environment label for grouping errors |
+
+---
+
+## Validation Rules
+
+The server validates configuration at startup. Invalid values cause the server to exit with a descriptive error message.
+
+### `SERVICENOW_INSTANCE_URL`
+
+- Must start with `https://` - HTTP connections are not supported
+- Trailing slash is stripped automatically (`https://dev12345.service-now.com/` becomes `https://dev12345.service-now.com`)
+
+### `MAX_ROW_LIMIT`
+
+- Must be an integer between 1 and 10000 (inclusive)
+- Values outside this range cause a startup validation error
+- This sets the upper bound for all query operations - user-supplied `limit` parameters are capped at this value
+
+### `MCP_TOOL_PACKAGE`
+
+- Must be either a valid preset package name or a comma-separated list of valid tool group names
+- Invalid package names or group names cause a startup validation error
+- See [[Tool-Packages]] for available presets and group names
+
+---
+
+## Computed Properties
+
+These are derived from the configured environment variables and used internally by the server.
+
+### `is_production`
+
+Returns `True` when `SERVICENOW_ENV` is exactly `"prod"` or `"production"` (case-insensitive comparison). This property controls write gating - when `True`, all write operations return an error envelope.
+
+### `large_table_names`
+
+Parsed from `LARGE_TABLE_NAMES_CSV` into a frozen set of table names. Tables in this set require date-bounded query filters to prevent unbounded queries against high-volume system tables.
+
+---
+
+## File Loading
+
+Settings are loaded from environment files in the working directory:
+
+1. `.env` - Base configuration
+2. `.env.local` - Local overrides (takes precedence over `.env`)
+
+**Loading behavior:**
+
+- `.env.local` values override `.env` values for the same variable
+- Extra or unrecognized variables are silently ignored (no startup errors)
+- Actual environment variables (set in the shell or MCP client config) take precedence over both files
+- The `.env.example` file in the repository root provides a documented template:
+
+```bash
+cp .env.example .env.local
+# Edit .env.local with your values
+```
+
+> **Important:** Never commit `.env.local` or files containing credentials to version control. The `.gitignore` already excludes these files.
+
+---
+
+## Production Mode
+
+When `is_production` evaluates to `True` (i.e., `SERVICENOW_ENV` is `"prod"` or `"production"`), the following restrictions apply:
+
+- **All write operations are blocked** - record create, update, delete, artifact create, artifact update, attachment upload, and attachment delete all return an error envelope
+- **Read operations work normally** - queries, schema introspection, debug traces, investigations, and documentation generation are unaffected
+- **There is no override mechanism** - production mode cannot be bypassed with additional configuration. If you need write access, use a sub-production instance (dev, test, staging, etc.)
+
+This is a deliberate safety guardrail. The server is designed for platform introspection and debugging - it should not be the primary mechanism for modifying production data. See [[Safety-and-Policy]] for additional security details.
+
+---
+
+## Sentry Configuration
+
+Error tracking via [Sentry](https://sentry.io/) is available for monitoring the MCP server in production environments. Since MCP servers run as child processes via stdio, the user never sees stderr output - Sentry provides visibility into errors that would otherwise go unnoticed.
+
+**Activation requires:**
+
+1. The `sentry-sdk` package is installed (it is a core dependency and always available)
+2. `SENTRY_DSN` is set to a non-empty value
+
+When both conditions are met, Sentry captures exceptions from tool execution, HTTP client errors, and configuration issues.
+
+| Variable | Default | Description |
+|---|---|---|
+| `SENTRY_DSN` | `""` | Sentry DSN - the presence of this value is the activation gate |
+| `SENTRY_ENVIRONMENT` | Falls back to `SERVICENOW_ENV` | Environment label for Sentry event grouping |
+
+See [[Telemetry]] for full details on error tracking integration points and what data is captured.
+
+---
+
+## Example Configuration
+
+A minimal `.env.local` for a development instance:
+
+```bash
+SERVICENOW_INSTANCE_URL=https://dev12345.service-now.com
+SERVICENOW_USERNAME=admin
+SERVICENOW_PASSWORD=my-dev-password
+```
+
+A more complete configuration:
+
+```bash
+# Connection
+SERVICENOW_INSTANCE_URL=https://dev12345.service-now.com
+SERVICENOW_USERNAME=admin
+SERVICENOW_PASSWORD=my-dev-password
+
+# Server behavior
+MCP_TOOL_PACKAGE=developer
+SERVICENOW_ENV=dev
+MAX_ROW_LIMIT=200
+
+# Error tracking
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+SENTRY_ENVIRONMENT=development
+```
+
+---
+
+## Next Steps
+
+- [[Getting-Started]] - Installation and MCP client configuration
+- [[Tool-Packages]] - Choose the right tool package for your workflow
+- [[Safety-and-Policy]] - Security guardrails and write gating details
+- [[Telemetry]] - Sentry integration and error tracking

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,0 +1,316 @@
+# Development
+
+Comprehensive development guide for contributing to `servicenow-devtools-mcp`.
+
+See also: [[Architecture]] for technical internals, [[Telemetry]] for observability.
+
+## Getting Started
+
+### Prerequisites
+
+- **Python 3.12+** (tested on 3.12, 3.13, 3.14)
+- **uv** - Fast Python package manager (not pip/poetry)
+- A ServiceNow instance with admin or developer credentials
+
+### Setup
+
+```bash
+git clone https://github.com/Xerrion/servicenow-devtools-mcp.git
+cd servicenow-devtools-mcp
+uv sync --group dev
+cp .env.example .env.local  # Fill in ServiceNow credentials
+```
+
+The `.env.local` file needs at minimum:
+
+```bash
+SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
+SERVICENOW_USERNAME=admin
+SERVICENOW_PASSWORD=your-password
+```
+
+No build step is required for development. The server runs directly from source via `uv run servicenow-devtools-mcp`.
+
+## Development Commands
+
+| Command | Purpose |
+|---|---|
+| `uv run ruff check .` | Lint (all rules) |
+| `uv run ruff check --fix .` | Auto-fix lint issues |
+| `uv run ruff format .` | Format code |
+| `uv run ruff format --check .` | Verify formatting without changes |
+| `uv run mypy src/` | Type checking |
+| `uv run pytest` | Run all unit tests (integration excluded) |
+| `uv run pytest tests/test_client.py` | Run a single test file |
+| `uv run pytest tests/test_client.py::TestClass::test_method` | Run a single test |
+| `uv run pytest -k "keyword"` | Run tests matching a keyword |
+| `uv run pytest -m integration` | Run integration tests (requires `.env.local`) |
+| `uv run pytest --no-cov` | Skip coverage collection for speed |
+| `uv build` | Build distribution wheel |
+
+## Code Style
+
+### Formatter
+
+- **Ruff** is the sole formatter and linter
+- Line length: **120 characters**
+- Quote style: **double quotes**
+- Target: **Python 3.12**
+- Indent style: **spaces**
+
+### Lint Rules
+
+The project enables an extensive set of ruff lint rules:
+
+| Rule Set | Category |
+|---|---|
+| E | pycodestyle errors |
+| F | pyflakes |
+| W | pycodestyle warnings |
+| I | isort (import sorting) |
+| UP | pyupgrade |
+| B | flake8-bugbear |
+| SIM | flake8-simplify |
+| RUF | ruff-specific rules |
+| C4 | flake8-comprehensions |
+| DTZ | flake8-datetimez |
+| T20 | flake8-print (no print statements in production code) |
+| PTH | flake8-use-pathlib |
+| TC | flake8-type-checking |
+| RET | flake8-return |
+| PLW | pylint warnings |
+| PT | flake8-pytest-style |
+| A | flake8-builtins |
+| COM | flake8-commas |
+| PIE | flake8-pie |
+| ISC | flake8-implicit-str-concat |
+| G | flake8-logging-format |
+| INP | flake8-no-pep420 |
+| TID | flake8-tidy-imports |
+| ERA | eradicate (commented-out code) |
+
+Notable ignored rules:
+
+- **E501** - Line too long (the formatter handles wrapping at 120 chars)
+- **COM812** - Missing trailing comma (conflicts with formatter)
+- **ISC001** - Implicit string concatenation (conflicts with formatter)
+- **TC001/TC002/TC003** - Type checking imports (would break runtime type resolution)
+- **RET504/RET505** - Return-related simplifications (reduces debuggability)
+
+### Import Order
+
+Enforced by ruff/isort:
+
+1. Standard library (`import logging`, `import json`)
+2. Third-party packages (`import httpx`, `from pydantic import ...`)
+3. Local imports (`from servicenow_mcp.client import ServiceNowClient`)
+
+**Absolute imports only** - relative imports are not used.
+
+## Type Annotations
+
+All function signatures must have full type hints - enforced by mypy with `disallow_untyped_defs = true`.
+
+### Rules
+
+- Return types always explicit, including `-> None` for void functions
+- Modern union syntax: `str | None` (not `Optional[str]`)
+- Lowercase generic types (PEP 585): `dict[str, Any]`, `list[str]`, `set[str]`
+- Primary typing import: `from typing import Any`
+- Regex patterns typed as `re.Pattern[str]`
+
+### mypy Configuration
+
+```toml
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = false
+warn_unused_configs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+```
+
+The `servicenow_mcp.server` module has `call-arg` error code disabled due to FastMCP's dynamic tool registration.
+
+## Naming Conventions
+
+| Category | Convention | Examples |
+|---|---|---|
+| Functions/methods/variables | `snake_case` | `check_table_access`, `query_store` |
+| Classes | `PascalCase` | `ServiceNowClient`, `ChoiceRegistry` |
+| Constants | `UPPER_SNAKE_CASE` | `DENIED_TABLES`, `MASK_VALUE`, `PACKAGE_REGISTRY` |
+| Private | Single `_` prefix | `_table_url`, `_http_client`, `_ensure_client` |
+| Logger | Module-level | `logger = logging.getLogger(__name__)` |
+| Test classes | `Test` prefix + feature | `TestServiceNowClientGetRecord` |
+| Test methods | `test_` prefix + descriptive | `test_get_record_success` |
+
+## Testing
+
+### Framework
+
+- **pytest** with **pytest-asyncio** (`asyncio_mode = "auto"` - no manual event loop configuration needed)
+- HTTP mocking: **respx** library with `@respx.mock` decorator on async test methods
+- Coverage: **pytest-cov**, reports to **Codecov**
+- Default addopts: `-m 'not integration' --cov=servicenow_mcp --cov-report=xml --cov-report=term-missing`
+
+### Parsing Tool Output in Tests
+
+All tool output uses TOON format. Always parse with `toon_decode()`:
+
+```python
+from toon_format import decode as toon_decode
+
+raw = await tools["my_tool"](param="value")
+result = toon_decode(raw)
+assert result["status"] == "success"
+assert result["data"]["field"] == "expected"
+```
+
+**Never** use `json.loads()` to parse tool output - it will fail on TOON-formatted strings.
+
+### Standard Test Helper Pattern
+
+```python
+def _register_and_get_tools(settings, auth_provider):
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider)
+    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+```
+
+Domain tools use the same pattern with an extra `choices` parameter:
+
+```python
+def _register_and_get_tools(settings, auth_provider, choices=None):
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider, choices=choices)
+    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+```
+
+### Test Fixtures
+
+Defined in `tests/conftest.py`:
+
+| Fixture | Scope | Description |
+|---|---|---|
+| `_disable_sentry_capture` | autouse | Resets Sentry `_initialized` flag to prevent real captures during tests |
+| `settings` | per-test | Dev environment settings (`SERVICENOW_ENV=dev`) |
+| `prod_settings` | per-test | Production environment settings (`SERVICENOW_ENV=prod`) |
+| `prod_auth_provider` | per-test | `BasicAuthProvider` from production settings |
+
+All fixtures construct `Settings(_env_file=None)` with `patch.dict("os.environ", ...)` to avoid loading real env files.
+
+### Integration Tests
+
+- Located in `tests/integration/`
+- Marked with `@pytest.mark.integration`
+- Excluded from default test runs (via `-m 'not integration'` addopts)
+- Require `.env.local` with real ServiceNow credentials
+- Run with: `uv run pytest -m integration`
+
+## CI Pipeline
+
+The CI workflow (`.github/workflows/ci.yml`) runs on every push to `main` and every pull request targeting `main`.
+
+### Concurrency
+
+Uses GitHub's concurrency groups with `cancel-in-progress: true` - new pushes cancel in-flight runs for the same branch.
+
+### Jobs
+
+Three parallel jobs run on `ubuntu-latest`:
+
+**1. Lint**
+- Installs dependencies with `uv sync --group dev`
+- Runs `uv run ruff check .` (lint rules)
+- Runs `uv run ruff format --check .` (formatting verification)
+
+**2. Type Check**
+- Installs dependencies with `uv sync --group dev`
+- Runs `uv run mypy src/`
+
+**3. Test** (matrix: Python 3.12, 3.13, 3.14)
+- Installs the target Python version via `uv python install`
+- Installs dependencies with `uv sync --group dev --python ${{ matrix.python-version }}`
+- Runs `uv run --python ${{ matrix.python-version }} pytest`
+- Uploads coverage to Codecov on **Python 3.12 only**
+
+All three jobs must pass before a PR can be merged.
+
+## Release Process
+
+Automated via **release-please** (`.github/workflows/release-please.yml`).
+
+### How It Works
+
+1. **Conventional commits** on `main` trigger release-please to create/update a release PR with a generated changelog
+2. **Merging the release PR** creates a GitHub Release with the new tag and version
+3. The **publish job** runs only when a release is created:
+   - Checks out the code
+   - Builds the package with `uv build`
+   - Publishes to PyPI with `uv publish --token ${{ secrets.PYPI_TOKEN }}`
+
+### Required Secrets
+
+| Secret | Purpose |
+|---|---|
+| `RELEASE_PLEASE_TOKEN` | GitHub token for creating release PRs |
+| `PYPI_TOKEN` | PyPI API token for package publishing |
+| `CODECOV_TOKEN` | Codecov upload token |
+
+### Commit Convention
+
+Release-please uses conventional commits to determine version bumps:
+
+| Prefix | Version Bump | Example |
+|---|---|---|
+| `feat:` | Minor | `feat: add attachment upload tool` |
+| `fix:` | Patch | `fix: handle empty query results` |
+| `docs:` | None | `docs: update README` |
+| `chore:` | None | `chore: update dependencies` |
+| `refactor:` | None | `refactor: extract query builder` |
+| `test:` | None | `test: add client error handling tests` |
+| `feat!:` or `BREAKING CHANGE:` | Major | `feat!: remove deprecated API` |
+
+## Git Workflow
+
+- **Never** work directly on `main` - always use feature branches
+- **Conventional commits** required (enforced by release-please)
+- **Small, atomic commits** - each commit should do one thing
+- **Use `gh` CLI** for GitHub operations (PRs, issues, etc.)
+- **Never** commit code that breaks existing tests
+
+## Project Dependencies
+
+### Core Dependencies
+
+| Package | Purpose |
+|---|---|
+| `mcp` (>=1.0.0) | MCP server framework |
+| `httpx` (>=0.27.0) | Async HTTP client |
+| `pydantic` (>=2.0.0) | Data validation |
+| `pydantic-settings` (>=2.0.0) | Environment-based configuration |
+| `python-dotenv` (>=1.0.0) | `.env` file loading |
+| `uvicorn` (>=0.30.0) | ASGI server (SSE transport) |
+| `starlette` (>=0.38.0) | ASGI framework (SSE transport) |
+| `toon-format` | LLM-optimized serialization (git dependency) |
+| `sentry-sdk` (>=2.55.0) | Error tracking |
+
+**Note:** `toon-format` is an external git dependency sourced from `https://github.com/toon-format/toon-python.git`. It is not available on PyPI.
+
+### Dev Dependencies
+
+| Package | Purpose |
+|---|---|
+| `pytest` (>=8.0.0) | Test framework |
+| `pytest-asyncio` (>=0.24.0) | Async test support |
+| `respx` (>=0.21.0) | httpx mocking |
+| `ruff` (>=0.9.0) | Linter and formatter |
+| `mypy` (>=1.14.0) | Type checker |
+| `pytest-cov` (>=6.0.0) | Coverage reporting |
+| `basedpyright` (>=1.29.0) | Alternative type checker |
+
+### Build System
+
+- **Build backend**: hatchling
+- **Wheel packages**: `src/servicenow_mcp` (src-layout)
+- **Entry point**: `servicenow-devtools-mcp = servicenow_mcp.server:main`

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,193 @@
+# Getting Started
+
+This guide walks you through installing and configuring the ServiceNow DevTools MCP server for use with your AI client.
+
+---
+
+## Prerequisites
+
+- **Python 3.12 or later** - The server requires Python 3.12+ (3.12, 3.13, and 3.14 are supported)
+- **A ServiceNow instance** - Developer, test, or production (note: write operations are blocked on production instances)
+- **ServiceNow credentials** - A user account with appropriate roles. Admin is recommended for full access to all tools
+- **An MCP-compatible AI client** - [OpenCode](https://opencode.ai), [Claude Desktop](https://claude.ai/download), [VS Code Copilot](https://code.visualstudio.com/), [Cursor](https://cursor.sh/), or any client supporting the [Model Context Protocol](https://modelcontextprotocol.io/)
+
+---
+
+## Installation
+
+### Recommended: Run with uvx (no install required)
+
+```bash
+uvx servicenow-devtools-mcp
+```
+
+This downloads and runs the server in an isolated environment. No permanent installation needed.
+
+### Alternative: Install with pip or uv
+
+```bash
+pip install servicenow-devtools-mcp
+```
+
+```bash
+uv add servicenow-devtools-mcp
+```
+
+> **Note:** The server communicates via stdio transport - it is launched by your MCP client as a subprocess, not run as a standalone service. You do not need to start it manually.
+
+---
+
+## Environment Variables
+
+Three environment variables are required. These are passed to the server by your MCP client configuration.
+
+| Variable | Required | Description |
+|---|---|---|
+| `SERVICENOW_INSTANCE_URL` | Yes | Full instance URL, must start with `https://` |
+| `SERVICENOW_USERNAME` | Yes | ServiceNow username for Basic Auth |
+| `SERVICENOW_PASSWORD` | Yes | ServiceNow password |
+| `MCP_TOOL_PACKAGE` | No | Tool package to load (default: `"full"`). See [[Tool-Packages]] |
+| `SERVICENOW_ENV` | No | Environment label (default: `"dev"`). Write ops blocked on `"prod"` / `"production"` |
+
+The server also loads variables from `.env` and `.env.local` files in the working directory (`.env.local` takes precedence).
+
+See [[Configuration]] for the full reference of all environment variables.
+
+---
+
+## MCP Client Configuration
+
+Configure your MCP client to launch the server with the required environment variables. Below are configuration examples for popular clients.
+
+### OpenCode
+
+File: `~/.config/opencode/opencode.json`
+
+```json
+{
+  "mcp": {
+    "servicenow": {
+      "type": "local",
+      "command": ["uvx", "servicenow-devtools-mcp"],
+      "environment": {
+        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
+        "SERVICENOW_USERNAME": "admin",
+        "SERVICENOW_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+File: `claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "servicenow": {
+      "command": "uvx",
+      "args": ["servicenow-devtools-mcp"],
+      "env": {
+        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
+        "SERVICENOW_USERNAME": "admin",
+        "SERVICENOW_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+### VS Code / Cursor
+
+File: `.vscode/mcp.json`
+
+```json
+{
+  "servers": {
+    "servicenow": {
+      "command": "uvx",
+      "args": ["servicenow-devtools-mcp"],
+      "env": {
+        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
+        "SERVICENOW_USERNAME": "admin",
+        "SERVICENOW_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+### Generic stdio
+
+For any client that supports stdio transport, launch the server with inline environment variables:
+
+```bash
+SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com \
+SERVICENOW_USERNAME=admin \
+SERVICENOW_PASSWORD=your-password \
+uvx servicenow-devtools-mcp
+```
+
+---
+
+## First Steps
+
+Once configured, try these example prompts with your AI agent:
+
+- **"Describe the incident table schema"** - Explores table structure, field types, and metadata
+- **"List open incidents"** - Queries records using domain tools with choice label resolution
+- **"Show me what business rules run on the incident table"** - Inspects platform artifacts
+- **"Trace the debug log for incident INC0010001"** - Builds an event timeline from system logs
+- **"What update sets were created this week?"** - Change intelligence across your instance
+- **"Run a table health investigation on cmdb_ci"** - Automated analysis with findings and recommendations
+
+---
+
+## AI Agent Setup
+
+For copy-paste installation instructions optimized for AI agents, see [INSTALL.md](https://github.com/Xerrion/servicenow-devtools-mcp/blob/main/INSTALL.md) in the repository root. This file is designed to be fed directly to an AI agent for self-configuration.
+
+---
+
+## Troubleshooting
+
+### Connection refused or timeout
+
+- Verify `SERVICENOW_INSTANCE_URL` starts with `https://` (HTTP is not supported)
+- Check that your ServiceNow instance is reachable from your network
+- Trailing slashes are stripped automatically - `https://dev12345.service-now.com/` works fine
+
+### Authentication errors
+
+- Confirm `SERVICENOW_USERNAME` and `SERVICENOW_PASSWORD` are correct
+- The user account needs appropriate ServiceNow roles. Admin is recommended for full tool access
+- Check if your instance requires MFA or SSO - Basic Auth must be enabled for the user
+
+### No tools appearing in your AI client
+
+- Verify `MCP_TOOL_PACKAGE` is set to a valid package name (default is `"full"`)
+- Use the `list_tool_packages` tool (always available) to see what packages and groups exist
+- Check your MCP client logs for startup errors
+
+### Write operations blocked
+
+- Write operations are blocked when `SERVICENOW_ENV` is set to `"prod"` or `"production"`
+- This is a safety guardrail with no override - use a sub-production instance for write operations
+- Read operations work normally regardless of environment setting
+
+### Server not starting
+
+- Ensure Python 3.12 or later is installed: `python --version`
+- Try running directly: `uvx servicenow-devtools-mcp` to see error output
+- Check that `uvx` is installed: `uv --version` (install from [astral.sh/uv](https://astral.sh/uv))
+
+---
+
+## Next Steps
+
+- [[Configuration]] - Full environment variable reference and validation rules
+- [[Tool-Reference]] - Complete list of available tools with descriptions
+- [[Tool-Packages]] - Choose the right tool package for your use case
+- [[Safety-and-Policy]] - Understand the security guardrails

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,72 @@
+# ServiceNow DevTools MCP Server
+
+A developer and debug-focused MCP server for ServiceNow - platform introspection, change intelligence, debugging, investigations, and documentation generation.
+
+---
+
+## What is this?
+
+**servicenow-devtools-mcp** is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI agents direct access to your ServiceNow instance. It exposes a comprehensive suite of tools covering schema exploration, record management, debugging, change intelligence, ITSM processes, and more - all through a standardized MCP interface.
+
+The server runs locally via stdio transport and is launched by your MCP-compatible AI client (OpenCode, Claude Desktop, VS Code Copilot, Cursor, etc.). Your AI agent gains the ability to query tables, inspect records, trace debug logs, generate documentation, manage incidents, and much more - without you needing to navigate the ServiceNow UI.
+
+---
+
+## Key Capabilities
+
+- **Schema and table introspection** - Describe table schemas, query records, compute aggregates, and build structured queries
+- **Record CRUD** - Create, read, update, and delete records with a preview-then-apply confirmation pattern
+- **Attachment operations** - List, download, upload, and delete attachments with base64 content transfer
+- **Change intelligence** - Inspect update sets, diff artifact versions, view audit trails, and generate release notes
+- **Debug and trace** - Build event timelines, trace field mutations, inspect flow executions, check integration health
+- **Investigations** - Run automated analyses: stale automations, deprecated APIs, table health, ACL conflicts, error patterns, slow transactions
+- **Documentation generation** - Generate automation maps, artifact summaries, test scenarios, and code review notes
+- **Workflow and Flow Designer analysis** - Map workflow structures, inspect executions, analyze migration readiness
+- **ITSM domain tools** - Full lifecycle management for Incidents, Changes, Problems, Requests, Knowledge, CMDB, and Service Catalog
+- **Artifact write** - Create and update platform artifacts (business rules, script includes, client scripts, etc.) with optional local script file injection
+
+---
+
+## Quick Navigation
+
+| Page | Description |
+|---|---|
+| [[Getting-Started]] | Installation, MCP client configuration, first steps |
+| [[Configuration]] | Environment variables, settings reference |
+| [[Tool-Reference]] | Complete tool reference with descriptions |
+| [[Tool-Packages]] | Preset and custom tool packages |
+| [[Safety-and-Policy]] | Security guardrails, table deny list, write gating |
+| [[Development]] | Contributing, testing, CI pipeline |
+| [[Architecture]] | Server internals, patterns, data flow |
+| [[Telemetry]] | Sentry error tracking setup |
+
+---
+
+## Quick Start
+
+**1. Run the server**
+
+```bash
+uvx servicenow-devtools-mcp
+```
+
+**2. Set environment variables**
+
+```bash
+SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
+SERVICENOW_USERNAME=admin
+SERVICENOW_PASSWORD=your-password
+```
+
+**3. Configure your MCP client** to launch the server with those environment variables.
+
+See [[Getting-Started]] for full setup instructions with configuration examples for OpenCode, Claude Desktop, VS Code, Cursor, and more.
+
+---
+
+## Links
+
+- [PyPI](https://pypi.org/project/servicenow-devtools-mcp/)
+- [GitHub Repository](https://github.com/Xerrion/servicenow-devtools-mcp)
+- [Issues](https://github.com/Xerrion/servicenow-devtools-mcp/issues)
+- [License (MIT)](https://github.com/Xerrion/servicenow-devtools-mcp/blob/main/LICENSE)

--- a/docs/wiki/Safety-and-Policy.md
+++ b/docs/wiki/Safety-and-Policy.md
@@ -1,0 +1,259 @@
+# Safety and Policy
+
+The server enforces multiple layers of safety guardrails to prevent accidental data exposure, unbounded queries, and unintended modifications. These policies are applied automatically - tool functions do not need to implement them manually.
+
+For the complete list of tools affected by these policies, see [[Tool-Reference]]. For environment variable configuration, see [[Configuration]].
+
+---
+
+## Overview
+
+| Layer | Purpose |
+|---|---|
+| Table access control | Blocks access to security-sensitive tables |
+| Sensitive field masking | Masks password, token, and credential fields in responses |
+| Query safety | Enforces row limits and date-bounded filters on large tables |
+| Write gating | Blocks all write operations in production environments |
+| Input validation | Validates table names, field names, and sys_id formats |
+| Error handling | Catches all exceptions and returns serialized error envelopes |
+| Attachment safety | Enforces size limits on attachment transfers |
+
+---
+
+## Table Access Control
+
+Eight security-sensitive tables are permanently blocked from all operations (read and write). Any attempt to query, describe, or write to these tables raises a `PolicyError`.
+
+### Denied Tables
+
+| Table | Reason |
+|---|---|
+| `sys_user_has_password` | Password hashes |
+| `oauth_credential` | OAuth credentials |
+| `oauth_entity` | OAuth entity configuration |
+| `sys_certificate` | SSL/TLS certificates |
+| `sys_ssh_key` | SSH private keys |
+| `sys_credentials` | Stored credentials |
+| `discovery_credentials` | Discovery credentials |
+| `sys_user_token` | User authentication tokens |
+
+These tables are blocked regardless of environment, tool package, or user role. There is no override mechanism.
+
+### How It Works
+
+The `check_table_access()` function is called before any ServiceNow API request. It compares the requested table name (lowercased) against the deny list and raises `PolicyError` if matched. The `@tool_handler` decorator catches this exception and returns a serialized error envelope - the tool never reaches the ServiceNow API.
+
+---
+
+## Sensitive Field Masking
+
+Fields matching sensitive name patterns are automatically masked in all tool responses. The original values are never returned to the AI agent.
+
+### Masked Patterns
+
+Six regex patterns (case-insensitive) trigger masking:
+
+| Pattern | Matches |
+|---|---|
+| `password` | Any field containing "password" (e.g., `user_password`, `password_hash`) |
+| `token` | Any field containing "token" (e.g., `access_token`, `token_value`) |
+| `secret` | Any field containing "secret" (e.g., `client_secret`, `secret_key`) |
+| `credential` | Any field containing "credential" (e.g., `credential_id`, `credentials`) |
+| `api_key` | Any field containing "api_key" (e.g., `rest_api_key`) |
+| `private_key` | Any field containing "private_key" (e.g., `ssh_private_key`) |
+
+Masked fields display as `***MASKED***` in the response.
+
+### Audit Entry Masking
+
+Audit records (`sys_audit`) receive special treatment. In audit entries, the actual field name is stored in a metadata key (`fieldname` or `field`), while values are in `oldvalue`/`newvalue` (or `old_value`/`new_value`). The `mask_audit_entry()` function inspects the field name value and masks the corresponding value fields when it matches a sensitive pattern.
+
+---
+
+## Query Safety
+
+Query safety prevents unbounded queries that could overload the ServiceNow instance or return excessive data.
+
+### Row Limits
+
+- User-supplied `limit` parameters are capped at `MAX_ROW_LIMIT` (default: 100, configurable up to 10000)
+- When no limit is specified, `MAX_ROW_LIMIT` is used as the default
+- The limit is floored at 1 to prevent zero or negative values
+- Internal metadata queries use a separate `INTERNAL_QUERY_LIMIT` of 1000
+
+### Large Table Protection
+
+Tables listed in `LARGE_TABLE_NAMES_CSV` require date-bounded filters in their queries. The default large tables are:
+
+- `syslog`
+- `sys_audit`
+- `sys_log_transaction`
+- `sys_email_log`
+
+When querying a large table, the query must contain a recognized date field with a comparison operator. Recognized date fields are:
+
+- `sys_created_on`
+- `sys_updated_on`
+- `opened_at`
+- `closed_at`
+- `sys_recorded_at`
+
+Accepted comparison operators include `>`, `>=`, `<`, `<=`, `BETWEEN`, and `javascript:gs.*Ago` functions (e.g., `gs.hoursAgo`, `gs.daysAgo`).
+
+If the query does not contain a date-bounded filter, a `QuerySafetyError` is raised with a descriptive message explaining the requirement.
+
+### Configuring Large Tables
+
+Override the default large table list via `LARGE_TABLE_NAMES_CSV`:
+
+```bash
+LARGE_TABLE_NAMES_CSV="syslog,sys_audit,sys_log_transaction,sys_email_log,my_custom_log_table"
+```
+
+---
+
+## Write Gating
+
+All write operations are blocked when the server is running in production mode. This is a deliberate safety guardrail with no override mechanism.
+
+### What Triggers Production Mode
+
+The `is_production` property returns `True` when `SERVICENOW_ENV` is set to `"prod"` or `"production"` (case-insensitive). Write operations are also blocked for any table on the denied tables list, regardless of environment.
+
+### What Gets Blocked
+
+When write gating is active, the following operations return an error envelope instead of executing:
+
+- **Record operations** - `record_create`, `record_update`, `record_delete`, and their preview variants
+- **Artifact operations** - `artifact_create`, `artifact_update`
+- **Attachment operations** - `attachment_upload`, `attachment_delete`
+- **Domain write operations** - `incident_create`, `incident_update`, `incident_resolve`, `change_create`, `change_update`, `problem_create`, `problem_update`, `problem_root_cause`, `request_item_update`, `knowledge_create`, `knowledge_update`, `sc_order_now`, `sc_add_to_cart`, `sc_cart_submit`, `sc_cart_checkout`
+
+### What Still Works
+
+All read operations work normally in production mode:
+
+- Table schema description and querying
+- Record fetching and reference discovery
+- Attachment listing and downloading
+- Change intelligence (update set inspection, diffing, audit trails)
+- Debug and trace operations
+- Investigations and documentation generation
+- Workflow and flow analysis
+- Listing and fetching domain records (incidents, changes, etc.)
+
+### How It Works
+
+Write tool functions call `write_gate(table, settings, correlation_id)` before performing any mutation. If writes are blocked, the function returns a pre-formatted error envelope immediately - the ServiceNow API is never contacted. The `write_blocked_reason()` function checks two conditions:
+
+1. Is the table on the denied tables list?
+2. Is the environment set to production?
+
+If either condition is true, a human-readable reason string is returned.
+
+---
+
+## Input Validation
+
+All table names, field names, and sys_id values are validated before use.
+
+### Identifier Validation
+
+Table and field names must match the pattern `^[a-z0-9_]+(\.[a-z0-9_]+)*$` - lowercase alphanumeric characters and underscores, with optional dot-walked segments (e.g., `change_request.number`, `child.sys_id`).
+
+Invalid identifiers raise a `ValueError` with a descriptive message. This prevents injection of malicious characters into ServiceNow API URLs and query parameters.
+
+### sys_id Validation
+
+sys_id values must be exactly 32 lowercase hexadecimal characters. Invalid sys_id values raise a `ValueError`.
+
+### Artifact Payload Validation
+
+The `artifact_create` and `artifact_update` tools validate their JSON payloads:
+
+- The payload must be a dictionary (not a list or primitive)
+- All dictionary keys are validated with `validate_identifier()` before submission
+- Artifact types are validated against the known `WRITABLE_ARTIFACT_TABLES` mapping
+
+### Script Path Security
+
+The `artifact_create` and `artifact_update` tools accept an optional `script_path` parameter for local script file injection:
+
+- The path is resolved via `Path.resolve(strict=True)` to prevent symlink and traversal attacks
+- When `SCRIPT_ALLOWED_ROOT` is configured, the resolved path must be under that root directory
+- Files are limited to 1 MB (`MAX_SCRIPT_FILE_BYTES = 1,048,576`)
+- Files are read as UTF-8
+
+---
+
+## Error Handling
+
+Tool functions never raise exceptions to the MCP transport. All errors are caught and returned as serialized error envelopes.
+
+### The Error Boundary
+
+The `@tool_handler` decorator wraps every tool invocation in `safe_tool_call()`, which catches all exceptions:
+
+- `ForbiddenError` (HTTP 403 / ACL denials) - returned as `"Access denied by ServiceNow ACL: ..."` error envelope
+- All other exceptions - returned as error envelope with the exception message
+
+Both paths capture the exception to Sentry (when configured) for visibility.
+
+### Exception Hierarchy
+
+| Exception | HTTP Status | Trigger |
+|---|---|---|
+| `AuthError` | 401 | Invalid credentials |
+| `ForbiddenError` | 403 | Insufficient permissions (ServiceNow ACL) |
+| `NotFoundError` | 404 | Record or resource not found |
+| `ServerError` | 5xx | ServiceNow server error |
+| `PolicyError` | 403 | Denied table access |
+| `QuerySafetyError` | 403 | Unsafe query (missing date filter on large table) |
+| `ServiceNowMCPError` | 400+ | Other HTTP client errors |
+
+### Error Envelope Format
+
+Error responses use the same TOON-serialized envelope as success responses:
+
+```
+status: "error"
+correlation_id: "<uuid>"
+data: null
+error:
+  message: "<descriptive error message>"
+```
+
+---
+
+## Attachment Safety
+
+Attachment transfers are limited to prevent excessive memory usage and transfer sizes.
+
+- **Maximum size:** 10 MB (`10 * 1024 * 1024` bytes)
+- **Upload format:** `content_base64` - base64-encoded file content
+- **Download format:** `content_base64` - base64-encoded file content returned in the response
+- **Write gating applies:** `attachment_upload` and `attachment_delete` are blocked in production mode
+
+---
+
+## Summary of Protections
+
+| Protection | Always Active | Production Only |
+|---|---|---|
+| Denied table list (8 tables) | Yes | - |
+| Sensitive field masking (6 patterns) | Yes | - |
+| Row limit capping | Yes | - |
+| Large table date-bounded filter requirement | Yes | - |
+| Input validation (identifiers, sys_ids) | Yes | - |
+| Error envelope wrapping | Yes | - |
+| Attachment size limit (10 MB) | Yes | - |
+| Write operation blocking | - | Yes |
+
+---
+
+## Next Steps
+
+- [[Configuration]] - Environment variables that control safety behavior (`SERVICENOW_ENV`, `MAX_ROW_LIMIT`, `LARGE_TABLE_NAMES_CSV`, `SCRIPT_ALLOWED_ROOT`)
+- [[Tool-Reference]] - Complete tool reference with write/read classification
+- [[Tool-Packages]] - Read-only packages for safe production exploration
+- [[Architecture]] - Server internals and error handling flow

--- a/docs/wiki/Safety-and-Policy.md
+++ b/docs/wiki/Safety-and-Policy.md
@@ -4,6 +4,8 @@ The server enforces multiple layers of safety guardrails to prevent accidental d
 
 For the complete list of tools affected by these policies, see [[Tool-Reference]]. For environment variable configuration, see [[Configuration]].
 
+> **Important:** While this server employs multiple layers of protection, no security mechanism is perfect. These guardrails significantly reduce risk but do not guarantee complete prevention of unintended actions. Always test in a sub-production environment first, review tool outputs carefully, and follow your organization's security policies.
+
 ---
 
 ## Overview
@@ -257,3 +259,14 @@ Attachment transfers are limited to prevent excessive memory usage and transfer 
 - [[Tool-Reference]] - Complete tool reference with write/read classification
 - [[Tool-Packages]] - Read-only packages for safe production exploration
 - [[Architecture]] - Server internals and error handling flow
+
+---
+
+## Limitations
+
+While the safety guardrails described above cover a wide range of scenarios, users should be aware of the following limitations:
+
+- **Best-effort protection** - Guardrails operate on a best-effort basis and may not catch every possible edge case or misconfiguration.
+- **API coverage gaps** - New ServiceNow APIs, custom table configurations, or non-standard platform customizations may not be covered by existing policy checks.
+- **Environment responsibility** - Users are responsible for validating the server's behavior in their specific ServiceNow environment before relying on it for sensitive operations.
+- **Production write blocking depends on correct configuration** - Write gating only activates when `SERVICENOW_ENV` is set to `"prod"` or `"production"`. If this variable is misconfigured or left at the default (`"dev"`), write operations will be permitted regardless of the actual target environment.

--- a/docs/wiki/Telemetry.md
+++ b/docs/wiki/Telemetry.md
@@ -1,0 +1,186 @@
+# Telemetry
+
+Observability documentation for the `servicenow-devtools-mcp` server. Currently, **Sentry** is the sole observability integration.
+
+See also: [[Architecture]] for server internals, [[Development]] for setup.
+
+## Overview
+
+MCP servers run as child processes of AI agents via stdio transport - the user never sees stdout or stderr. This makes traditional logging insufficient for error visibility. Sentry provides structured error capture, contextual data, and alerting for production deployments.
+
+> **Note:** OpenTelemetry was previously available but has been removed from the project. See [Historical Note](#historical-note) at the end of this page.
+
+## Sentry Integration
+
+The Sentry integration lives in `sentry.py` and follows a graceful-degradation pattern - all public functions are safe to call regardless of whether Sentry is active.
+
+### Activation Requirements
+
+`sentry-sdk` is a **core dependency** (always installed, not an optional extra). However, Sentry only activates when the `SENTRY_DSN` environment variable is set to a non-empty value. There is no separate `SENTRY_ENABLED` flag - the DSN presence is the gate.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SENTRY_DSN` | `""` (disabled) | Sentry Data Source Name - activates error tracking when set |
+| `SENTRY_ENVIRONMENT` | Falls back to `SERVICENOW_ENV` | Environment label shown in Sentry UI |
+
+Both values are defined in the `Settings` class (`config.py`) and loaded from environment variables or `.env`/`.env.local` files.
+
+## Import Guard Pattern
+
+The module uses a two-level import guard to handle environments where `sentry-sdk` might not be installed and SDK versions that may or may not include the MCP integration:
+
+```python
+# Primary guard
+HAS_SENTRY: bool
+try:
+    import sentry_sdk
+    HAS_SENTRY = True
+except ImportError:
+    HAS_SENTRY = False
+
+# Secondary guard for newer SDK versions
+_HAS_MCP_INTEGRATION = False
+if HAS_SENTRY:
+    try:
+        from sentry_sdk.integrations.mcp import MCPIntegration
+        _HAS_MCP_INTEGRATION = True
+    except ImportError:
+        pass
+```
+
+When `HAS_SENTRY` is `False`, all public functions no-op immediately - zero overhead. The secondary guard allows the optional `MCPIntegration` to be used when available in newer SDK versions without breaking on older ones.
+
+## SDK Configuration
+
+When activated, Sentry is initialized with these settings:
+
+```python
+sentry_sdk.init(
+    dsn=dsn,
+    environment=environment,
+    release=_RELEASE,            # e.g. "servicenow-devtools-mcp@0.9.0"
+    send_default_pii=True,
+    integrations=integrations,   # Includes MCPIntegration when available
+    traces_sample_rate=1.0,      # All transactions sampled
+    profiles_sample_rate=None,   # Profiling disabled
+)
+```
+
+The release string is dynamically derived from package metadata using `importlib.metadata.version()`:
+
+```python
+try:
+    _RELEASE = f"servicenow-devtools-mcp@{pkg_version('servicenow-devtools-mcp')}"
+except Exception:
+    _RELEASE = "servicenow-devtools-mcp@unknown"
+```
+
+## Instrumentation Points
+
+Sentry context and exception capture is woven through the codebase at key points:
+
+### `@tool_handler` (decorators.py)
+
+Every tool invocation sets:
+
+- **Tags** (indexed, searchable):
+  - `tool.name` - The tool function name (e.g., `"record_list"`)
+  - `tool.correlation_id` - UUID4 for request tracing
+- **Context** (structured data):
+  - `"tool"` context with `name`, `correlation_id`, and `args` (with `correlation_id` excluded from the args dict)
+
+### `safe_tool_call()` (utils.py)
+
+The error boundary that wraps all tool executions:
+
+- Catches `ForbiddenError` - captures to Sentry, returns ACL denial error envelope
+- Catches generic `Exception` - captures to Sentry, returns generic error envelope
+
+Both paths call `capture_exception(e)` before returning the serialized error response.
+
+### `serialize()` (utils.py)
+
+Captures TOON encoding failures to Sentry before falling back to JSON serialization.
+
+### `_raise_for_status()` (client.py)
+
+Before raising HTTP-related exceptions, sets `"http"` Sentry context with:
+
+- `status_code` - The HTTP status code
+- `method` - The HTTP method (GET, POST, etc.)
+- `url` - The request URL
+
+### `ChoiceRegistry` (choices.py)
+
+Captures persistent `sys_choice` fetch failures when the registry cannot load choice data from the ServiceNow instance.
+
+### Server Bootstrap (server.py)
+
+- Sets `"server"` Sentry context with instance hostname (extracted from URL), environment, `is_production` flag, and tool package name
+- Captures `ImportError` exceptions when tool group modules fail to load
+
+## Public API
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `setup_sentry` | `(settings: Settings) -> None` | Initialize SDK with DSN gating. No-ops on re-call. |
+| `capture_exception` | `(exc: BaseException \| None) -> None` | Capture exception (or current `sys.exc_info()` if `None`) |
+| `set_sentry_tag` | `(key: str, value: str) -> None` | Set indexed tag on current isolation scope |
+| `set_sentry_context` | `(key: str, data: dict[str, Any]) -> None` | Set structured context dict on current isolation scope |
+| `shutdown_sentry` | `() -> None` | Flush pending events (2s timeout) and close client (2s timeout) |
+
+All functions no-op when either `HAS_SENTRY` is `False` or `_initialized` is `False`.
+
+## Lifecycle
+
+### Startup
+
+`setup_sentry(settings)` is called early in `create_mcp_server()`, before tool registration. The function uses a triple gate to prevent double-initialization:
+
+1. **`_initialized` check** - Short-circuits if already called
+2. **`HAS_SENTRY` check** - Short-circuits if `sentry-sdk` is not installed (sets `_initialized = True`)
+3. **DSN check** - Short-circuits if `sentry_dsn` is empty (sets `_initialized = True`)
+
+In all three cases, `_initialized` is set to `True` so future calls no-op immediately.
+
+### Shutdown
+
+`shutdown_sentry()` is called in the `finally` block of `main()`:
+
+```python
+def main() -> None:
+    mcp = create_mcp_server()
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        shutdown_sentry()
+```
+
+The shutdown sequence:
+
+1. Checks `HAS_SENTRY and _initialized`
+2. Gets the active Sentry client
+3. If the client is active: flushes pending events (2s timeout), then closes the client (2s timeout)
+4. Resets `_initialized = False`
+5. Wraps everything in try/except to prevent shutdown errors from propagating
+
+### Testing
+
+Tests use an autouse fixture (`_disable_sentry_capture` in `tests/conftest.py`) that resets `_initialized = False` before and after each test, preventing real Sentry SDK calls during test runs:
+
+```python
+@pytest.fixture(autouse=True)
+def _disable_sentry_capture():
+    import servicenow_mcp.sentry as _sentry_mod
+    _sentry_mod._initialized = False
+    yield
+    _sentry_mod._initialized = False
+```
+
+## Historical Note
+
+OpenTelemetry was previously integrated via a `telemetry.py` module that provided distributed tracing with spans for tool invocations and HTTP requests. It supported OTLP and console exporters, W3C `traceparent` header injection, and trace context in response envelopes.
+
+The OTel integration was **removed in v0.9.0** (commit `b72cee3`, PR [#68](https://github.com/Xerrion/servicenow-devtools-mcp/pull/68)) to resolve SonarCloud issues and simplify the observability stack. The `.env.example` file may still contain stale OTel-related variables (`OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) - these are ignored by the server and have no effect.

--- a/docs/wiki/Tool-Packages.md
+++ b/docs/wiki/Tool-Packages.md
@@ -1,0 +1,212 @@
+# Tool Packages
+
+Tool packages control which tools are loaded when the server starts. Configure the active package via the `MCP_TOOL_PACKAGE` environment variable. The default is `"full"`.
+
+For a complete reference of every tool in each group, see [[Tool-Reference]]. For security guardrails that apply across all packages, see [[Safety-and-Policy]].
+
+---
+
+## Overview
+
+The server organizes tools into 21 **tool groups**. A **tool package** is a named collection of groups that are loaded together. There are 14 preset packages for common workflows, and you can also define custom packages by listing group names directly.
+
+The `list_tool_packages` tool is always available - even with `MCP_TOOL_PACKAGE="none"` - and returns all available packages and their contents at runtime.
+
+---
+
+## Preset Packages
+
+| Package | Groups | Description |
+|---|---|---|
+| `full` (default) | 20 | All standard tool groups (excludes `testing`) |
+| `itil` | 16 | ITIL process tools - incidents, changes, problems, requests, plus platform support tools |
+| `developer` | 13 | Development-focused - schema, records, attachments, debugging, investigations, workflows |
+| `readonly` | 10 | Read-only operations only - no create, update, or delete tools |
+| `analyst` | 8 | Analysis and reporting - schema, records, investigations, documentation, workflows |
+| `incident_management` | 9 | Incident lifecycle with supporting platform tools |
+| `problem_management` | 9 | Problem lifecycle with supporting platform tools |
+| `change_management` | 8 | Change request management with change intelligence |
+| `request_management` | 8 | Request and RITM management with workflow tools |
+| `cmdb` | 6 | CMDB management with relationships |
+| `knowledge_management` | 6 | Knowledge base tools |
+| `service_catalog` | 6 | Service catalog browsing, ordering, and cart management |
+| `core_readonly` | 4 | Minimal read-only core - table, record, attachment, metadata only |
+| `none` | 0 | No tools loaded - only `list_tool_packages` is available (useful for testing) |
+
+---
+
+## Package Contents
+
+### `full` (20 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `metadata`, `artifact_write`, `changes`, `debug`, `investigations`, `documentation`, `workflow`, `flow_designer`, `domain_incident`, `domain_change`, `domain_cmdb`, `domain_problem`, `domain_request`, `domain_knowledge`, `domain_service_catalog`
+
+> **Note:** The `testing` group is excluded from `full`. To include it, use a custom package (see below).
+
+### `itil` (16 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `metadata`, `artifact_write`, `changes`, `debug`, `documentation`, `workflow`, `flow_designer`, `domain_incident`, `domain_change`, `domain_problem`, `domain_request`
+
+### `developer` (13 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `metadata`, `artifact_write`, `changes`, `debug`, `investigations`, `documentation`, `workflow`, `flow_designer`
+
+### `readonly` (10 groups)
+
+`table`, `record`, `attachment`, `metadata`, `changes`, `debug`, `investigations`, `documentation`, `workflow`, `flow_designer`
+
+### `analyst` (8 groups)
+
+`table`, `record`, `attachment`, `metadata`, `investigations`, `documentation`, `workflow`, `flow_designer`
+
+### `incident_management` (9 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_incident`, `debug`, `workflow`, `flow_designer`
+
+### `problem_management` (9 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_problem`, `debug`, `workflow`, `flow_designer`
+
+### `change_management` (8 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_change`, `changes`, `flow_designer`
+
+### `request_management` (8 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_request`, `workflow`, `flow_designer`
+
+### `cmdb` (6 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_cmdb`
+
+### `knowledge_management` (6 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_knowledge`
+
+### `service_catalog` (6 groups)
+
+`table`, `record`, `attachment`, `record_write`, `attachment_write`, `domain_service_catalog`
+
+### `core_readonly` (4 groups)
+
+`table`, `record`, `attachment`, `metadata`
+
+### `none` (0 groups)
+
+No tool groups loaded. Only the always-on `list_tool_packages` tool is available.
+
+---
+
+## Tool Group Reference
+
+All 21 tool groups that can be included in packages:
+
+| Group | Type | Description |
+|---|---|---|
+| `table` | Standard | Schema description, record queries, aggregation, query building |
+| `record` | Standard | Record fetch, inbound/outbound reference discovery |
+| `attachment` | Standard | Attachment listing, metadata, content download |
+| `attachment_write` | Standard | Attachment upload and delete |
+| `record_write` | Standard | Record create, update, delete with preview/apply pattern |
+| `metadata` | Standard | Platform artifact listing, inspection, cross-references |
+| `artifact_write` | Standard | Platform artifact create and update with script file support |
+| `changes` | Standard | Update set inspection, artifact diffing, audit trails, release notes |
+| `debug` | Standard | Event timelines, flow execution, email tracing, integration health |
+| `investigations` | Standard | Automated analysis modules (7 investigation types) |
+| `documentation` | Standard | Automation maps, artifact summaries, test scenarios, review notes |
+| `workflow` | Standard | Legacy workflow context, structure, status, and activity inspection |
+| `flow_designer` | Standard | Flow Designer flows, executions, snapshots, migration analysis |
+| `testing` | Standard | ATF test and suite listing, execution, and health analysis |
+| `domain_incident` | Domain | Incident lifecycle with choice label resolution |
+| `domain_change` | Domain | Change request lifecycle with choice label resolution |
+| `domain_cmdb` | Domain | CMDB browsing, relationships, classes, health |
+| `domain_problem` | Domain | Problem lifecycle with choice label resolution |
+| `domain_request` | Domain | Request and RITM management with choice label resolution |
+| `domain_knowledge` | Domain | Knowledge article search, CRUD, and feedback |
+| `domain_service_catalog` | Domain | Catalog browsing, ordering, cart, and checkout |
+
+**Standard** groups receive `settings` and `auth_provider` at registration. **Domain** groups additionally receive a `ChoiceRegistry` instance for resolving human-readable labels (e.g., "open", "high") to ServiceNow internal values.
+
+See [[Tool-Reference]] for the complete list of tools in each group.
+
+---
+
+## Custom Packages
+
+You can create a custom package by setting `MCP_TOOL_PACKAGE` to a comma-separated list of group names:
+
+```bash
+MCP_TOOL_PACKAGE="table,record,debug,domain_incident"
+```
+
+This loads exactly the specified groups - no more, no less.
+
+### Rules
+
+- Group names must be valid (see the Tool Group Reference table above)
+- Invalid group names cause a startup validation error
+- Custom package values must not collide with preset package names (e.g., you cannot use `"full"` as a custom list)
+- The `list_tool_packages` tool is always available regardless of the custom package contents
+- You can include the `testing` group in a custom package (it is only excluded from the `full` preset)
+
+### Examples
+
+**Minimal incident workflow:**
+```bash
+MCP_TOOL_PACKAGE="table,record,domain_incident"
+```
+
+**Developer tools with testing:**
+```bash
+MCP_TOOL_PACKAGE="table,record,attachment,record_write,attachment_write,metadata,artifact_write,changes,debug,investigations,documentation,workflow,flow_designer,testing"
+```
+
+**Read-only CMDB inspection:**
+```bash
+MCP_TOOL_PACKAGE="table,record,attachment,domain_cmdb"
+```
+
+---
+
+## Choosing a Package
+
+| If you need... | Use this package |
+|---|---|
+| Everything (default) | `full` |
+| ITSM process management | `itil` |
+| Platform development and debugging | `developer` |
+| Read-only exploration and analysis | `readonly` or `analyst` |
+| Incident-focused workflow | `incident_management` |
+| Change request workflow | `change_management` |
+| Problem management | `problem_management` |
+| Request/RITM management | `request_management` |
+| CMDB exploration | `cmdb` |
+| Knowledge base work | `knowledge_management` |
+| Service catalog operations | `service_catalog` |
+| Minimal read-only access | `core_readonly` |
+| Connection test only | `none` |
+| Specific combination of groups | Custom (comma-separated group names) |
+
+### Considerations
+
+- **Fewer tools = less noise** - AI agents work better when they have fewer, more relevant tools to choose from. Start with a focused package and expand if needed.
+- **Read-only is safe** - The `readonly`, `analyst`, and `core_readonly` packages contain no write operations, making them safe for production exploration.
+- **Write gating applies regardless** - Even packages with write tools are subject to production write gating when `SERVICENOW_ENV` is `"prod"` or `"production"`. See [[Safety-and-Policy]] for details.
+
+---
+
+## The `list_tool_packages` Tool
+
+This tool is always available and returns the complete package registry at runtime. Use it to:
+
+- Discover available preset packages and their group contents
+- Verify which groups are loaded in the current configuration
+- Check valid group names for building custom packages
+
+---
+
+## Next Steps
+
+- [[Tool-Reference]] - Complete tool reference with descriptions and parameters
+- [[Safety-and-Policy]] - Security guardrails and write gating
+- [[Configuration]] - Environment variables and settings reference

--- a/docs/wiki/Tool-Reference.md
+++ b/docs/wiki/Tool-Reference.md
@@ -1,0 +1,323 @@
+# Tool Reference
+
+Complete reference for all tools provided by the ServiceNow DevTools MCP server. Tools are organized into groups that can be selectively loaded via [[Tool-Packages]].
+
+All tools return responses in TOON format (not JSON) with a standardized envelope containing `correlation_id`, `status`, `data`, and optionally `pagination` and `warnings`. See [[Architecture]] for details on the response format.
+
+For security guardrails that apply across all tools, see [[Safety-and-Policy]].
+
+---
+
+## Always-On Tool
+
+The `list_tool_packages` tool is always available, regardless of which tool package is configured - even with `MCP_TOOL_PACKAGE="none"`.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `list_tool_packages` | List available tool packages and their contents | - |
+
+---
+
+## Table (4 tools)
+
+Describe table schemas with enriched metadata, query records with encoded queries, compute aggregate statistics, and build structured queries. The `build_query` tool returns a reusable `query_token` that can be passed to other query-accepting tools.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `table_describe` | Describe a table's schema with enriched metadata from sys_db_object and sys_documentation | `table` |
+| `table_query` | Query records from a table using an encoded query | `table`, `query_token`, `fields`, `limit`, `offset`, `order_by`, `display_values` |
+| `table_aggregate` | Compute aggregate statistics (count, avg, min, max, sum) for a table | `table`, `query_token`, `group_by`, `avg_fields`, `min_fields`, `max_fields`, `sum_fields` |
+| `build_query` | Build a structured query from conditions and return a reusable query_token | `conditions` (JSON array) |
+
+---
+
+## Record (3 tools)
+
+Fetch records by sys_id and explore referential relationships in both directions.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `record_get` | Fetch a single record by sys_id with optional field selection | `table`, `sys_id`, `fields`, `display_values` |
+| `rel_references_to` | Find all records that reference a given record (inbound references) | `table`, `sys_id` |
+| `rel_references_from` | Find all records that a given record references (outbound references) | `table`, `sys_id` |
+
+---
+
+## Attachment (4 tools)
+
+List attachment metadata, fetch individual attachment records, and download attachment content as base64.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `attachment_list` | List attachments for a table or record with filtering and pagination | `table_name`, `table_sys_id`, `file_name`, `limit`, `offset`, `order_by` |
+| `attachment_get` | Fetch a single attachment metadata record by sys_id | `sys_id` |
+| `attachment_download` | Download attachment content as base64 by sys_id | `sys_id` |
+| `attachment_download_by_name` | Download attachment content as base64 by table, record, and file name | `table_name`, `table_sys_id`, `file_name` |
+
+---
+
+## Attachment Write (2 tools)
+
+Upload attachments with base64-encoded content and delete attachments by sys_id. Write operations are subject to [[Safety-and-Policy|write gating]].
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `attachment_upload` | Upload an attachment with base64-encoded content | `table_name`, `table_sys_id`, `file_name`, `content_base64`, `content_type`, `encryption_context`, `creation_time` |
+| `attachment_delete` | Delete an attachment by sys_id | `sys_id` |
+
+---
+
+## Metadata (4 tools)
+
+List and inspect platform artifacts (business rules, script includes, client scripts, etc.), find cross-references across script tables, and discover which automations write to a table.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `meta_list_artifacts` | List platform artifacts of a given type with optional query filtering | `artifact_type`, `query_token`, `limit` |
+| `meta_get_artifact` | Fetch a single platform artifact by type and sys_id | `artifact_type`, `sys_id` |
+| `meta_find_references` | Find cross-references to a target across script tables | `target`, `limit` |
+| `meta_what_writes` | Find automations that write to a specific table and field | `table`, `field` |
+
+---
+
+## Artifact Write (2 tools)
+
+Create and update platform artifacts (business rules, script includes, client scripts, etc.) with optional local script file injection via `script_path`. Write operations are subject to [[Safety-and-Policy|write gating]].
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `artifact_create` | Create a new platform artifact with optional local script file | `artifact_type`, `data`, `script_path` |
+| `artifact_update` | Update an existing platform artifact with optional local script file | `artifact_type`, `sys_id`, `changes`, `script_path` |
+
+---
+
+## Change Intelligence (4 tools)
+
+Inspect update sets, diff artifact versions, view audit trails, and generate release notes.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `changes_updateset_inspect` | Inspect an update set and list its customer updates | `update_set_id` |
+| `changes_diff_artifact` | Diff an artifact's current version against its update set version | `table`, `sys_id` |
+| `changes_last_touched` | View the audit trail of recent changes to a record | `table`, `sys_id`, `limit` |
+| `changes_release_notes` | Generate release notes from an update set's contents | `update_set_id`, `format` |
+
+---
+
+## Debug and Trace (6 tools)
+
+Build event timelines, inspect flow executions, trace email delivery, check integration health, inspect import sets, and trace field-level mutations.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `debug_trace` | Build an event timeline for a record from system logs | `record_sys_id`, `table`, `minutes` |
+| `debug_flow_execution` | Inspect a flow execution context and its action outputs | `context_id` |
+| `debug_email_trace` | Trace email delivery for a record | `record_sys_id` |
+| `debug_integration_health` | Check integration health by inspecting ECC queue errors | `kind`, `hours` |
+| `debug_importset_run` | Inspect an import set run and its row-level results | `import_set_sys_id` |
+| `debug_field_mutation_story` | Trace field-level mutations from sys_audit | `table`, `sys_id`, `field`, `limit` |
+
+---
+
+## Record Write (7 tools)
+
+Create, update, and delete records directly or via a preview-then-apply confirmation pattern. The preview tools return a `preview_token` that can be passed to `record_apply` for confirmation. Write operations are subject to [[Safety-and-Policy|write gating]].
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `record_create` | Create a record directly (no preview) | `table`, `data` |
+| `record_preview_create` | Preview a record creation and return a preview_token | `table`, `data` |
+| `record_update` | Update a record directly (no preview) | `table`, `sys_id`, `changes` |
+| `record_preview_update` | Preview a record update and return a preview_token | `table`, `sys_id`, `changes` |
+| `record_delete` | Delete a record directly (no preview) | `table`, `sys_id` |
+| `record_preview_delete` | Preview a record deletion and return a preview_token | `table`, `sys_id` |
+| `record_apply` | Apply a previously previewed operation using its preview_token | `preview_token` |
+
+---
+
+## Investigations (2 tools)
+
+Run automated investigations and explain individual findings. Seven investigation modules are available: `stale_automations`, `deprecated_apis`, `table_health`, `acl_conflicts`, `error_analysis`, `slow_transactions`, and `performance_bottlenecks`.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `investigate_run` | Run an automated investigation module with parameters | `investigation`, `params` |
+| `investigate_explain` | Explain a specific finding from an investigation result | `investigation`, `element_id` |
+
+---
+
+## Documentation (4 tools)
+
+Generate automation maps, artifact summaries with dependency analysis, test scenario suggestions, and code review findings.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `docs_logic_map` | Generate an automation map for a table (business rules, client scripts, etc.) | `table` |
+| `docs_artifact_summary` | Generate a summary of a platform artifact with dependency analysis | `artifact_type`, `sys_id` |
+| `docs_test_scenarios` | Generate test scenario suggestions for a platform artifact | `artifact_type`, `sys_id` |
+| `docs_review_notes` | Generate code review findings for a platform artifact | `artifact_type`, `sys_id` |
+
+---
+
+## Workflow Analysis (5 tools)
+
+List workflow contexts for a record, map workflow structures, inspect execution status, view activity details, and list workflow versions.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `workflow_contexts` | List workflow contexts for a record | `record_sys_id`, `table`, `state`, `limit` |
+| `workflow_map` | Map the structure of a workflow version (activities and transitions) | `workflow_version_sys_id` |
+| `workflow_status` | Inspect execution status of a workflow context | `context_sys_id` |
+| `workflow_activity_detail` | View details of a specific workflow activity | `activity_sys_id` |
+| `workflow_version_list` | List workflow versions with optional filtering | `table`, `active_only`, `limit` |
+
+---
+
+## Flow Designer (8 tools)
+
+List, inspect, and map Flow Designer flows. View action details, execution history, published snapshots, and analyze legacy workflows for migration readiness.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `flow_list` | List Flow Designer flows with filtering | `table`, `flow_type`, `status`, `active_only`, `limit` |
+| `flow_get` | Fetch a Flow Designer flow by sys_id | `flow_sys_id` |
+| `flow_map` | Map the structure of a flow (trigger, actions, conditions) | `flow_sys_id` |
+| `flow_action_detail` | View details of a specific flow action instance | `action_instance_sys_id` |
+| `flow_execution_list` | List flow executions with filtering | `flow_sys_id`, `source_record`, `state`, `limit` |
+| `flow_execution_detail` | View detailed execution results for a flow context | `context_id` |
+| `flow_snapshot_list` | List published snapshots (versions) of a flow | `flow_sys_id`, `limit` |
+| `workflow_migration_analysis` | Analyze a legacy workflow version for Flow Designer migration readiness | `workflow_version_sys_id` |
+
+---
+
+## Incident Management (6 tools)
+
+Full incident lifecycle: list, fetch, create, update, resolve, and add comments or work notes. State and priority parameters accept human-readable labels (e.g., "open", "high") which are automatically resolved to ServiceNow values via the ChoiceRegistry.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `incident_list` | List incidents with filtering by state, priority, assignment | `state`, `priority`, `assigned_to`, `assignment_group`, `fields`, `limit` |
+| `incident_get` | Fetch a single incident by number | `number` |
+| `incident_create` | Create a new incident | `short_description`, `urgency`, `impact`, `priority`, `description`, `caller_id`, `assignment_group`, `assigned_to`, `category`, `subcategory` |
+| `incident_update` | Update an existing incident | `number`, `short_description`, `urgency`, `impact`, `priority`, `state`, `description`, `assignment_group`, `assigned_to`, `category`, `subcategory` |
+| `incident_resolve` | Resolve an incident with close code and notes | `number`, `close_code`, `close_notes` |
+| `incident_add_comment` | Add a comment or work note to an incident | `number`, `comment`, `work_note` |
+
+---
+
+## Change Management (6 tools)
+
+Manage change requests: list, fetch, create, update, view associated tasks, and add comments or work notes.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `change_list` | List change requests with filtering by state, type, risk, assignment | `state`, `type`, `risk`, `assignment_group`, `fields`, `limit` |
+| `change_get` | Fetch a single change request by number | `number` |
+| `change_create` | Create a new change request | `short_description`, `description`, `type`, `risk`, `assignment_group`, `start_date`, `end_date` |
+| `change_update` | Update an existing change request | `number`, `short_description`, `description`, `type`, `risk`, `assignment_group`, `state` |
+| `change_tasks` | List tasks associated with a change request | `number` |
+| `change_add_comment` | Add a comment or work note to a change request | `number`, `comment`, `work_note` |
+
+---
+
+## Problem Management (5 tools)
+
+Problem lifecycle: list, fetch, create, update, and document root cause analysis.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `problem_list` | List problems with filtering by state, priority, assignment | `state`, `priority`, `assigned_to`, `assignment_group`, `fields`, `limit` |
+| `problem_get` | Fetch a single problem by number | `number` |
+| `problem_create` | Create a new problem | `short_description`, `urgency`, `impact`, `priority`, `description`, `assigned_to`, `assignment_group`, `category`, `subcategory` |
+| `problem_update` | Update an existing problem | `number`, `short_description`, `urgency`, `impact`, `priority`, `state`, `description`, `assigned_to`, `assignment_group`, `category`, `subcategory` |
+| `problem_root_cause` | Document root cause analysis for a problem | `number`, `cause_notes`, `fix` |
+
+---
+
+## CMDB (5 tools)
+
+Browse configuration items, inspect relationships, list CI classes, and check CMDB health by operational status.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `cmdb_list` | List configuration items with filtering by class and operational status | `ci_class`, `operational_status`, `fields`, `limit` |
+| `cmdb_get` | Fetch a single CI by name or sys_id | `name_or_sys_id`, `ci_class` |
+| `cmdb_relationships` | Inspect CI relationships (parent, child, upstream, downstream) | `name_or_sys_id`, `direction`, `ci_class` |
+| `cmdb_classes` | List available CI classes | `limit` |
+| `cmdb_health` | Check CMDB health by analyzing operational status distribution | `ci_class` |
+
+---
+
+## Request Management (5 tools)
+
+Manage service requests and requested items (RITMs): list, fetch, view items, and update request items.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `request_list` | List service requests with filtering | `state`, `requested_for`, `assignment_group`, `fields`, `limit` |
+| `request_get` | Fetch a single service request by number | `number` |
+| `request_items` | List requested items (RITMs) for a service request | `number`, `fields`, `limit` |
+| `request_item_get` | Fetch a single requested item by number | `number` |
+| `request_item_update` | Update a requested item | `number`, `state`, `assignment_group`, `assigned_to` |
+
+---
+
+## Knowledge Management (5 tools)
+
+Search, read, create, and update knowledge articles and submit feedback or ratings.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `knowledge_search` | Search knowledge articles by query text | `query`, `workflow_state`, `fields`, `limit` |
+| `knowledge_get` | Fetch a single knowledge article by number or sys_id | `number_or_sys_id` |
+| `knowledge_create` | Create a new knowledge article | `short_description`, `text`, `kb_knowledge_base`, `kb_category`, `workflow_state` |
+| `knowledge_update` | Update an existing knowledge article | `number_or_sys_id`, `short_description`, `text`, `workflow_state`, `kb_knowledge_base`, `kb_category` |
+| `knowledge_feedback` | Submit feedback or a rating for a knowledge article | `number_or_sys_id`, `rating`, `comment` |
+
+---
+
+## Service Catalog (12 tools)
+
+Browse catalogs, categories, and items. View item variables, order items directly, manage cart contents, and checkout.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `sc_catalogs_list` | List available service catalogs | `limit`, `text` |
+| `sc_catalog_get` | Fetch a single catalog by sys_id | `sys_id` |
+| `sc_categories_list` | List categories in a catalog | `catalog_sys_id`, `limit`, `offset`, `top_level_only` |
+| `sc_category_get` | Fetch a single category by sys_id | `sys_id` |
+| `sc_items_list` | List catalog items with filtering | `limit`, `offset`, `text`, `catalog`, `category` |
+| `sc_item_get` | Fetch a single catalog item by sys_id | `sys_id` |
+| `sc_item_variables` | List variables (form fields) for a catalog item | `sys_id` |
+| `sc_order_now` | Order a catalog item directly (bypasses cart) | `item_sys_id`, `variables` |
+| `sc_add_to_cart` | Add a catalog item to the cart | `item_sys_id`, `variables` |
+| `sc_cart_get` | View current cart contents | - |
+| `sc_cart_submit` | Submit the current cart as a request | - |
+| `sc_cart_checkout` | Checkout the current cart (two-step ordering) | - |
+
+---
+
+## Testing (7 tools)
+
+> **Note:** The testing group is disabled in the `full` package. To use these tools, configure a custom package that includes `testing` (e.g., `MCP_TOOL_PACKAGE="full,testing"` or `MCP_TOOL_PACKAGE="table,record,testing"`).
+
+Automated Test Framework (ATF) tools for listing, running, and analyzing tests and test suites.
+
+| Tool | Description | Key Parameters |
+|---|---|---|
+| `atf_list_tests` | List ATF tests with optional query filtering | `query_token`, `limit`, `fields` |
+| `atf_get_test` | Fetch a single ATF test by sys_id | `test_id` |
+| `atf_list_suites` | List ATF test suites with optional query filtering | `query_token`, `limit` |
+| `atf_get_results` | Fetch test or suite execution results | `test_id`, `suite_id`, `limit` |
+| `atf_run_test` | Run an ATF test with optional polling for results | `test_id`, `poll`, `poll_interval`, `max_poll_duration` |
+| `atf_run_suite` | Run an ATF test suite with optional polling for results | `suite_id`, `poll`, `poll_interval`, `max_poll_duration` |
+| `atf_test_health` | Analyze test or suite execution health over time | `test_id`, `suite_id`, `days`, `limit` |
+
+---
+
+## Next Steps
+
+- [[Tool-Packages]] - Choose the right tool package for your workflow
+- [[Safety-and-Policy]] - Security guardrails, table deny list, write gating
+- [[Configuration]] - Environment variables and settings reference
+- [[Architecture]] - Server internals and data flow patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "servicenow-devtools-mcp"
 version = "0.9.0"
-description = "A developer & debug-focused MCP server for ServiceNow — 32 tools for platform introspection, change intelligence, debugging, investigations, and documentation generation."
+description = "A developer & debug-focused MCP server for ServiceNow — platform introspection, change intelligence, debugging, investigations, and documentation generation."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
@@ -33,9 +33,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/xerrion/servicenow-devtools-mcp"
-Repository = "https://github.com/xerrion/servicenow-devtools-mcp"
-Issues = "https://github.com/xerrion/servicenow-devtools-mcp/issues"
+Homepage = "https://github.com/Xerrion/servicenow-devtools-mcp"
+Repository = "https://github.com/Xerrion/servicenow-devtools-mcp"
+Issues = "https://github.com/Xerrion/servicenow-devtools-mcp/issues"
+Documentation = "https://github.com/Xerrion/servicenow-devtools-mcp/wiki"
 
 [project.scripts]
 servicenow-devtools-mcp = "servicenow_mcp.server:main"


### PR DESCRIPTION
## Summary

Complete documentation overhaul addressing stale data, missing docs, and improving discoverability.

### Changes

**Metadata fixes:**
- Banner SVG: '36 Tools' -> '90+ Tools', added ITSM and CMDB category pills
- pyproject.toml: removed stale tool count, added wiki URL, normalized URL casing

**Issue templates (new):**
- Bug report, feature request, tool request, documentation issue
- Template chooser config with blank issues disabled

**Core documentation:**
- README.md rewritten from 664 to ~186 lines (links to Wiki for details)
- INSTALL.md created as self-contained AI agent installation guide
- Fixed denied table names to match policy.py source of truth
- Fixed write gating language accuracy

**Wiki (9 pages, deployed):**
- Home, Getting Started, Configuration
- Tool Reference (all 21 tool groups), Tool Packages (14 presets)
- Safety and Policy, Architecture, Development, Telemetry

**GitHub metadata (already applied):**
- Updated repo description (removed stale tool count)
- Set homepage to wiki URL
- Added topics: servicenow, mcp, model-context-protocol, devtools, debugging, python

### Notes
- No hardcoded tool counts anywhere - uses dynamic language to avoid staleness
- Wiki content also lives in docs/wiki/ for version control
- AGENTS.md still has some stale references (denied tables, OTel) - separate concern