### PR TITLE
chore: rename project from servicenow-devtools-mcp to servicenow-platform-mcp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
     id: version
     attributes:
       label: Server Version
-      description: "Output of `pip show servicenow-devtools-mcp` or check pyproject.toml"
+      description: "Output of `pip show servicenow-platform-mcp` or check pyproject.toml"
       placeholder: "e.g., 0.9.0"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/Xerrion/servicenow-devtools-mcp/security/advisories/new
+    url: https://github.com/Xerrion/servicenow-platform-mcp/security/advisories/new
     about: Report a security vulnerability privately via GitHub Security Advisories

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md - servicenow-devtools-mcp
+# AGENTS.md - servicenow-platform-mcp
 
 ## 📋 Project Overview
 
@@ -442,7 +442,7 @@ async def explain(client, element_id) -> dict:
 
 1. Creates `Settings` and auth via `create_auth()`.
 2. Calls `setup_sentry(settings)` and sets Sentry context with instance URL, environment, and tool package.
-3. Creates `FastMCP('servicenow-dev-debug')`.
+3. Creates `FastMCP('servicenow-platform-mcp')`.
 4. Calls `attach_servicenow_state(mcp, settings, auth_provider, query_store, choices)` to attach shared state.
 5. Always registers the `list_tool_packages` tool.
 6. Loads tool groups via `importlib`; `domain_` prefix modules get `choices=choices` kwarg.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
-# ServiceNow DevTools MCP Server - Installation Guide
+# ServiceNow Platform MCP Server - Installation Guide
 
-> **For AI Agents:** You are helping your user install and configure the ServiceNow DevTools MCP server.
+> **For AI Agents:** You are helping your user install and configure the ServiceNow Platform MCP server.
 > Follow each step below in order. Ask the user questions where indicated, then generate the appropriate configuration.
 
 ## Step 0: Gather Credentials
@@ -48,7 +48,7 @@ Write to `~/.config/opencode/opencode.json`:
   "mcp": {
     "servicenow": {
       "type": "local",
-      "command": ["uvx", "servicenow-devtools-mcp"],
+      "command": ["uvx", "servicenow-platform-mcp"],
       "environment": {
         "SERVICENOW_INSTANCE_URL": "<instance_url>",
         "SERVICENOW_USERNAME": "<username>",
@@ -70,7 +70,7 @@ Add to `claude_desktop_config.json`:
   "mcpServers": {
     "servicenow": {
       "command": "uvx",
-      "args": ["servicenow-devtools-mcp"],
+      "args": ["servicenow-platform-mcp"],
       "env": {
         "SERVICENOW_INSTANCE_URL": "<instance_url>",
         "SERVICENOW_USERNAME": "<username>",
@@ -92,7 +92,7 @@ Write to `.vscode/mcp.json` in the workspace:
   "servers": {
     "servicenow": {
       "command": "uvx",
-      "args": ["servicenow-devtools-mcp"],
+      "args": ["servicenow-platform-mcp"],
       "env": {
         "SERVICENOW_INSTANCE_URL": "<instance_url>",
         "SERVICENOW_USERNAME": "<username>",
@@ -115,7 +115,7 @@ SERVICENOW_USERNAME=<username> \
 SERVICENOW_PASSWORD=<password> \
 MCP_TOOL_PACKAGE=<package> \
 SERVICENOW_ENV=<env> \
-uvx servicenow-devtools-mcp
+uvx servicenow-platform-mcp
 ```
 
 **Important:** Replace all `<placeholder>` values with the user's actual answers from Steps 0-1 before writing the config.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <p align="center">
-  <img src="assets/banner.svg" alt="servicenow-devtools-mcp banner" width="900" />
+  <img src="assets/banner.svg" alt="servicenow-platform-mcp banner" width="900" />
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-devtools-mcp" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/servicenow-devtools-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-devtools-mcp" alt="Python versions"></a>
-  <a href="https://github.com/Xerrion/servicenow-devtools-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Xerrion/servicenow-devtools-mcp" alt="License"></a>
+  <a href="https://pypi.org/project/servicenow-platform-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-platform-mcp" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/servicenow-platform-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-platform-mcp" alt="Python versions"></a>
+  <a href="https://github.com/Xerrion/servicenow-platform-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Xerrion/servicenow-platform-mcp" alt="License"></a>
 </p>
 
-# servicenow-devtools-mcp
+# servicenow-platform-mcp
 
-A developer and debug-focused [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for ServiceNow. Provides a comprehensive suite of tools across 20 tool groups for platform introspection, change intelligence, debugging, record management, ITSM workflows, CMDB operations, service catalog, automated investigations, documentation generation, and Flow Designer analysis.
+A comprehensive [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for ServiceNow. Provides a comprehensive suite of tools across 20 tool groups for platform introspection, change intelligence, debugging, record management, ITSM workflows, CMDB operations, service catalog, automated investigations, documentation generation, and Flow Designer analysis.
 
 ## Quick Start
 
@@ -25,7 +25,7 @@ export SERVICENOW_PASSWORD=your-password
 **2. Run the server:**
 
 ```bash
-uvx servicenow-devtools-mcp
+uvx servicenow-platform-mcp
 ```
 
 **3. Connect your MCP client** (see [Configuration](#configuration) below).
@@ -41,7 +41,7 @@ Add to `~/.config/opencode/opencode.json`:
   "mcp": {
     "servicenow": {
       "type": "local",
-      "command": ["uvx", "servicenow-devtools-mcp"],
+      "command": ["uvx", "servicenow-platform-mcp"],
       "environment": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
@@ -61,7 +61,7 @@ Add to `claude_desktop_config.json`:
   "mcpServers": {
     "servicenow": {
       "command": "uvx",
-      "args": ["servicenow-devtools-mcp"],
+      "args": ["servicenow-platform-mcp"],
       "env": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
@@ -81,7 +81,7 @@ Add to `.vscode/mcp.json`:
   "servers": {
     "servicenow": {
       "command": "uvx",
-      "args": ["servicenow-devtools-mcp"],
+      "args": ["servicenow-platform-mcp"],
       "env": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
@@ -98,7 +98,7 @@ Add to `.vscode/mcp.json`:
 SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com \
 SERVICENOW_USERNAME=admin \
 SERVICENOW_PASSWORD=your-password \
-uvx servicenow-devtools-mcp
+uvx servicenow-platform-mcp
 ```
 
 ## Environment Variables
@@ -123,8 +123,8 @@ The server reads from `.env` and `.env.local` files automatically.
 Copy and paste this prompt to your AI agent (Claude Code, Cursor, OpenCode, etc.):
 
 ```
-Install and configure servicenow-devtools-mcp by following the instructions here:
-https://raw.githubusercontent.com/Xerrion/servicenow-devtools-mcp/refs/heads/main/INSTALL.md
+Install and configure servicenow-platform-mcp by following the instructions here:
+https://raw.githubusercontent.com/Xerrion/servicenow-platform-mcp/refs/heads/main/INSTALL.md
 ```
 
 Or read the [Installation Guide](INSTALL.md) directly.
@@ -165,7 +165,7 @@ Control which tools are loaded with `MCP_TOOL_PACKAGE`. There are 14 preset pack
 | `knowledge_management` | 6 | Knowledge base tools |
 | `service_catalog` | 6 | Service catalog tools |
 
-You can also create custom packages with comma-separated group names (e.g. `MCP_TOOL_PACKAGE="table,record,debug"`). See the [Wiki](https://github.com/Xerrion/servicenow-devtools-mcp/wiki) for full package and tool group details.
+You can also create custom packages with comma-separated group names (e.g. `MCP_TOOL_PACKAGE="table,record,debug"`). See the [Wiki](https://github.com/Xerrion/servicenow-platform-mcp/wiki) for full package and tool group details.
 
 ## Safety
 
@@ -176,13 +176,13 @@ You can also create custom packages with comma-separated group names (e.g. `MCP_
 
 These guardrails reduce risk but are not a guarantee - always validate in a sub-production environment.
 
-See the [Safety & Policy](https://github.com/Xerrion/servicenow-devtools-mcp/wiki) wiki page for complete details.
+See the [Safety & Policy](https://github.com/Xerrion/servicenow-platform-mcp/wiki) wiki page for complete details.
 
 ## Development
 
 ```bash
-git clone https://github.com/Xerrion/servicenow-devtools-mcp.git
-cd servicenow-devtools-mcp
+git clone https://github.com/Xerrion/servicenow-platform-mcp.git
+cd servicenow-platform-mcp
 uv sync --group dev
 uv run pytest                  # Run tests
 uv run ruff check .            # Lint

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -64,12 +64,12 @@
 
   <!-- Title -->
   <text x="130" y="75" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="36" font-weight="700" fill="#ffffff" letter-spacing="-0.5">
-    servicenow-devtools-mcp
+    servicenow-platform-mcp
   </text>
 
   <!-- Tagline -->
   <text x="130" y="128" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="18" fill="#94a3b8" font-weight="400">
-    Developer &amp; Debug MCP Server for ServiceNow
+    Comprehensive MCP Server for ServiceNow
   </text>
 
   <!-- Tool count pill -->

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Deep technical architecture of the `servicenow-devtools-mcp` server - an async Python MCP server for ServiceNow platform introspection, change intelligence, debugging, investigations, and documentation generation.
+Deep technical architecture of the `servicenow-platform-mcp` server - an async Python MCP server for ServiceNow platform introspection, change intelligence, debugging, investigations, and documentation generation.
 
 ## Overview
 
@@ -28,7 +28,7 @@ This function performs a strict initialization sequence:
 2. **Create auth provider** - `create_auth(settings)` returns a `BasicAuthProvider` for ServiceNow API authentication
 3. **Initialize Sentry** - `setup_sentry(settings)` activates error tracking when a DSN is configured
 4. **Set server context** - Attaches instance hostname, environment, production flag, and tool package to Sentry scope
-5. **Create FastMCP instance** - `FastMCP("servicenow-dev-debug")`
+5. **Create FastMCP instance** - `FastMCP("servicenow-platform-mcp")`
 6. **Create shared state** - `QueryTokenStore()` for query token management, `ChoiceRegistry(settings, auth_provider)` for choice label resolution
 7. **Attach state to FastMCP** - `attach_servicenow_state()` stores all shared objects on the FastMCP instance via typed helpers in `mcp_state.py`
 8. **Register `list_tool_packages`** - Always-on tool that returns all available tool packages

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,6 +1,6 @@
 # Development
 
-Comprehensive development guide for contributing to `servicenow-devtools-mcp`.
+Comprehensive development guide for contributing to `servicenow-platform-mcp`.
 
 See also: [[Architecture]] for technical internals, [[Telemetry]] for observability.
 
@@ -15,8 +15,8 @@ See also: [[Architecture]] for technical internals, [[Telemetry]] for observabil
 ### Setup
 
 ```bash
-git clone https://github.com/Xerrion/servicenow-devtools-mcp.git
-cd servicenow-devtools-mcp
+git clone https://github.com/Xerrion/servicenow-platform-mcp.git
+cd servicenow-platform-mcp
 uv sync --group dev
 cp .env.example .env.local  # Fill in ServiceNow credentials
 ```
@@ -29,7 +29,7 @@ SERVICENOW_USERNAME=admin
 SERVICENOW_PASSWORD=your-password
 ```
 
-No build step is required for development. The server runs directly from source via `uv run servicenow-devtools-mcp`.
+No build step is required for development. The server runs directly from source via `uv run servicenow-platform-mcp`.
 
 ## Development Commands
 
@@ -313,4 +313,4 @@ Release-please uses conventional commits to determine version bumps:
 
 - **Build backend**: hatchling
 - **Wheel packages**: `src/servicenow_mcp` (src-layout)
-- **Entry point**: `servicenow-devtools-mcp = servicenow_mcp.server:main`
+- **Entry point**: `servicenow-platform-mcp = servicenow_mcp.server:main`

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide walks you through installing and configuring the ServiceNow DevTools MCP server for use with your AI client.
+This guide walks you through installing and configuring the ServiceNow Platform MCP server for use with your AI client.
 
 ---
 
@@ -18,7 +18,7 @@ This guide walks you through installing and configuring the ServiceNow DevTools 
 ### Recommended: Run with uvx (no install required)
 
 ```bash
-uvx servicenow-devtools-mcp
+uvx servicenow-platform-mcp
 ```
 
 This downloads and runs the server in an isolated environment. No permanent installation needed.
@@ -26,11 +26,11 @@ This downloads and runs the server in an isolated environment. No permanent inst
 ### Alternative: Install with pip or uv
 
 ```bash
-pip install servicenow-devtools-mcp
+pip install servicenow-platform-mcp
 ```
 
 ```bash
-uv add servicenow-devtools-mcp
+uv add servicenow-platform-mcp
 ```
 
 > **Note:** The server communicates via stdio transport - it is launched by your MCP client as a subprocess, not run as a standalone service. You do not need to start it manually.
@@ -68,7 +68,7 @@ File: `~/.config/opencode/opencode.json`
   "mcp": {
     "servicenow": {
       "type": "local",
-      "command": ["uvx", "servicenow-devtools-mcp"],
+      "command": ["uvx", "servicenow-platform-mcp"],
       "environment": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
@@ -88,7 +88,7 @@ File: `claude_desktop_config.json`
   "mcpServers": {
     "servicenow": {
       "command": "uvx",
-      "args": ["servicenow-devtools-mcp"],
+      "args": ["servicenow-platform-mcp"],
       "env": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
@@ -108,7 +108,7 @@ File: `.vscode/mcp.json`
   "servers": {
     "servicenow": {
       "command": "uvx",
-      "args": ["servicenow-devtools-mcp"],
+      "args": ["servicenow-platform-mcp"],
       "env": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_USERNAME": "admin",
@@ -127,7 +127,7 @@ For any client that supports stdio transport, launch the server with inline envi
 SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com \
 SERVICENOW_USERNAME=admin \
 SERVICENOW_PASSWORD=your-password \
-uvx servicenow-devtools-mcp
+uvx servicenow-platform-mcp
 ```
 
 ---
@@ -147,7 +147,7 @@ Once configured, try these example prompts with your AI agent:
 
 ## AI Agent Setup
 
-For copy-paste installation instructions optimized for AI agents, see [INSTALL.md](https://github.com/Xerrion/servicenow-devtools-mcp/blob/main/INSTALL.md) in the repository root. This file is designed to be fed directly to an AI agent for self-configuration.
+For copy-paste installation instructions optimized for AI agents, see [INSTALL.md](https://github.com/Xerrion/servicenow-platform-mcp/blob/main/INSTALL.md) in the repository root. This file is designed to be fed directly to an AI agent for self-configuration.
 
 ---
 
@@ -180,7 +180,7 @@ For copy-paste installation instructions optimized for AI agents, see [INSTALL.m
 ### Server not starting
 
 - Ensure Python 3.12 or later is installed: `python --version`
-- Try running directly: `uvx servicenow-devtools-mcp` to see error output
+- Try running directly: `uvx servicenow-platform-mcp` to see error output
 - Check that `uvx` is installed: `uv --version` (install from [astral.sh/uv](https://astral.sh/uv))
 
 ---

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,12 +1,12 @@
-# ServiceNow DevTools MCP Server
+# ServiceNow Platform MCP Server
 
-A developer and debug-focused MCP server for ServiceNow - platform introspection, change intelligence, debugging, investigations, and documentation generation.
+A comprehensive MCP server for ServiceNow - platform introspection, change intelligence, debugging, investigations, and documentation generation.
 
 ---
 
 ## What is this?
 
-**servicenow-devtools-mcp** is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI agents direct access to your ServiceNow instance. It exposes a comprehensive suite of tools covering schema exploration, record management, debugging, change intelligence, ITSM processes, and more - all through a standardized MCP interface.
+**servicenow-platform-mcp** is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI agents direct access to your ServiceNow instance. It exposes a comprehensive suite of tools covering schema exploration, record management, debugging, change intelligence, ITSM processes, and more - all through a standardized MCP interface.
 
 The server runs locally via stdio transport and is launched by your MCP-compatible AI client (OpenCode, Claude Desktop, VS Code Copilot, Cursor, etc.). Your AI agent gains the ability to query tables, inspect records, trace debug logs, generate documentation, manage incidents, and much more - without you needing to navigate the ServiceNow UI.
 
@@ -47,7 +47,7 @@ The server runs locally via stdio transport and is launched by your MCP-compatib
 **1. Run the server**
 
 ```bash
-uvx servicenow-devtools-mcp
+uvx servicenow-platform-mcp
 ```
 
 **2. Set environment variables**
@@ -66,7 +66,7 @@ See [[Getting-Started]] for full setup instructions with configuration examples 
 
 ## Links
 
-- [PyPI](https://pypi.org/project/servicenow-devtools-mcp/)
-- [GitHub Repository](https://github.com/Xerrion/servicenow-devtools-mcp)
-- [Issues](https://github.com/Xerrion/servicenow-devtools-mcp/issues)
-- [License (MIT)](https://github.com/Xerrion/servicenow-devtools-mcp/blob/main/LICENSE)
+- [PyPI](https://pypi.org/project/servicenow-platform-mcp/)
+- [GitHub Repository](https://github.com/Xerrion/servicenow-platform-mcp)
+- [Issues](https://github.com/Xerrion/servicenow-platform-mcp/issues)
+- [License (MIT)](https://github.com/Xerrion/servicenow-platform-mcp/blob/main/LICENSE)

--- a/docs/wiki/Telemetry.md
+++ b/docs/wiki/Telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-Observability documentation for the `servicenow-devtools-mcp` server. Currently, **Sentry** is the sole observability integration.
+Observability documentation for the `servicenow-platform-mcp` server. Currently, **Sentry** is the sole observability integration.
 
 See also: [[Architecture]] for server internals, [[Development]] for setup.
 
@@ -60,7 +60,7 @@ When activated, Sentry is initialized with these settings:
 sentry_sdk.init(
     dsn=dsn,
     environment=environment,
-    release=_RELEASE,            # e.g. "servicenow-devtools-mcp@0.9.0"
+    release=_RELEASE,            # e.g. "servicenow-platform-mcp@0.9.0"
     send_default_pii=True,
     integrations=integrations,   # Includes MCPIntegration when available
     traces_sample_rate=1.0,      # All transactions sampled
@@ -72,9 +72,9 @@ The release string is dynamically derived from package metadata using `importlib
 
 ```python
 try:
-    _RELEASE = f"servicenow-devtools-mcp@{pkg_version('servicenow-devtools-mcp')}"
+    _RELEASE = f"servicenow-platform-mcp@{pkg_version('servicenow-platform-mcp')}"
 except Exception:
-    _RELEASE = "servicenow-devtools-mcp@unknown"
+    _RELEASE = "servicenow-platform-mcp@unknown"
 ```
 
 ## Instrumentation Points
@@ -183,4 +183,4 @@ def _disable_sentry_capture():
 
 OpenTelemetry was previously integrated via a `telemetry.py` module that provided distributed tracing with spans for tool invocations and HTTP requests. It supported OTLP and console exporters, W3C `traceparent` header injection, and trace context in response envelopes.
 
-The OTel integration was **removed in v0.9.0** (commit `b72cee3`, PR [#68](https://github.com/Xerrion/servicenow-devtools-mcp/pull/68)) to resolve SonarCloud issues and simplify the observability stack. The `.env.example` file may still contain stale OTel-related variables (`OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) - these are ignored by the server and have no effect.
+The OTel integration was **removed in v0.9.0** (commit `b72cee3`, PR [#68](https://github.com/Xerrion/servicenow-platform-mcp/pull/68)) to resolve SonarCloud issues and simplify the observability stack. The `.env.example` file may still contain stale OTel-related variables (`OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) - these are ignored by the server and have no effect.

--- a/docs/wiki/Tool-Reference.md
+++ b/docs/wiki/Tool-Reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Complete reference for all tools provided by the ServiceNow DevTools MCP server. Tools are organized into groups that can be selectively loaded via [[Tool-Packages]].
+Complete reference for all tools provided by the ServiceNow Platform MCP server. Tools are organized into groups that can be selectively loaded via [[Tool-Packages]].
 
 All tools return responses in TOON format (not JSON) with a standardized envelope containing `correlation_id`, `status`, `data`, and optionally `pagination` and `warnings`. See [[Architecture]] for details on the response format.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
-name = "servicenow-devtools-mcp"
+name = "servicenow-platform-mcp"
 version = "0.9.1"
-description = "A developer & debug-focused MCP server for ServiceNow — platform introspection, change intelligence, debugging, investigations, and documentation generation."
+description = "A comprehensive MCP server for ServiceNow - platform introspection, ITSM workflows, CMDB operations, change intelligence, debugging, investigations, and documentation generation."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 authors = [
     { name = "Lasse Nielsen", email = "lasse@xerrion.dk" },
 ]
-keywords = ["servicenow", "mcp", "model-context-protocol", "devtools", "debugging"]
+keywords = ["servicenow", "mcp", "model-context-protocol", "platform", "itsm", "cmdb", "debugging"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Topic :: Software Development :: Debuggers",
+    "Topic :: System :: Systems Administration",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
@@ -33,13 +33,13 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Xerrion/servicenow-devtools-mcp"
-Repository = "https://github.com/Xerrion/servicenow-devtools-mcp"
-Issues = "https://github.com/Xerrion/servicenow-devtools-mcp/issues"
-Documentation = "https://github.com/Xerrion/servicenow-devtools-mcp/wiki"
+Homepage = "https://github.com/Xerrion/servicenow-platform-mcp"
+Repository = "https://github.com/Xerrion/servicenow-platform-mcp"
+Issues = "https://github.com/Xerrion/servicenow-platform-mcp/issues"
+Documentation = "https://github.com/Xerrion/servicenow-platform-mcp/wiki"
 
 [project.scripts]
-servicenow-devtools-mcp = "servicenow_mcp.server:main"
+servicenow-platform-mcp = "servicenow_mcp.server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/servicenow_mcp/sentry.py
+++ b/src/servicenow_mcp/sentry.py
@@ -22,9 +22,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 try:
-    _RELEASE = f"servicenow-devtools-mcp@{pkg_version('servicenow-devtools-mcp')}"
+    _RELEASE = f"servicenow-platform-mcp@{pkg_version('servicenow-platform-mcp')}"
 except Exception:
-    _RELEASE = "servicenow-devtools-mcp@unknown"
+    _RELEASE = "servicenow-platform-mcp@unknown"
 
 # ---------------------------------------------------------------------------
 # Try-import sentry-sdk

--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -34,7 +34,7 @@ def create_mcp_server() -> FastMCP:
         },
     )
 
-    mcp = FastMCP("servicenow-dev-debug")
+    mcp = FastMCP("servicenow-platform-mcp")
 
     query_store = QueryTokenStore()
     choices = ChoiceRegistry(settings, auth_provider)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,7 +26,7 @@ class TestCreateMcpServer:
         with patch.dict("os.environ", env, clear=True):
             mcp_server = create_mcp_server()
 
-        assert mcp_server.name == "servicenow-dev-debug"
+        assert mcp_server.name == "servicenow-platform-mcp"
 
     def test_server_has_list_tool_packages_tool(self) -> None:
         """Server always registers the list_tool_packages tool."""


### PR DESCRIPTION
## Summary

Renames the project from `servicenow-devtools-mcp` to `servicenow-platform-mcp` to better reflect the comprehensive scope of the server - only ~8 of 21 tool groups are developer/debug focused, while the majority serve ITSM operators, CMDB admins, service catalog users, knowledge managers, and analysts.

## Changes

**Identity alignment** - all three name variants now converge on `servicenow-platform-mcp`:
- Package/PyPI name: `servicenow-devtools-mcp` -> `servicenow-platform-mcp`
- FastMCP server identity: `servicenow-dev-debug` -> `servicenow-platform-mcp`
- CLI entry point: `servicenow-devtools-mcp` -> `servicenow-platform-mcp`
- Python import package (`servicenow_mcp`) unchanged

**Description & metadata:**
- "developer & debug-focused" -> "comprehensive"
- Keywords: replaced `devtools` with `platform`, added `itsm` and `cmdb`
- Classifier: `Debuggers` -> `Systems Administration`

**16 files updated** across source code, tests, docs, wiki, CI templates, and assets.

## Post-merge steps

- [ ] Rename GitHub repository: Settings -> `servicenow-platform-mcp` (auto-redirects old URLs)
- [ ] Publish to PyPI under new name
- [ ] Consider a final deprecation release of old package pointing to new name