### PR TITLE
security: pentest remediation (phases 1-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,26 @@ SERVICENOW_PASSWORD=your-password-here
 
 # Sentry environment tag (defaults to SERVICENOW_ENV if not set)
 # SENTRY_ENVIRONMENT=
+
+# Send default PII (IP addresses, user IDs, request headers) to Sentry.
+# Default: false. Opt back in only if you accept the secret-leak surface;
+# tool payloads can contain cleartext field values, attachment bytes, etc.
+# SENTRY_SEND_PII=false
+
+# Trace sample rate (0.0 to 1.0). Default: 0.05 (5% of transactions).
+# Tool-call spans can include argument names; lower = less exposure.
+# SENTRY_TRACES_SAMPLE_RATE=0.05
+
+# -----------------------------------------------------------------------------
+# DANGEROUS: Policy bypass (user-only, never set by agents)
+# -----------------------------------------------------------------------------
+# WARNING: Setting this to "true" DISABLES the denied-table access check,
+# the write gate (including the production-environment guard), and query
+# safety checks. Field masking for sensitive values remains in effect.
+#
+# This is intended ONLY for a human operator who knows exactly what they are
+# doing. Never enable this under automation or agent control. When enabled
+# in a non-production environment, the server logs a loud warning on startup
+# and reports to Sentry. Setting this in a production environment
+# (SERVICENOW_ENV=prod) will refuse to start.
+# SERVICENOW_ALLOW_DANGEROUS_BYPASS=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "uvicorn>=0.30.0",
     "starlette>=0.38.0",
-    "toon-format",
     "sentry-sdk>=2.55.0",
 ]
 
@@ -71,6 +70,7 @@ dev = [
 line-length = 120
 target-version = "py312"
 src = ["src", "tests"]
+extend-exclude = ["src/servicenow_mcp/_vendor"]
 
 [tool.ruff.lint]
 select = [
@@ -142,6 +142,11 @@ warn_return_any = false
 warn_unused_configs = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
+exclude = ["src/servicenow_mcp/_vendor/"]
+
+[[tool.mypy.overrides]]
+module = "servicenow_mcp._vendor.*"
+ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "servicenow_mcp.server"
@@ -149,6 +154,7 @@ disable_error_code = ["call-arg"]
 
 [tool.basedpyright]
 pythonVersion = "3.12"
+exclude = ["src/servicenow_mcp/_vendor"]
 reportAny = false
 reportExplicitAny = false
 reportUnusedCallResult = false
@@ -159,6 +165,3 @@ reportUnknownArgumentType = false
 reportUnknownVariableType = false
 reportUnknownLambdaType = false
 reportImplicitStringConcatenation = false
-
-[tool.uv.sources]
-toon-format = { git = "https://github.com/toon-format/toon-python.git" }

--- a/src/servicenow_mcp/_vendor/__init__.py
+++ b/src/servicenow_mcp/_vendor/__init__.py
@@ -1,0 +1,6 @@
+"""Vendored third-party packages.
+
+Modules under this package are verbatim (or minimally patched) copies of
+upstream libraries. Each vendored package has a sibling ``NOTICE`` file
+documenting the upstream source, resolved commit, and license.
+"""

--- a/src/servicenow_mcp/_vendor/toon_format/NOTICE
+++ b/src/servicenow_mcp/_vendor/toon_format/NOTICE
@@ -1,0 +1,47 @@
+toon_format - vendored third-party package
+===========================================
+
+Upstream project: https://github.com/toon-format/toon-python
+Upstream version: 0.9.0b1
+Resolved commit:  90861444e5bf7d6408e91bd95e58dba41dd99be8
+Vendored on:      2026-04-23
+License:          MIT
+
+This directory is a verbatim copy of the upstream ``toon_format`` Python
+package at the commit above. It is vendored (rather than declared as a
+git dependency) so that the servicenow-platform-mcp distribution has no
+runtime dependency on an external git repository. Do not modify files
+here; re-sync from upstream if an update is required, then refresh this
+NOTICE accordingly.
+
+No additional runtime dependencies are introduced by vendoring: the
+upstream only requires ``typing-extensions`` for Python < 3.10, and this
+project requires Python >= 3.12.
+
+Upstream LICENSE (MIT)
+----------------------
+
+MIT License
+
+Copyright (c) 2025-PRESENT Xavi Vinaixa
+Copyright (c) 2025-PRESENT David Pirogov
+Copyright (c) 2025-PRESENT Justar
+Copyright (c) 2025-PRESENT Johann Schopplich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/servicenow_mcp/_vendor/toon_format/__init__.py
+++ b/src/servicenow_mcp/_vendor/toon_format/__init__.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""TOON Format for Python.
+
+Token-Oriented Object Notation (TOON) is a compact, human-readable serialization
+format optimized for LLM contexts. Achieves 30-60% token reduction vs JSON while
+maintaining readability and structure.
+
+This package provides encoding and decoding functionality with 100% compatibility
+with the official TOON specification (v1.3).
+
+Example:
+    >>> from toon_format import encode, decode
+    >>> data = {"name": "Alice", "age": 30}
+    >>> toon = encode(data)
+    >>> print(toon)
+    name: Alice
+    age: 30
+    >>> decode(toon)
+    {'name': 'Alice', 'age': 30}
+"""
+
+from .decoder import ToonDecodeError, decode
+from .encoder import encode
+from .types import DecodeOptions, Delimiter, DelimiterKey, EncodeOptions
+from .utils import compare_formats, count_tokens, estimate_savings
+
+__version__ = "0.9.0-beta.1"
+__all__ = [
+    "encode",
+    "decode",
+    "ToonDecodeError",
+    "Delimiter",
+    "DelimiterKey",
+    "EncodeOptions",
+    "DecodeOptions",
+    "count_tokens",
+    "estimate_savings",
+    "compare_formats",
+]

--- a/src/servicenow_mcp/_vendor/toon_format/__main__.py
+++ b/src/servicenow_mcp/_vendor/toon_format/__main__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""CLI entry point for TOON format.
+
+Allows running the package as a module: python -m toon_format
+"""
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/servicenow_mcp/_vendor/toon_format/_literal_utils.py
+++ b/src/servicenow_mcp/_vendor/toon_format/_literal_utils.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Utilities for detecting literal token types.
+
+This module provides functions to identify different types of literal
+values in TOON syntax, such as booleans, null, and numeric literals.
+Used during decoding to distinguish between literal values and strings.
+"""
+
+from .constants import FALSE_LITERAL, NULL_LITERAL, TRUE_LITERAL
+
+
+def is_boolean_or_null_literal(token: str) -> bool:
+    """Check if a token is a boolean or null literal (`true`, `false`, `null`).
+
+    Args:
+        token: The token to check
+
+    Returns:
+        True if the token is a boolean or null literal
+
+    Examples:
+        >>> is_boolean_or_null_literal("true")
+        True
+        >>> is_boolean_or_null_literal("null")
+        True
+        >>> is_boolean_or_null_literal("hello")
+        False
+    """
+    return token == TRUE_LITERAL or token == FALSE_LITERAL or token == NULL_LITERAL
+
+
+def is_numeric_literal(token: str) -> bool:
+    """Check if a token represents a valid numeric literal.
+
+    Rejects numbers with leading zeros (except `"0"` itself or decimals like `"0.5"`).
+    Per Section 7.3 of the TOON specification.
+
+    Args:
+        token: The token to check
+
+    Returns:
+        True if the token is a valid numeric literal
+
+    Examples:
+        >>> is_numeric_literal("42")
+        True
+        >>> is_numeric_literal("3.14")
+        True
+        >>> is_numeric_literal("0.5")
+        True
+        >>> is_numeric_literal("0123")  # Leading zero - not valid
+        False
+        >>> is_numeric_literal("-01")  # Negative with leading zero - not valid
+        False
+        >>> is_numeric_literal("hello")
+        False
+    """
+    if not token:
+        return False
+
+    # Handle negative numbers
+    start_idx = 1 if token.startswith("-") else 0
+    if start_idx >= len(token):
+        return False
+
+    # Must not have leading zeros (except for `"0"` itself or decimals like `"0.5"`)
+    # Check the first digit after optional minus sign
+    if len(token) > start_idx + 1 and token[start_idx] == "0" and token[start_idx + 1] != ".":
+        return False
+
+    # Check if it's a valid number
+    try:
+        num = float(token)
+        # Reject NaN and infinity
+        return not (num != num or not (-float("inf") < num < float("inf")))
+    except ValueError:
+        return False

--- a/src/servicenow_mcp/_vendor/toon_format/_parsing_utils.py
+++ b/src/servicenow_mcp/_vendor/toon_format/_parsing_utils.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Parsing utilities for quote-aware string processing.
+
+This module provides utilities for parsing TOON strings while respecting
+quoted sections and escape sequences. Used extensively in decoder for
+finding delimiters and structural characters outside of quoted strings.
+"""
+
+from typing import Iterator, List, Tuple
+
+from .constants import BACKSLASH, DOUBLE_QUOTE
+
+
+def iter_unquoted(line: str, start: int = 0) -> Iterator[Tuple[int, str, bool]]:
+    """Iterate over characters in a line, tracking quote state.
+
+    This is the core utility for quote-aware string processing. It handles:
+    - Tracking quote boundaries
+    - Skipping escaped characters within quotes
+    - Yielding (index, character, is_quoted) tuples
+
+    Args:
+        line: The line to iterate over
+        start: Starting position (default: 0)
+
+    Yields:
+        Tuple of (index, char, is_quoted) for each character
+
+    Examples:
+        >>> list(iter_unquoted('a"b:c"d'))
+        [(0, 'a', False), (1, '"', False), (2, 'b', True), (3, ':', True),
+         (4, 'c', True), (5, '"', True), (6, 'd', False)]
+    """
+    in_quotes = False
+    i = start
+
+    while i < len(line):
+        char = line[i]
+
+        if char == DOUBLE_QUOTE:
+            # Yield quote with current state, THEN toggle for next char
+            yield (i, char, in_quotes)
+            in_quotes = not in_quotes
+        elif char == BACKSLASH and i + 1 < len(line) and in_quotes:
+            # Escaped character - yield backslash, then skip and yield next char
+            yield (i, char, True)
+            i += 1
+            if i < len(line):
+                yield (i, line[i], True)
+        else:
+            yield (i, char, in_quotes)
+
+        i += 1
+
+
+def find_unquoted_char(line: str, target_char: str, start: int = 0) -> int:
+    """Find first occurrence of target character outside of quoted strings.
+
+    Args:
+        line: Line to search
+        target_char: Character to find
+        start: Starting position (default: 0)
+
+    Returns:
+        Index of character, or -1 if not found
+
+    Examples:
+        >>> find_unquoted_char('a:b"c:d"e', ':')
+        1
+        >>> find_unquoted_char('a"b:c"d:e', ':', 0)
+        7
+        >>> find_unquoted_char('"a:b":c', ':', 0)
+        5
+    """
+    for i, char, is_quoted in iter_unquoted(line, start):
+        if char == target_char and not is_quoted:
+            return i
+    return -1
+
+
+def parse_delimited_values(line: str, delimiter: str) -> List[str]:
+    """Parse delimiter-separated values, respecting quotes and escapes.
+
+    This function splits a line on the delimiter, but only at unquoted positions.
+    Quotes and escape sequences within quoted sections are preserved.
+
+    Args:
+        line: Line content
+        delimiter: Active delimiter (e.g., ',', '\\t', '|')
+
+    Returns:
+        List of token strings (with quotes and escapes preserved)
+
+    Examples:
+        >>> parse_delimited_values('a,b,c', ',')
+        ['a', 'b', 'c']
+        >>> parse_delimited_values('a,"b,c",d', ',')
+        ['a', '"b,c"', 'd']
+        >>> parse_delimited_values('"a,b",c', ',')
+        ['"a,b"', 'c']
+    """
+    tokens: List[str] = []
+    current: List[str] = []
+
+    for i, char, is_quoted in iter_unquoted(line):
+        if char == delimiter and not is_quoted:
+            # Split on unquoted delimiter
+            tokens.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+
+    # Add final token (always add, even if empty, to handle trailing delimiters)
+    if current or tokens:
+        tokens.append("".join(current))
+
+    return tokens
+
+
+def split_at_unquoted_char(line: str, target_char: str) -> Tuple[str, str]:
+    """Split a line at the first unquoted occurrence of target character.
+
+    Args:
+        line: Line content
+        target_char: Character to split on
+
+    Returns:
+        Tuple of (before, after) strings
+
+    Raises:
+        ValueError: If target character not found outside quotes
+
+    Examples:
+        >>> split_at_unquoted_char('key: value', ':')
+        ('key', ' value')
+        >>> split_at_unquoted_char('"key:1": value', ':')
+        ('"key:1"', ' value')
+    """
+    idx = find_unquoted_char(line, target_char)
+    if idx == -1:
+        raise ValueError(f"Character '{target_char}' not found outside quotes")
+    return (line[:idx], line[idx + 1 :])
+
+
+def find_first_unquoted(line: str, chars: List[str], start: int = 0) -> Tuple[int, str]:
+    """Find the first occurrence of any character in chars, outside quotes.
+
+    Args:
+        line: Line to search
+        chars: List of characters to search for
+        start: Starting position (default: 0)
+
+    Returns:
+        Tuple of (index, character) for first match, or (-1, '') if none found
+
+    Examples:
+        >>> find_first_unquoted('a:b,c', [':', ','])
+        (1, ':')
+        >>> find_first_unquoted('a"b:c",d', [':', ','])
+        (7, ',')
+    """
+    char_set = set(chars)
+    for i, char, is_quoted in iter_unquoted(line, start):
+        if char in char_set and not is_quoted:
+            return (i, char)
+    return (-1, "")

--- a/src/servicenow_mcp/_vendor/toon_format/_scanner.py
+++ b/src/servicenow_mcp/_vendor/toon_format/_scanner.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Scanner for parsing TOON input into lines with depth information.
+
+This module implements the first stage of the TOON decoding pipeline:
+scanning the input text and converting it into structured line objects
+with depth and indentation metadata. Handles strict and lenient parsing modes.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from .constants import SPACE, TAB
+
+
+@dataclass
+class ParsedLine:
+    """A parsed line with metadata.
+
+    Attributes:
+        raw: The original raw line content
+        depth: The indentation depth (number of indent levels)
+        indent: The number of leading spaces
+        content: The line content after removing indentation
+        line_num: The 1-based line number in the source
+    """
+
+    raw: str
+    depth: int
+    indent: int
+    content: str
+    line_num: int
+
+    @property
+    def is_blank(self) -> bool:
+        """Check if this line is blank (only whitespace).
+
+        Returns:
+            True if the line contains only whitespace
+        """
+        return not self.content.strip()
+
+
+@dataclass
+class BlankLineInfo:
+    """Information about a blank line.
+
+    Attributes:
+        line_num: The 1-based line number
+        indent: The number of leading spaces
+        depth: The computed indentation depth
+    """
+
+    line_num: int
+    indent: int
+    depth: int
+
+
+class LineCursor:
+    """Iterator-like class for traversing parsed lines.
+
+    Provides methods to peek at the current line, advance to the next line,
+    and check for lines at specific depths. This abstraction makes the decoder
+    logic cleaner and easier to test.
+    """
+
+    def __init__(
+        self,
+        lines: List[ParsedLine],
+        blank_lines: Optional[List[BlankLineInfo]] = None,
+    ) -> None:
+        """Initialize a line cursor.
+
+        Args:
+            lines: The parsed lines to traverse
+            blank_lines: Optional list of blank line information
+        """
+        self._lines = lines
+        self._index = 0
+        self._blank_lines = blank_lines or []
+
+    def get_blank_lines(self) -> List[BlankLineInfo]:
+        """Get the list of blank lines."""
+        return self._blank_lines
+
+    def peek(self) -> Optional[ParsedLine]:
+        """Peek at the current line without advancing.
+
+        Returns:
+            The current line, or None if at end
+        """
+        if self._index >= len(self._lines):
+            return None
+        return self._lines[self._index]
+
+    def next(self) -> Optional[ParsedLine]:
+        """Get the current line and advance.
+
+        Returns:
+            The current line, or None if at end
+        """
+        if self._index >= len(self._lines):
+            return None
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+    def current(self) -> Optional[ParsedLine]:
+        """Get the most recently consumed line.
+
+        Returns:
+            The previous line, or None if no line has been consumed
+        """
+        if self._index > 0:
+            return self._lines[self._index - 1]
+        return None
+
+    def advance(self) -> None:
+        """Advance to the next line."""
+        self._index += 1
+
+    def at_end(self) -> bool:
+        """Check if cursor is at the end of lines.
+
+        Returns:
+            True if at end
+        """
+        return self._index >= len(self._lines)
+
+    @property
+    def length(self) -> int:
+        """Get the total number of lines."""
+        return len(self._lines)
+
+    def peek_at_depth(self, target_depth: int) -> Optional[ParsedLine]:
+        """Peek at the next line at a specific depth.
+
+        Args:
+            target_depth: The target depth
+
+        Returns:
+            The line if it matches the depth, None otherwise
+        """
+        line = self.peek()
+        if not line or line.depth < target_depth:
+            return None
+        if line.depth == target_depth:
+            return line
+        return None
+
+    def has_more_at_depth(self, target_depth: int) -> bool:
+        """Check if there are more lines at a specific depth.
+
+        Args:
+            target_depth: The target depth
+
+        Returns:
+            True if there are more lines at the target depth
+        """
+        return self.peek_at_depth(target_depth) is not None
+
+    def skip_deeper_than(self, depth: int) -> None:
+        """Skip all lines that are deeper than the given depth.
+
+        This is useful for skipping over nested structures after processing them.
+
+        Args:
+            depth: The reference depth. All lines with depth > this will be skipped.
+
+        Example:
+            >>> cursor.skip_deeper_than(1)  # Skip all lines at depth 2, 3, 4, etc.
+        """
+        line = self.peek()
+        while line and line.depth > depth:
+            self.advance()
+            line = self.peek()
+
+
+def to_parsed_lines(
+    source: str,
+    indent_size: int,
+    strict: bool,
+) -> Tuple[List[ParsedLine], List[BlankLineInfo]]:
+    """Convert source string to parsed lines with depth information.
+
+    Per Section 12 of the TOON specification for indentation handling.
+    This is the entry point for the scanning stage of the decoder pipeline.
+
+    Args:
+        source: The source string to parse
+        indent_size: The number of spaces per indentation level
+        strict: Whether to enforce strict indentation validation
+
+    Returns:
+        A tuple of (parsed_lines, blank_lines)
+
+    Raises:
+        SyntaxError: If strict mode validation fails (tabs in indentation, invalid spacing)
+
+    Examples:
+        >>> lines, blanks = to_parsed_lines("name: Alice\\n  age: 30", 2, True)
+        >>> lines[0].content
+        'name: Alice'
+        >>> lines[1].depth
+        1
+    """
+    if not source.strip():
+        return [], []
+
+    lines = source.split("\n")
+    parsed: List[ParsedLine] = []
+    blank_lines: List[BlankLineInfo] = []
+
+    for i, raw in enumerate(lines):
+        line_num = i + 1
+        indent = 0
+        while indent < len(raw) and raw[indent] == SPACE:
+            indent += 1
+
+        content = raw[indent:]
+
+        # Compute depth for both blank and non-blank lines
+        depth = _compute_depth_from_indent(indent, indent_size)
+
+        # Track blank lines (but still include them in parsed list for validation)
+        is_blank = not content.strip()
+        if is_blank:
+            blank_lines.append(
+                BlankLineInfo(
+                    line_num=line_num,
+                    indent=indent,
+                    depth=depth,
+                )
+            )
+            # Blank lines are not validated for indentation
+            # But we still add them to parsed list for array blank line detection
+
+        # Strict mode validation (skip for blank lines)
+        if strict and not is_blank:
+            # Find the full leading whitespace region (spaces and tabs)
+            ws_end = 0
+            while ws_end < len(raw) and (raw[ws_end] == SPACE or raw[ws_end] == TAB):
+                ws_end += 1
+
+            # Check for tabs in leading whitespace (before actual content)
+            if TAB in raw[:ws_end]:
+                raise SyntaxError(
+                    f"Line {line_num}: Tabs not allowed in indentation in strict mode"
+                )
+
+            # Check for exact multiples of indent_size
+            if indent > 0 and indent % indent_size != 0:
+                raise SyntaxError(
+                    f"Line {line_num}: Indent must be exact multiple of {indent_size}, "
+                    f"but found {indent} spaces"
+                )
+
+        parsed.append(
+            ParsedLine(
+                raw=raw,
+                indent=indent,
+                content=content,
+                depth=depth,
+                line_num=line_num,
+            )
+        )
+
+    return parsed, blank_lines
+
+
+def _compute_depth_from_indent(indent_spaces: int, indent_size: int) -> int:
+    """Compute depth from indentation spaces.
+
+    Args:
+        indent_spaces: Number of leading spaces
+        indent_size: Number of spaces per indentation level
+
+    Returns:
+        The computed depth
+
+    Examples:
+        >>> _compute_depth_from_indent(0, 2)
+        0
+        >>> _compute_depth_from_indent(4, 2)
+        2
+        >>> _compute_depth_from_indent(3, 2)  # Lenient mode
+        1
+    """
+    return indent_spaces // indent_size

--- a/src/servicenow_mcp/_vendor/toon_format/_string_utils.py
+++ b/src/servicenow_mcp/_vendor/toon_format/_string_utils.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""String utilities for TOON encoding and decoding.
+
+This module provides shared string processing functions used by both
+the encoder and decoder, following the TOON specification Section 7.1
+for escape sequences and quoted string handling.
+"""
+
+from .constants import (
+    BACKSLASH,
+    CARRIAGE_RETURN,
+    DOUBLE_QUOTE,
+    NEWLINE,
+    TAB,
+)
+
+
+def escape_string(value: str) -> str:
+    """Escape special characters in a string for encoding.
+
+    Handles backslashes, quotes, newlines, carriage returns, and tabs.
+    Per Section 7.1 of the TOON specification.
+
+    Args:
+        value: The string to escape
+
+    Returns:
+        The escaped string
+
+    Examples:
+        >>> escape_string('hello\\nworld')
+        'hello\\\\nworld'
+        >>> escape_string('say "hello"')
+        'say \\\\"hello\\\\"'
+    """
+    return (
+        value.replace(BACKSLASH, BACKSLASH + BACKSLASH)
+        .replace(DOUBLE_QUOTE, BACKSLASH + DOUBLE_QUOTE)
+        .replace(NEWLINE, BACKSLASH + "n")
+        .replace(CARRIAGE_RETURN, BACKSLASH + "r")
+        .replace(TAB, BACKSLASH + "t")
+    )
+
+
+def unescape_string(value: str) -> str:
+    """Unescape a string by processing escape sequences.
+
+    Handles `\\n`, `\\t`, `\\r`, `\\\\`, and `\\"` escape sequences.
+    Per Section 7.1 of the TOON specification.
+
+    Args:
+        value: The string to unescape (without surrounding quotes)
+
+    Returns:
+        The unescaped string
+
+    Raises:
+        ValueError: If an invalid escape sequence is encountered
+
+    Examples:
+        >>> unescape_string('hello\\\\nworld')
+        'hello\\nworld'
+        >>> unescape_string('say \\\\"hello\\\\"')
+        'say "hello"'
+    """
+    result = ""
+    i = 0
+
+    while i < len(value):
+        if value[i] == BACKSLASH:
+            if i + 1 >= len(value):
+                raise ValueError("Invalid escape sequence: backslash at end of string")
+
+            next_char = value[i + 1]
+            if next_char == "n":
+                result += NEWLINE
+                i += 2
+                continue
+            if next_char == "t":
+                result += TAB
+                i += 2
+                continue
+            if next_char == "r":
+                result += CARRIAGE_RETURN
+                i += 2
+                continue
+            if next_char == BACKSLASH:
+                result += BACKSLASH
+                i += 2
+                continue
+            if next_char == DOUBLE_QUOTE:
+                result += DOUBLE_QUOTE
+                i += 2
+                continue
+
+            raise ValueError(f"Invalid escape sequence: \\{next_char}")
+
+        result += value[i]
+        i += 1
+
+    return result
+
+
+def find_closing_quote(content: str, start: int) -> int:
+    """Find the index of the closing double quote, accounting for escape sequences.
+
+    Args:
+        content: The string to search in
+        start: The index of the opening quote
+
+    Returns:
+        The index of the closing quote, or -1 if not found
+
+    Examples:
+        >>> find_closing_quote('"hello"', 0)
+        6
+        >>> find_closing_quote('"hello \\\\"world\\\\""', 0)
+        17
+    """
+    i = start + 1
+    while i < len(content):
+        if content[i] == BACKSLASH and i + 1 < len(content):
+            # Skip escaped character
+            i += 2
+            continue
+        if content[i] == DOUBLE_QUOTE:
+            return i
+        i += 1
+    return -1  # Not found
+
+
+def find_unquoted_char(content: str, char: str, start: int = 0) -> int:
+    """Find the index of a specific character outside of quoted sections.
+
+    Args:
+        content: The string to search in
+        char: The character to look for
+        start: Optional starting index (defaults to 0)
+
+    Returns:
+        The index of the character, or -1 if not found outside quotes
+
+    Examples:
+        >>> find_unquoted_char('key: "value: nested"', ':', 0)
+        3
+        >>> find_unquoted_char('"key: nested": value', ':', 0)
+        13
+    """
+    in_quotes = False
+    i = start
+
+    while i < len(content):
+        if content[i] == BACKSLASH and i + 1 < len(content) and in_quotes:
+            # Skip escaped character
+            i += 2
+            continue
+
+        if content[i] == DOUBLE_QUOTE:
+            in_quotes = not in_quotes
+            i += 1
+            continue
+
+        if content[i] == char and not in_quotes:
+            return i
+
+        i += 1
+
+    return -1

--- a/src/servicenow_mcp/_vendor/toon_format/_validation.py
+++ b/src/servicenow_mcp/_vendor/toon_format/_validation.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Validation utilities for TOON encoding.
+
+This module provides validation functions to determine whether strings,
+keys, and values can be safely encoded without quotes or need quoting
+according to TOON specification rules.
+"""
+
+import re
+
+from ._literal_utils import is_boolean_or_null_literal
+from .constants import (
+    COMMA,
+    LIST_ITEM_MARKER,
+    NUMERIC_REGEX,
+    OCTAL_REGEX,
+    VALID_KEY_REGEX,
+)
+
+
+def is_valid_unquoted_key(key: str) -> bool:
+    """Check if a key can be used without quotes.
+
+    Valid unquoted keys must start with a letter or underscore,
+    followed by letters, digits, underscores, or dots.
+    Per Section 8.2 of the TOON specification.
+
+    Args:
+        key: The key to validate
+
+    Returns:
+        True if the key can be used without quotes
+
+    Examples:
+        >>> is_valid_unquoted_key("name")
+        True
+        >>> is_valid_unquoted_key("user_id")
+        True
+        >>> is_valid_unquoted_key("config.value")
+        True
+        >>> is_valid_unquoted_key("123")  # Starts with digit
+        False
+        >>> is_valid_unquoted_key("my-key")  # Contains hyphen
+        False
+    """
+    if not key:
+        return False
+    return bool(re.match(VALID_KEY_REGEX, key, re.IGNORECASE))
+
+
+def is_safe_unquoted(value: str, delimiter: str = COMMA) -> bool:
+    """Determine if a string value can be safely encoded without quotes.
+
+    A string needs quoting if it:
+    - Is empty
+    - Has leading or trailing whitespace
+    - Could be confused with a literal (boolean, null, number)
+    - Contains structural characters (colons, brackets, braces)
+    - Contains quotes or backslashes (need escaping)
+    - Contains control characters (newlines, tabs, etc.)
+    - Contains the active delimiter
+    - Starts with a list marker (hyphen)
+
+    Per Section 7.2 of the TOON specification.
+
+    Args:
+        value: The string value to check
+        delimiter: The active delimiter (default: comma)
+
+    Returns:
+        True if the string can be safely encoded without quotes
+
+    Examples:
+        >>> is_safe_unquoted("hello")
+        True
+        >>> is_safe_unquoted("")  # Empty
+        False
+        >>> is_safe_unquoted("true")  # Reserved literal
+        False
+        >>> is_safe_unquoted("123")  # Looks like number
+        False
+        >>> is_safe_unquoted("hello world")  # Has whitespace (but not leading/trailing)
+        True
+    """
+    if not value:
+        return False
+
+    if value != value.strip():
+        return False
+
+    # Check if it looks like any literal value (boolean, null, or numeric)
+    if is_boolean_or_null_literal(value) or is_numeric_like(value):
+        return False
+
+    # Check for colon (always structural)
+    if ":" in value:
+        return False
+
+    # Check for quotes and backslash (always need escaping)
+    if '"' in value or "\\" in value:
+        return False
+
+    # Check for brackets and braces (always structural)
+    if re.search(r"[\[\]{}]", value):
+        return False
+
+    # Check for control characters (newline, carriage return, tab)
+    if re.search(r"[\n\r\t]", value):
+        return False
+
+    # Check for the active delimiter
+    if delimiter in value:
+        return False
+
+    # Check for hyphen at start (list marker)
+    if value.startswith(LIST_ITEM_MARKER):
+        return False
+
+    return True
+
+
+def is_numeric_like(value: str) -> bool:
+    """Check if a string looks like a number.
+
+    Match numbers like `42`, `-3.14`, `1e-6`, `05`, etc.
+    Includes octal-like numbers (leading zero) which must be quoted.
+
+    Args:
+        value: The string to check
+
+    Returns:
+        True if the string looks like a number
+
+    Examples:
+        >>> is_numeric_like("42")
+        True
+        >>> is_numeric_like("-3.14")
+        True
+        >>> is_numeric_like("1e-6")
+        True
+        >>> is_numeric_like("0123")  # Octal-like
+        True
+        >>> is_numeric_like("hello")
+        False
+    """
+    return bool(
+        re.match(NUMERIC_REGEX, value, re.IGNORECASE)
+        or re.match(OCTAL_REGEX, value)  # Octal pattern
+    )

--- a/src/servicenow_mcp/_vendor/toon_format/cli.py
+++ b/src/servicenow_mcp/_vendor/toon_format/cli.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Command-line interface for TOON encoding/decoding.
+
+Provides the `toon` command-line tool for converting between JSON and TOON formats.
+Supports auto-detection based on file extensions and content, with options for
+delimiters, indentation, and validation modes.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import decode, encode
+from .types import DecodeOptions, EncodeOptions
+
+
+def main() -> int:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="toon",
+        description="Convert between JSON and TOON formats",
+    )
+
+    parser.add_argument(
+        "input",
+        type=str,
+        help="Input file path (or - for stdin)",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Output file path (prints to stdout if omitted)",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--encode",
+        action="store_true",
+        help="Force encode mode (overrides auto-detection)",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--decode",
+        action="store_true",
+        help="Force decode mode (overrides auto-detection)",
+    )
+
+    parser.add_argument(
+        "--delimiter",
+        type=str,
+        choices=[",", "\t", "|"],
+        default=",",
+        help='Array delimiter: , (comma), \\t (tab), | (pipe) (default: ",")',
+    )
+
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Indentation size (default: 2)",
+    )
+
+    parser.add_argument(
+        "--length-marker",
+        action="store_true",
+        help="Add # prefix to array lengths (e.g., items[#3])",
+    )
+
+    parser.add_argument(
+        "--no-strict",
+        action="store_true",
+        help="Disable strict validation when decoding",
+    )
+
+    args = parser.parse_args()
+
+    # Read input
+    try:
+        if args.input == "-":
+            input_text = sys.stdin.read()
+            input_path = None
+        else:
+            input_path = Path(args.input)
+            if not input_path.exists():
+                print(f"Error: Input file not found: {args.input}", file=sys.stderr)
+                return 1
+            input_text = input_path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"Error reading input: {e}", file=sys.stderr)
+        return 1
+
+    # Determine operation mode
+    if args.encode and args.decode:
+        print("Error: Cannot specify both --encode and --decode", file=sys.stderr)
+        return 1
+
+    if args.encode:
+        mode = "encode"
+    elif args.decode:
+        mode = "decode"
+    else:
+        # Auto-detect based on file extension
+        if input_path:
+            if input_path.suffix.lower() == ".json":
+                mode = "encode"
+            elif input_path.suffix.lower() == ".toon":
+                mode = "decode"
+            else:
+                # Try to detect by content
+                try:
+                    json.loads(input_text)
+                    mode = "encode"
+                except json.JSONDecodeError:
+                    mode = "decode"
+        else:
+            # No file path, try to detect by content
+            try:
+                json.loads(input_text)
+                mode = "encode"
+            except json.JSONDecodeError:
+                mode = "decode"
+
+    # Process
+    try:
+        if mode == "encode":
+            output_text = encode_json_to_toon(
+                input_text,
+                delimiter=args.delimiter,
+                indent=args.indent,
+                length_marker=args.length_marker,
+            )
+        else:
+            output_text = decode_toon_to_json(
+                input_text,
+                indent=args.indent,
+                strict=not args.no_strict,
+            )
+    except Exception as e:
+        print(f"Error during {mode}: {e}", file=sys.stderr)
+        return 1
+
+    # Write output
+    try:
+        if args.output:
+            output_path = Path(args.output)
+            output_path.write_text(output_text, encoding="utf-8")
+        else:
+            print(output_text)
+    except Exception as e:
+        print(f"Error writing output: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def encode_json_to_toon(
+    json_text: str,
+    delimiter: str = ",",
+    indent: int = 2,
+    length_marker: bool = False,
+) -> str:
+    """Encode JSON text to TOON format.
+
+    Args:
+        json_text: JSON input string
+        delimiter: Delimiter character
+        indent: Indentation size
+        length_marker: Whether to add # prefix
+
+    Returns:
+        TOON-formatted string
+
+    Raises:
+        json.JSONDecodeError: If JSON is invalid
+    """
+    data = json.loads(json_text)
+
+    options: EncodeOptions = {
+        "indent": indent,
+        "delimiter": delimiter,
+        "lengthMarker": "#" if length_marker else False,
+    }
+
+    return encode(data, options)
+
+
+def decode_toon_to_json(
+    toon_text: str,
+    indent: int = 2,
+    strict: bool = True,
+) -> str:
+    """Decode TOON text to JSON format.
+
+    Args:
+        toon_text: TOON input string
+        indent: Indentation size
+        strict: Whether to use strict validation
+
+    Returns:
+        JSON-formatted string
+
+    Raises:
+        ToonDecodeError: If TOON is invalid
+    """
+    options = DecodeOptions(indent=indent, strict=strict)
+    data = decode(toon_text, options)
+
+    return json.dumps(data, indent=indent, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/servicenow_mcp/_vendor/toon_format/constants.py
+++ b/src/servicenow_mcp/_vendor/toon_format/constants.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Constants for TOON format encoding and decoding.
+
+Defines all string literals, characters, and configuration values used throughout
+the TOON implementation. Centralizes magic values for maintainability.
+"""
+
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from .types import Delimiter
+
+# region List markers
+LIST_ITEM_MARKER = "-"
+LIST_ITEM_PREFIX = "- "
+# endregion
+
+# region Structural characters
+COMMA: "Delimiter" = ","
+COLON = ":"
+SPACE = " "
+PIPE: "Delimiter" = "|"
+# endregion
+
+# region Brackets and braces
+OPEN_BRACKET = "["
+CLOSE_BRACKET = "]"
+OPEN_BRACE = "{"
+CLOSE_BRACE = "}"
+# endregion
+
+# region Literals
+NULL_LITERAL = "null"
+TRUE_LITERAL = "true"
+FALSE_LITERAL = "false"
+# endregion
+
+# region Escape characters
+BACKSLASH = "\\"
+DOUBLE_QUOTE = '"'
+NEWLINE = "\n"
+CARRIAGE_RETURN = "\r"
+TAB: "Delimiter" = "\t"
+# endregion
+
+# region Delimiters
+DELIMITERS: Dict[str, "Delimiter"] = {
+    "comma": COMMA,
+    "tab": TAB,
+    "pipe": PIPE,
+}
+
+DEFAULT_DELIMITER: "Delimiter" = DELIMITERS["comma"]
+# endregion
+
+# region Regex patterns
+# Pattern strings are compiled in modules that use them
+STRUCTURAL_CHARS_REGEX = r"[\[\]{}]"
+CONTROL_CHARS_REGEX = r"[\n\r\t]"
+NUMERIC_REGEX = r"^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$"
+OCTAL_REGEX = r"^0\d+$"
+VALID_KEY_REGEX = r"^[A-Z_][\w.]*$"
+HEADER_LENGTH_REGEX = r"^#?(\d+)([\|\t])?$"
+INTEGER_REGEX = r"^-?\d+$"
+# endregion
+
+# region Escape sequence maps
+ESCAPE_SEQUENCES = {
+    BACKSLASH: "\\\\",
+    DOUBLE_QUOTE: '\\"',
+    NEWLINE: "\\n",
+    CARRIAGE_RETURN: "\\r",
+    TAB: "\\t",
+}
+
+UNESCAPE_SEQUENCES = {
+    "n": NEWLINE,
+    "r": CARRIAGE_RETURN,
+    "t": TAB,
+    "\\": BACKSLASH,
+    '"': DOUBLE_QUOTE,
+}
+# endregion

--- a/src/servicenow_mcp/_vendor/toon_format/decoder.py
+++ b/src/servicenow_mcp/_vendor/toon_format/decoder.py
@@ -1,0 +1,788 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""TOON decoder implementation following v1.3 spec.
+
+This module provides the main `decode()` function and ToonDecodeError exception
+for converting TOON format strings back to Python values. Supports strict and
+lenient parsing modes, handles all TOON syntax forms (objects, arrays, primitives),
+and validates array lengths and delimiters.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from ._literal_utils import is_boolean_or_null_literal, is_numeric_literal
+from ._parsing_utils import (
+    find_first_unquoted,
+    find_unquoted_char,
+    parse_delimited_values,
+)
+from ._scanner import ParsedLine, to_parsed_lines
+from ._string_utils import unescape_string as _unescape_string
+from .constants import (
+    CLOSE_BRACE,
+    CLOSE_BRACKET,
+    COLON,
+    COMMA,
+    DOUBLE_QUOTE,
+    FALSE_LITERAL,
+    LIST_ITEM_MARKER,
+    OPEN_BRACE,
+    OPEN_BRACKET,
+    PIPE,
+    TAB,
+    TRUE_LITERAL,
+)
+from .types import DecodeOptions, JsonValue
+
+
+class ToonDecodeError(Exception):
+    """TOON decoding error."""
+
+    pass
+
+
+def unescape_string(value: str) -> str:
+    """Unescape a quoted string.
+
+    Args:
+        value: Escaped string (without surrounding quotes)
+
+    Returns:
+        Unescaped string
+
+    Raises:
+        ToonDecodeError: If escape sequence is invalid
+    """
+    try:
+        return _unescape_string(value)
+    except ValueError as e:
+        raise ToonDecodeError(str(e)) from e
+
+
+def parse_primitive(token: str) -> JsonValue:
+    """Parse a primitive token.
+
+    Args:
+        token: Token string
+
+    Returns:
+        Parsed value
+
+    Raises:
+        ToonDecodeError: If quoted string is malformed
+    """
+    token = token.strip()
+
+    # Quoted string
+    if token.startswith(DOUBLE_QUOTE):
+        if not token.endswith(DOUBLE_QUOTE) or len(token) < 2:
+            raise ToonDecodeError("Unterminated string: missing closing quote")
+        return unescape_string(token[1:-1])
+
+    # Boolean and null literals
+    if is_boolean_or_null_literal(token):
+        if token == TRUE_LITERAL:
+            return True
+        if token == FALSE_LITERAL:
+            return False
+        return None  # NULL_LITERAL
+
+    # Try to parse as number using utility function
+    if token and is_numeric_literal(token):
+        try:
+            # Try int first
+            if "." not in token and "e" not in token.lower():
+                return int(token)
+            # Then float
+            return float(token)
+        except ValueError:
+            pass
+
+    # Otherwise it's an unquoted string (including octal-like "0123")
+    return token
+
+
+def parse_header(
+    line: str,
+) -> Optional[Tuple[Optional[str], int, str, Optional[List[str]]]]:
+    """Parse an array header.
+
+    Args:
+        line: Line content
+
+    Returns:
+        Tuple of (key, length, delimiter, fields) or None if not a header
+
+    Raises:
+        ToonDecodeError: If header is malformed
+    """
+    line = line.strip()
+
+    # Find the bracket segment (respecting quoted strings)
+    bracket_start = find_unquoted_char(line, OPEN_BRACKET)
+    if bracket_start == -1:
+        return None
+
+    # Extract key (if any)
+    key = None
+    if bracket_start > 0:
+        key_part = line[:bracket_start].strip()
+        key = parse_key(key_part) if key_part else None
+
+    # Find closing bracket
+    bracket_end = find_unquoted_char(line, CLOSE_BRACKET, bracket_start)
+    if bracket_end == -1:
+        return None
+
+    # Parse bracket content: [#?N<delim?>]
+    bracket_content = line[bracket_start + 1 : bracket_end]
+
+    # Remove optional # marker
+    if bracket_content.startswith("#"):
+        bracket_content = bracket_content[1:]
+
+    # Determine delimiter from bracket content
+    delimiter = COMMA  # default
+    length_str = bracket_content
+
+    if bracket_content.endswith(TAB):
+        delimiter = TAB
+        length_str = bracket_content[:-1]
+    elif bracket_content.endswith(PIPE):
+        delimiter = PIPE
+        length_str = bracket_content[:-1]
+    elif bracket_content.endswith(COMMA):
+        # Explicit comma delimiter (for tabular arrays)
+        delimiter = COMMA
+        length_str = bracket_content[:-1]
+
+    # Parse length
+    try:
+        length = int(length_str)
+    except ValueError:
+        return None
+
+    # Check for fields segment
+    fields = None
+    after_bracket = line[bracket_end + 1 :].strip()
+
+    if after_bracket.startswith(OPEN_BRACE):
+        brace_end = find_unquoted_char(after_bracket, CLOSE_BRACE)
+        if brace_end == -1:
+            raise ToonDecodeError("Unterminated fields segment")
+
+        fields_content = after_bracket[1:brace_end]
+        # Parse fields using the delimiter
+        field_tokens = parse_delimited_values(fields_content, delimiter)
+        fields = [parse_key(f.strip()) for f in field_tokens]
+
+        after_bracket = after_bracket[brace_end + 1 :].strip()
+
+    # Must end with colon
+    if not after_bracket.startswith(COLON):
+        return None
+
+    return (key, length, delimiter, fields)
+
+
+def parse_key(key_str: str) -> str:
+    """Parse a key (quoted or unquoted).
+
+    Args:
+        key_str: Key string
+
+    Returns:
+        Parsed key
+
+    Raises:
+        ToonDecodeError: If quoted key is malformed
+    """
+    key_str = key_str.strip()
+
+    if key_str.startswith(DOUBLE_QUOTE):
+        if not key_str.endswith(DOUBLE_QUOTE) or len(key_str) < 2:
+            raise ToonDecodeError("Unterminated quoted key")
+        return unescape_string(key_str[1:-1])
+
+    return key_str
+
+
+def split_key_value(line: str) -> Tuple[str, str]:
+    """Split a line into key and value at first unquoted colon.
+
+    Args:
+        line: Line content
+
+    Returns:
+        Tuple of (key, value)
+
+    Raises:
+        ToonDecodeError: If no colon found
+    """
+    colon_idx = find_unquoted_char(line, COLON)
+    if colon_idx == -1:
+        raise ToonDecodeError("Missing colon after key")
+
+    key = line[:colon_idx].strip()
+    value = line[colon_idx + 1 :].strip()
+    return (key, value)
+
+
+def decode(input_str: str, options: Optional[DecodeOptions] = None) -> JsonValue:
+    """Decode a TOON-formatted string to a Python value.
+
+    Args:
+        input_str: TOON-formatted string
+        options: Optional decoding options
+
+    Returns:
+        Decoded Python value
+
+    Raises:
+        ToonDecodeError: If input is malformed
+    """
+    if options is None:
+        options = DecodeOptions()
+
+    indent_size = options.indent
+    strict = options.strict
+
+    # Parse lines using scanner module
+    try:
+        parsed_lines, blank_lines_info = to_parsed_lines(input_str, indent_size, strict)
+    except SyntaxError as e:
+        # Convert scanner's SyntaxError to ToonDecodeError
+        raise ToonDecodeError(str(e)) from e
+
+    # Convert ParsedLine to have stripped content (decoder expects stripped)
+    # Note: ParsedLine.content keeps whitespace after indent removal, but decoder needs stripped
+    lines: List[ParsedLine] = [
+        ParsedLine(
+            raw=line.raw,
+            depth=line.depth,
+            indent=line.indent,
+            content=line.content.strip(),
+            line_num=line.line_num,
+        )
+        for line in parsed_lines
+    ]
+
+    # Remove blank lines outside arrays (Section 12)
+    # For simplicity, we'll handle this during parsing
+
+    # Check for empty input (per spec Section 8: empty/whitespace-only → empty object)
+    non_blank_lines = [ln for ln in lines if not ln.is_blank]
+    if not non_blank_lines:
+        return {}
+
+    # Determine root form (Section 5)
+    first_line = non_blank_lines[0]
+
+    # Check if it's a root array header
+    header_info = parse_header(first_line.content)
+    if header_info is not None and header_info[0] is None:  # No key = root array
+        # Root array
+        return decode_array(lines, 0, 0, header_info, strict)
+
+    # Check if it's a single primitive
+    if len(non_blank_lines) == 1:
+        line_content = first_line.content
+        # Check if it's not a key-value line
+        try:
+            split_key_value(line_content)
+            # It's a key-value, so root object
+        except ToonDecodeError:
+            # Not a key-value, check if it's a header
+            if header_info is None:
+                # Single primitive
+                return parse_primitive(line_content)
+
+    # Otherwise, root object
+    return decode_object(lines, 0, 0, strict)
+
+
+def decode_object(
+    lines: List[ParsedLine], start_idx: int, parent_depth: int, strict: bool
+) -> Dict[str, Any]:
+    """Decode an object starting at given line index.
+
+    Args:
+        lines: List of lines
+        start_idx: Starting line index
+        parent_depth: Parent indentation depth
+        strict: Strict mode flag
+
+    Returns:
+        Decoded object
+    """
+    result: Dict[str, Any] = {}
+    i = start_idx
+    expected_depth = parent_depth if start_idx == 0 else parent_depth + 1
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Skip blank lines outside arrays (allowed)
+        if line.is_blank:
+            i += 1
+            continue
+
+        # Stop if we've dedented below expected depth
+        if line.depth < expected_depth:
+            break
+
+        # Skip lines that are too deeply indented (they belong to nested structures)
+        if line.depth > expected_depth:
+            i += 1
+            continue
+
+        content = line.content
+
+        # Check for array header
+        header_info = parse_header(content)
+        if header_info is not None:
+            key, length, delimiter, fields = header_info
+            if key is not None:
+                # Array field
+                array_val, next_i = decode_array_from_header(
+                    lines, i, line.depth, header_info, strict
+                )
+                result[key] = array_val
+                i = next_i
+                continue
+
+        # Must be a key-value line
+        try:
+            key_str, value_str = split_key_value(content)
+        except ToonDecodeError:
+            # Invalid line, skip in non-strict mode
+            if strict:
+                raise
+            i += 1
+            continue
+
+        key = parse_key(key_str)
+
+        # Check if value is empty (nested object)
+        if not value_str:
+            # Nested object
+            result[key] = decode_object(lines, i + 1, line.depth, strict)
+            # Skip past nested object
+            i += 1
+            while i < len(lines) and lines[i].depth > line.depth:
+                i += 1
+        else:
+            # Primitive value
+            result[key] = parse_primitive(value_str)
+            i += 1
+
+    return result
+
+
+def decode_array_from_header(
+    lines: List[ParsedLine],
+    header_idx: int,
+    header_depth: int,
+    header_info: Tuple[Optional[str], int, str, Optional[List[str]]],
+    strict: bool,
+) -> Tuple[List[Any], int]:
+    """Decode array starting from a header line.
+
+    Args:
+        lines: List of lines
+        header_idx: Index of header line
+        header_depth: Depth of header line
+        header_info: Parsed header info
+        strict: Strict mode flag
+
+    Returns:
+        Tuple of (decoded array, next line index)
+    """
+    key, length, delimiter, fields = header_info
+    header_line = lines[header_idx].content
+
+    # Check if there's inline content after the colon
+    # Use split_key_value to find the colon position (respects quoted strings)
+    try:
+        _, inline_content = split_key_value(header_line)
+    except ToonDecodeError:
+        # No colon found (shouldn't happen with valid headers)
+        inline_content = ""
+
+    # Inline primitive array (can be empty if length is 0)
+    if inline_content or (not fields and length == 0):
+        # Inline primitive array (handles empty arrays like [0]:)
+        return (
+            decode_inline_array(inline_content, delimiter, length, strict),
+            header_idx + 1,
+        )
+
+    # Non-inline array
+    if fields is not None:
+        # Tabular array
+        return decode_tabular_array(
+            lines, header_idx + 1, header_depth, fields, delimiter, length, strict
+        )
+    else:
+        # List format (mixed/non-uniform)
+        return decode_list_array(lines, header_idx + 1, header_depth, delimiter, length, strict)
+
+
+def decode_array(
+    lines: List[ParsedLine],
+    start_idx: int,
+    parent_depth: int,
+    header_info: Tuple[Optional[str], int, str, Optional[List[str]]],
+    strict: bool,
+) -> List[Any]:
+    """Decode array (convenience wrapper).
+
+    Args:
+        lines: List of lines
+        start_idx: Starting line index
+        parent_depth: Parent depth
+        header_info: Header info
+        strict: Strict mode
+
+    Returns:
+        Decoded array
+    """
+    arr, _ = decode_array_from_header(lines, start_idx, parent_depth, header_info, strict)
+    return arr
+
+
+def decode_inline_array(
+    content: str, delimiter: str, expected_length: int, strict: bool
+) -> List[Any]:
+    """Decode an inline primitive array.
+
+    Args:
+        content: Inline content after colon
+        delimiter: Active delimiter
+        expected_length: Expected array length
+        strict: Strict mode flag
+
+    Returns:
+        Decoded array
+
+    Raises:
+        ToonDecodeError: If length mismatch in strict mode
+    """
+    if not content and expected_length == 0:
+        return []
+
+    tokens = parse_delimited_values(content, delimiter)
+    values = [parse_primitive(token) for token in tokens]
+
+    if strict and len(values) != expected_length:
+        raise ToonDecodeError(f"Expected {expected_length} values, but got {len(values)}")
+
+    return values
+
+
+def decode_tabular_array(
+    lines: List[ParsedLine],
+    start_idx: int,
+    header_depth: int,
+    fields: List[str],
+    delimiter: str,
+    expected_length: int,
+    strict: bool,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Decode a tabular array.
+
+    Args:
+        lines: List of lines
+        start_idx: Starting line index (after header)
+        header_depth: Depth of header
+        fields: Field names
+        delimiter: Active delimiter
+        expected_length: Expected number of rows
+        strict: Strict mode flag
+
+    Returns:
+        Tuple of (decoded array, next line index)
+
+    Raises:
+        ToonDecodeError: If row width or count mismatch in strict mode
+    """
+    result = []
+    i = start_idx
+    row_depth = header_depth + 1
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Handle blank lines
+        if line.is_blank:
+            if strict:
+                # In strict mode: blank lines at or above row depth are errors
+                # Blank lines dedented below row depth mean array has ended
+                if line.depth >= row_depth:
+                    raise ToonDecodeError("Blank lines not allowed inside arrays")
+                else:
+                    break
+            else:
+                # In non-strict mode: ignore all blank lines and continue
+                i += 1
+                continue
+
+        # Stop if dedented or different depth
+        if line.depth < row_depth:
+            break
+        if line.depth > row_depth:
+            # End of tabular rows (might be next key-value)
+            break
+
+        content = line.content
+
+        # Disambiguation: check if this is a row or a key-value line
+        # A row has no unquoted colon, or delimiter before colon
+        if is_row_line(content, delimiter):
+            # Parse as row
+            tokens = parse_delimited_values(content, delimiter)
+            values = [parse_primitive(token) for token in tokens]
+
+            if strict and len(values) != len(fields):
+                raise ToonDecodeError(
+                    f"Expected {len(fields)} values in row, but got {len(values)}"
+                )
+
+            obj = {fields[j]: values[j] for j in range(min(len(fields), len(values)))}
+            result.append(obj)
+            i += 1
+        else:
+            # Not a row, end of tabular data
+            break
+
+    if strict and len(result) != expected_length:
+        raise ToonDecodeError(f"Expected {expected_length} rows, but got {len(result)}")
+
+    return result, i
+
+
+def is_row_line(line: str, delimiter: str) -> bool:
+    """Check if a line is a tabular row (not a key-value line).
+
+    A line is a tabular row if:
+    - It has no unquoted colon, OR
+    - The first unquoted delimiter appears before the first unquoted colon
+
+    Args:
+        line: Line content
+        delimiter: Active delimiter
+
+    Returns:
+        True if it's a row line
+    """
+    # Find first occurrence of delimiter or colon (single pass optimization)
+    pos, char = find_first_unquoted(line, [delimiter, COLON])
+
+    # No special chars found -> row
+    if pos == -1:
+        return True
+
+    # First special char is delimiter -> row
+    # First special char is colon -> key-value
+    return char == delimiter
+
+
+def decode_list_array(
+    lines: List[ParsedLine],
+    start_idx: int,
+    header_depth: int,
+    delimiter: str,
+    expected_length: int,
+    strict: bool,
+) -> Tuple[List[Any], int]:
+    """Decode a list-format array (mixed/non-uniform).
+
+    Args:
+        lines: List of lines
+        start_idx: Starting line index
+        header_depth: Header depth
+        delimiter: Active delimiter
+        expected_length: Expected number of items
+        strict: Strict mode flag
+
+    Returns:
+        Tuple of (decoded array, next line index)
+
+    Raises:
+        ToonDecodeError: If item count mismatch in strict mode
+    """
+    result: List[Any] = []
+    i = start_idx
+    item_depth = header_depth + 1
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Handle blank lines
+        if line.is_blank:
+            if strict:
+                # In strict mode: blank lines at or above item depth are errors
+                # Blank lines dedented below item depth mean array has ended
+                if line.depth >= item_depth:
+                    raise ToonDecodeError("Blank lines not allowed inside arrays")
+                else:
+                    break
+            else:
+                # In non-strict mode: ignore all blank lines and continue
+                i += 1
+                continue
+
+        # Stop if dedented
+        if line.depth < item_depth:
+            break
+
+        # Must start with "- "
+        content = line.content
+        if not content.startswith(LIST_ITEM_MARKER):
+            # Not a list item, end of array
+            break
+
+        # Remove "- " prefix
+        item_content = content[len(LIST_ITEM_MARKER) :].strip()
+
+        # Check what kind of item this is
+        item_header = parse_header(item_content)
+        if item_header is not None:
+            # It's an array header: - [N]: ... or - key[N]: ...
+            key, length, item_delim, fields = item_header
+
+            if key is None:
+                # - [N]: inline array
+                colon_idx = item_content.find(COLON)
+                if colon_idx != -1:
+                    inline_part = item_content[colon_idx + 1 :].strip()
+                    # Inline primitive array (handles empty arrays like [0]:)
+                    if inline_part or length == 0:
+                        item_val = decode_inline_array(inline_part, item_delim, length, strict)
+                        result.append(item_val)
+                        i += 1
+                        continue
+            else:
+                # - key[N]: array field in object
+                # This is an object with an array as its first field
+                item_obj: Dict[str, Any] = {}
+                array_val, next_i = decode_array_from_header(
+                    lines, i, line.depth, item_header, strict
+                )
+                item_obj[key] = array_val
+
+                # Continue reading remaining fields at depth +1
+                i = next_i
+                while i < len(lines) and lines[i].depth == line.depth + 1:
+                    field_line = lines[i]
+                    if field_line.is_blank:
+                        i += 1
+                        continue
+
+                    field_content = field_line.content
+
+                    # Check for array header
+                    field_header = parse_header(field_content)
+                    if field_header is not None and field_header[0] is not None:
+                        field_key, field_length, field_delim, field_fields = field_header
+                        assert field_key is not None  # Already checked above
+                        field_val, next_i = decode_array_from_header(
+                            lines, i, field_line.depth, field_header, strict
+                        )
+                        item_obj[field_key] = field_val
+                        i = next_i
+                        continue
+
+                    try:
+                        field_key_str, field_value_str = split_key_value(field_content)
+                        field_key = parse_key(field_key_str)
+
+                        if not field_value_str:
+                            # Nested object
+                            item_obj[field_key] = decode_object(
+                                lines, i + 1, field_line.depth, strict
+                            )
+                            i += 1
+                            while i < len(lines) and lines[i].depth > field_line.depth:
+                                i += 1
+                        else:
+                            item_obj[field_key] = parse_primitive(field_value_str)
+                            i += 1
+                    except ToonDecodeError:
+                        break
+
+                result.append(item_obj)
+                continue
+
+        # Check if it's an object (has colon)
+        try:
+            key_str, value_str = split_key_value(item_content)
+            # It's an object item
+            obj_item: Dict[str, Any] = {}
+
+            # First field
+            key = parse_key(key_str)
+            if not value_str:
+                # First field is nested object: fields at depth +2
+                nested = decode_object(lines, i + 1, line.depth + 1, strict)
+                obj_item[key] = nested
+                # Skip nested content
+                i += 1
+                while i < len(lines) and lines[i].depth > line.depth + 1:
+                    i += 1
+            else:
+                # First field is primitive
+                obj_item[key] = parse_primitive(value_str)
+                i += 1
+
+            # Remaining fields at depth +1
+            while i < len(lines) and lines[i].depth == line.depth + 1:
+                field_line = lines[i]
+                if field_line.is_blank:
+                    i += 1
+                    continue
+
+                field_content = field_line.content
+
+                # Check for array header
+                field_header = parse_header(field_content)
+                if field_header is not None and field_header[0] is not None:
+                    field_key, field_length, field_delim, field_fields = field_header
+                    assert field_key is not None  # Already checked above
+                    field_val, next_i = decode_array_from_header(
+                        lines, i, field_line.depth, field_header, strict
+                    )
+                    obj_item[field_key] = field_val
+                    i = next_i
+                    continue
+
+                try:
+                    field_key_str, field_value_str = split_key_value(field_content)
+                    field_key = parse_key(field_key_str)
+
+                    if not field_value_str:
+                        # Nested object
+                        obj_item[field_key] = decode_object(lines, i + 1, field_line.depth, strict)
+                        i += 1
+                        while i < len(lines) and lines[i].depth > field_line.depth:
+                            i += 1
+                    else:
+                        obj_item[field_key] = parse_primitive(field_value_str)
+                        i += 1
+                except ToonDecodeError:
+                    break
+
+            result.append(obj_item)
+        except ToonDecodeError:
+            # Not an object, must be a primitive
+            # Special case: empty content after "- " is an empty object
+            if not item_content:
+                result.append({})
+            else:
+                result.append(parse_primitive(item_content))
+            i += 1
+
+    if strict and len(result) != expected_length:
+        raise ToonDecodeError(f"Expected {expected_length} items, but got {len(result)}")
+
+    return result, i

--- a/src/servicenow_mcp/_vendor/toon_format/encoder.py
+++ b/src/servicenow_mcp/_vendor/toon_format/encoder.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Core TOON encoding functionality.
+
+This module provides the main `encode()` function for converting Python values
+to TOON format strings. Handles option resolution and coordinates the encoding
+pipeline: normalization → encoding → writing.
+"""
+
+from typing import Any, Optional
+
+from .constants import DEFAULT_DELIMITER, DELIMITERS
+from .encoders import encode_value
+from .normalize import normalize_value
+from .types import EncodeOptions, ResolvedEncodeOptions
+from .writer import LineWriter
+
+
+def encode(value: Any, options: Optional[EncodeOptions] = None) -> str:
+    """Encode a value into TOON format.
+
+    Args:
+        value: The value to encode (must be JSON-serializable)
+        options: Optional encoding options
+
+    Returns:
+        TOON-formatted string
+    """
+    normalized = normalize_value(value)
+    resolved_options = resolve_options(options)
+    writer = LineWriter(resolved_options.indent)
+    encode_value(normalized, resolved_options, writer, 0)
+    return writer.to_string()
+
+
+def resolve_options(options: Optional[EncodeOptions]) -> ResolvedEncodeOptions:
+    """Resolve encoding options with defaults.
+
+    Args:
+        options: Optional user-provided options
+
+    Returns:
+        Resolved options with defaults applied
+    """
+    if options is None:
+        return ResolvedEncodeOptions()
+
+    indent = options.get("indent", 2)
+    delimiter = options.get("delimiter", DEFAULT_DELIMITER)
+    length_marker = options.get("lengthMarker", False)
+
+    # Resolve delimiter if it's a key
+    if delimiter in DELIMITERS:
+        delimiter = DELIMITERS[delimiter]
+
+    return ResolvedEncodeOptions(indent=indent, delimiter=delimiter, length_marker=length_marker)

--- a/src/servicenow_mcp/_vendor/toon_format/encoders.py
+++ b/src/servicenow_mcp/_vendor/toon_format/encoders.py
@@ -1,0 +1,456 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Type-specific encoders for TOON format.
+
+Provides encoding functions for different value types: objects, arrays (primitive,
+tabular, and list formats), and primitives. Includes format detection logic to
+determine the most efficient TOON representation for arrays.
+"""
+
+from typing import List, Optional, cast
+
+from .constants import LIST_ITEM_PREFIX
+from .normalize import (
+    is_array_of_arrays,
+    is_array_of_objects,
+    is_array_of_primitives,
+    is_json_array,
+    is_json_object,
+    is_json_primitive,
+)
+from .primitives import encode_key, encode_primitive, format_header, join_encoded_values
+from .types import (
+    Depth,
+    JsonArray,
+    JsonObject,
+    JsonPrimitive,
+    JsonValue,
+    ResolvedEncodeOptions,
+)
+from .writer import LineWriter
+
+
+def encode_value(
+    value: JsonValue,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth = 0,
+) -> None:
+    """Encode a value to TOON format.
+
+    Args:
+        value: Normalized JSON value
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+    """
+    if is_json_primitive(value):
+        writer.push(depth, encode_primitive(cast(JsonPrimitive, value), options.delimiter))
+    elif is_json_array(value):
+        encode_array(cast(JsonArray, value), options, writer, depth, None)
+    elif is_json_object(value):
+        encode_object(cast(JsonObject, value), options, writer, depth, None)
+
+
+def encode_object(
+    obj: JsonObject,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+    key: Optional[str],
+) -> None:
+    """Encode an object to TOON format.
+
+    Args:
+        obj: Dictionary object
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+        key: Optional key name
+    """
+    if key:
+        writer.push(depth, f"{encode_key(key)}:")
+
+    for obj_key, obj_value in obj.items():
+        encode_key_value_pair(obj_key, obj_value, options, writer, depth if not key else depth + 1)
+
+
+def encode_key_value_pair(
+    key: str,
+    value: JsonValue,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+) -> None:
+    """Encode a key-value pair.
+
+    Args:
+        key: Key name
+        value: Value to encode
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+    """
+    if is_json_primitive(value):
+        primitive_str = encode_primitive(cast(JsonPrimitive, value), options.delimiter)
+        writer.push(depth, f"{encode_key(key)}: {primitive_str}")
+    elif is_json_array(value):
+        encode_array(cast(JsonArray, value), options, writer, depth, key)
+    elif is_json_object(value):
+        encode_object(cast(JsonObject, value), options, writer, depth, key)
+
+
+def encode_array(
+    arr: JsonArray,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+    key: Optional[str],
+) -> None:
+    """Encode an array to TOON format.
+
+    Args:
+        arr: List array
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+        key: Optional key name
+    """
+    # Handle empty array
+    if not arr:
+        header = format_header(key, 0, None, options.delimiter, options.lengthMarker)
+        writer.push(depth, header)
+        return
+
+    # Check array type and encode accordingly
+    if is_array_of_primitives(arr):
+        encode_inline_primitive_array(arr, options, writer, depth, key)
+    elif is_array_of_arrays(arr):
+        encode_array_of_arrays(arr, options, writer, depth, key)
+    elif is_array_of_objects(arr):
+        tabular_header = detect_tabular_header(arr, options.delimiter)
+        if tabular_header:
+            encode_array_of_objects_as_tabular(arr, tabular_header, options, writer, depth, key)
+        else:
+            encode_mixed_array_as_list_items(arr, options, writer, depth, key)
+    else:
+        encode_mixed_array_as_list_items(arr, options, writer, depth, key)
+
+
+def encode_array_content(
+    arr: JsonArray,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+) -> None:
+    """Encode array content without header (header already written).
+
+    Args:
+        arr: Array to encode
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth for array items
+    """
+    # Handle empty array
+    if not arr:
+        return
+
+    # Check array type and encode accordingly
+    if is_array_of_primitives(arr):
+        # Inline primitive array - write values on same line as header
+        # But header was already written, so we need to append to last line
+        # Actually, we can't modify the last line, so this won't work for inline arrays
+        # For now, encode inline arrays separately
+        encoded_values = [encode_primitive(item, options.delimiter) for item in arr]
+        joined = join_encoded_values(encoded_values, options.delimiter)
+        # Get the last line and append to it
+        # This is tricky - we need to modify the writer to support this
+        # For now, let's just write at current depth
+        # Actually, looking at the expected output, inline arrays should have their content
+        # on the same line as the header. But we already wrote the header.
+        # The solution is to NOT use this function for inline primitive arrays
+        # Instead, we should write them completely inline
+        pass  # Handled differently
+    elif is_array_of_arrays(arr):
+        for item in arr:
+            if is_array_of_primitives(item):
+                encoded_values = [encode_primitive(v, options.delimiter) for v in item]
+                joined = join_encoded_values(encoded_values, options.delimiter)
+                item_header = format_header(
+                    None, len(item), None, options.delimiter, options.lengthMarker
+                )
+                line = f"{LIST_ITEM_PREFIX}{item_header}"
+                if joined:
+                    line += f" {joined}"
+                writer.push(depth, line)
+            else:
+                encode_array(item, options, writer, depth, None)
+    elif is_array_of_objects(arr):
+        tabular_header = detect_tabular_header(arr, options.delimiter)
+        if tabular_header:
+            # Tabular format
+            for obj in arr:
+                row_values = [
+                    encode_primitive(obj[field], options.delimiter) for field in tabular_header
+                ]
+                row = join_encoded_values(row_values, options.delimiter)
+                writer.push(depth, row)
+        else:
+            # List format
+            for item in arr:
+                encode_object_as_list_item(item, options, writer, depth)
+    else:
+        # Mixed array
+        for item in arr:
+            if is_json_primitive(item):
+                writer.push(
+                    depth,
+                    f"{LIST_ITEM_PREFIX}{encode_primitive(item, options.delimiter)}",
+                )
+            elif is_json_object(item):
+                encode_object_as_list_item(item, options, writer, depth)
+            elif is_json_array(item):
+                encode_array(item, options, writer, depth, None)
+
+
+def encode_inline_primitive_array(
+    arr: JsonArray,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+    key: Optional[str],
+) -> None:
+    """Encode an array of primitives inline.
+
+    Args:
+        arr: Array of primitives
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+        key: Optional key name
+    """
+    encoded_values = [encode_primitive(item, options.delimiter) for item in arr]
+    joined = join_encoded_values(encoded_values, options.delimiter)
+    header = format_header(key, len(arr), None, options.delimiter, options.lengthMarker)
+    writer.push(depth, f"{header} {joined}")
+
+
+def encode_array_of_arrays(
+    arr: JsonArray,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+    key: Optional[str],
+) -> None:
+    """Encode an array of arrays.
+
+    Args:
+        arr: Array of arrays
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+        key: Optional key name
+    """
+    header = format_header(key, len(arr), None, options.delimiter, options.lengthMarker)
+    writer.push(depth, header)
+
+    for item in arr:
+        if is_array_of_primitives(item):
+            encoded_values = [encode_primitive(v, options.delimiter) for v in item]
+            joined = join_encoded_values(encoded_values, options.delimiter)
+            # Use format_header for correct delimiter handling
+            item_header = format_header(
+                None, len(item), None, options.delimiter, options.lengthMarker
+            )
+            # Only add space and content if array is not empty
+            line = f"{LIST_ITEM_PREFIX}{item_header}"
+            if joined:
+                line += f" {joined}"
+            writer.push(depth + 1, line)
+        else:
+            encode_array(item, options, writer, depth + 1, None)
+
+
+def detect_tabular_header(arr: List[JsonObject], delimiter: str) -> Optional[List[str]]:
+    """Detect if array can use tabular format and return header keys.
+
+    Args:
+        arr: Array of objects
+        delimiter: Delimiter character
+
+    Returns:
+        List of keys if tabular, None otherwise
+    """
+    if not arr:
+        return None
+
+    # Get keys from first object
+    first_keys = list(arr[0].keys())
+    first_keys_set = set(first_keys)
+
+    # Check all objects have same keys (regardless of order) and all values are primitives
+    for obj in arr:
+        if set(obj.keys()) != first_keys_set:
+            return None
+        if not all(is_json_primitive(value) for value in obj.values()):
+            return None
+
+    return first_keys
+
+
+def is_tabular_array(arr: List[JsonObject], delimiter: str) -> bool:
+    """Check if array qualifies for tabular format.
+
+    Args:
+        arr: Array to check
+        delimiter: Delimiter character
+
+    Returns:
+        True if tabular format can be used
+    """
+    return detect_tabular_header(arr, delimiter) is not None
+
+
+def encode_array_of_objects_as_tabular(
+    arr: List[JsonObject],
+    fields: List[str],
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+    key: Optional[str],
+) -> None:
+    """Encode array of uniform objects in tabular format.
+
+    Args:
+        arr: Array of uniform objects
+        fields: Field names for header
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+        key: Optional key name
+    """
+    header = format_header(key, len(arr), fields, options.delimiter, options.lengthMarker)
+    writer.push(depth, header)
+
+    for obj in arr:
+        row_values = [encode_primitive(obj[field], options.delimiter) for field in fields]
+        row = join_encoded_values(row_values, options.delimiter)
+        writer.push(depth + 1, row)
+
+
+def encode_mixed_array_as_list_items(
+    arr: JsonArray,
+    options: ResolvedEncodeOptions,
+    writer: LineWriter,
+    depth: Depth,
+    key: Optional[str],
+) -> None:
+    """Encode mixed array as list items.
+
+    Args:
+        arr: Mixed array
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+        key: Optional key name
+    """
+    header = format_header(key, len(arr), None, options.delimiter, options.lengthMarker)
+    writer.push(depth, header)
+
+    for item in arr:
+        if is_json_primitive(item):
+            writer.push(
+                depth + 1,
+                f"{LIST_ITEM_PREFIX}{encode_primitive(item, options.delimiter)}",
+            )
+        elif is_json_object(item):
+            encode_object_as_list_item(item, options, writer, depth + 1)
+        elif is_json_array(item):
+            # Arrays as list items need the "- " prefix with their header
+            item_arr = cast(JsonArray, item)
+            if is_array_of_primitives(item_arr):
+                # Inline primitive array: "- [N]: values"
+                encoded_values = [encode_primitive(v, options.delimiter) for v in item_arr]
+                joined = join_encoded_values(encoded_values, options.delimiter)
+                header = format_header(
+                    None, len(item_arr), None, options.delimiter, options.lengthMarker
+                )
+                line = f"{LIST_ITEM_PREFIX}{header}"
+                if joined:
+                    line += f" {joined}"
+                writer.push(depth + 1, line)
+            else:
+                # Non-inline array: "- [N]:" header, then content at depth + 2
+                tabular_fields = None
+                if is_array_of_objects(item_arr):
+                    tabular_fields = detect_tabular_header(item_arr, options.delimiter)
+                header = format_header(
+                    None,
+                    len(item_arr),
+                    tabular_fields,
+                    options.delimiter,
+                    options.lengthMarker,
+                )
+                writer.push(depth + 1, f"{LIST_ITEM_PREFIX}{header}")
+                encode_array_content(item_arr, options, writer, depth + 2)
+
+
+def encode_object_as_list_item(
+    obj: JsonObject, options: ResolvedEncodeOptions, writer: LineWriter, depth: Depth
+) -> None:
+    """Encode object as a list item.
+
+    Args:
+        obj: Object to encode
+        options: Resolved encoding options
+        writer: Line writer for output
+        depth: Current indentation depth
+    """
+    # Get all keys
+    keys = list(obj.items())
+    if not keys:
+        writer.push(depth, LIST_ITEM_PREFIX.rstrip())
+        return
+
+    # First key-value pair goes on same line as the "-"
+    first_key, first_value = keys[0]
+    if is_json_primitive(first_value):
+        encoded_val = encode_primitive(first_value, options.delimiter)
+        writer.push(depth, f"{LIST_ITEM_PREFIX}{encode_key(first_key)}: {encoded_val}")
+    elif is_json_array(first_value):
+        # Arrays go on the same line as "-" with their header
+        first_arr = cast(JsonArray, first_value)
+        if is_array_of_primitives(first_arr):
+            # Inline primitive array: write header and content on same line
+            encoded_values = [encode_primitive(item, options.delimiter) for item in first_arr]
+            joined = join_encoded_values(encoded_values, options.delimiter)
+            header = format_header(
+                first_key, len(first_arr), None, options.delimiter, options.lengthMarker
+            )
+            line = f"{LIST_ITEM_PREFIX}{header}"
+            if joined:
+                line += f" {joined}"
+            writer.push(depth, line)
+        else:
+            # Non-inline array: write header on hyphen line, content below
+            tabular_fields = None
+            if is_array_of_objects(first_arr):
+                tabular_fields = detect_tabular_header(first_arr, options.delimiter)
+            header = format_header(
+                first_key,
+                len(first_arr),
+                tabular_fields,
+                options.delimiter,
+                options.lengthMarker,
+            )
+            writer.push(depth, f"{LIST_ITEM_PREFIX}{header}")
+            # Now encode the array content at depth + 1
+            encode_array_content(first_arr, options, writer, depth + 1)
+    else:
+        # If first value is an object, put "-" alone then encode normally
+        writer.push(depth, LIST_ITEM_PREFIX.rstrip())
+        encode_key_value_pair(first_key, first_value, options, writer, depth + 1)
+
+    # Rest of the keys go normally indented
+    for key, value in keys[1:]:
+        encode_key_value_pair(key, value, options, writer, depth + 1)

--- a/src/servicenow_mcp/_vendor/toon_format/logging_config.py
+++ b/src/servicenow_mcp/_vendor/toon_format/logging_config.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Centralized logging configuration for toon_format.
+
+This module provides consistent logging infrastructure across all toon_format
+modules with support for the TOON_FORMAT_DEBUG environment variable for
+enabling debug-level logging.
+"""
+
+import logging
+import os
+from functools import lru_cache
+from typing import Optional
+
+# Constants
+TOON_FORMAT_DEBUG_ENV_VAR = "TOON_FORMAT_DEBUG"
+DEFAULT_LOG_LEVEL = logging.WARNING
+DEBUG_LOG_LEVEL = logging.DEBUG
+
+
+@lru_cache(maxsize=1)
+def is_debug_enabled() -> bool:
+    """Check if TOON_FORMAT_DEBUG environment variable is set to truthy value.
+
+    Accepts: "1", "true", "True", "TRUE", "yes", "Yes", "YES"
+
+    Returns:
+        bool: True if debug mode is enabled, False otherwise.
+
+    Note:
+        Result is cached for performance.
+    """
+    value = os.environ.get(TOON_FORMAT_DEBUG_ENV_VAR, "").lower()
+    return value in ("1", "true", "yes")
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Create or retrieve logger for given module name.
+
+    Configures logger with appropriate level based on environment variable
+    and adds a StreamHandler with consistent formatting.
+
+    Args:
+        name: Module name (typically __name__).
+
+    Returns:
+        logging.Logger: Configured logger instance.
+
+    Examples:
+        >>> logger = get_logger(__name__)
+        >>> logger.debug("Debug message")  # Only shown if TOON_FORMAT_DEBUG=1
+    """
+    logger = logging.getLogger(name)
+
+    # Set log level based on debug mode
+    level = DEBUG_LOG_LEVEL if is_debug_enabled() else DEFAULT_LOG_LEVEL
+    logger.setLevel(level)
+
+    # Add StreamHandler if not already present
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(level)
+        formatter = logging.Formatter("[%(name)s] %(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    return logger
+
+
+def configure_logging(level: Optional[int] = None) -> None:
+    """Configure log level programmatically for all toon_format loggers.
+
+    Useful for testing and programmatic control of logging.
+
+    Args:
+        level: Log level (e.g., logging.DEBUG, logging.INFO).
+               If None, uses environment variable or default.
+
+    Examples:
+        >>> configure_logging(logging.DEBUG)  # Enable debug logging
+        >>> configure_logging(logging.WARNING)  # Reset to default
+    """
+    if level is None:
+        level = DEBUG_LOG_LEVEL if is_debug_enabled() else DEFAULT_LOG_LEVEL
+
+    # Update all existing toon_format loggers
+    for name in list(logging.Logger.manager.loggerDict.keys()):
+        if name.startswith("toon_format"):
+            logger = logging.getLogger(name)
+            logger.setLevel(level)
+            for handler in logger.handlers:
+                handler.setLevel(level)

--- a/src/servicenow_mcp/_vendor/toon_format/normalize.py
+++ b/src/servicenow_mcp/_vendor/toon_format/normalize.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Value normalization for TOON encoding.
+
+Converts Python-specific types to JSON-compatible values before encoding:
+- datetime/date → ISO 8601 strings
+- Decimal → float
+- tuple/set/frozenset → sorted lists
+- pathlib.Path → string representation
+- Infinity/NaN → null
+- Functions/callables → null
+- Negative zero → zero
+"""
+
+import math
+import sys
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import PurePath
+from typing import Any
+
+# TypeGuard was added in Python 3.10, use typing_extensions for older versions
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extensions import TypeGuard
+
+from .logging_config import get_logger
+from .types import JsonArray, JsonObject, JsonPrimitive, JsonValue
+
+# Module logger
+logger = get_logger(__name__)
+
+_MAX_SAFE_INTEGER = 2**53 - 1
+
+
+def normalize_value(value: Any) -> JsonValue:
+    """Normalize Python value to JSON-compatible type.
+
+    Converts Python-specific types to JSON-compatible equivalents:
+    - datetime objects → ISO 8601 strings
+    - sets → sorted lists
+    - pathlib.Path → string representation
+    - Large integers (>2^53-1) → strings (for JS compatibility)
+    - Non-finite floats (inf, -inf, NaN) → null
+    - Negative zero → positive zero
+    - Mapping types → dicts with string keys
+    - Unsupported types → null
+
+    Args:
+        value: Python value to normalize.
+
+    Returns:
+        JsonValue: Normalized value (None, bool, int, float, str, list, or dict).
+
+    Examples:
+        >>> normalize_value(datetime(2024, 1, 1))
+        '2024-01-01T00:00:00'
+
+        >>> normalize_value({1, 2, 3})
+        [1, 2, 3]
+
+        >>> normalize_value(float('inf'))
+        None
+
+        >>> normalize_value(2**60)  # Large integer
+        '1152921504606846976'
+
+        >>> from pathlib import Path
+        >>> normalize_value(Path('/tmp/file.txt'))
+        '/tmp/file.txt'
+
+    Note:
+        - Recursive: normalizes nested structures
+        - Sets are sorted for deterministic output
+        - Heterogeneous sets sorted by repr() if natural sorting fails
+        - Path objects are converted to their string representation
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, int):
+        # Python integers have arbitrary precision and are encoded directly
+        # Note: JavaScript BigInt types are converted to strings during normalization
+        # (per spec Section 3), but Python ints don't need this conversion
+        return value
+
+    if isinstance(value, float):
+        # Handle non-finite first
+        if not math.isfinite(value) or value != value:  # includes inf, -inf, NaN
+            logger.debug(f"Converting non-finite float to null: {value}")
+            return None
+        if value == 0.0 and math.copysign(1.0, value) == -1.0:
+            logger.debug("Converting negative zero to positive zero")
+            return 0
+        return value
+
+    # Handle Decimal
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            logger.debug(f"Converting non-finite Decimal to null: {value}")
+            return None
+        return float(value)
+
+    # Handle pathlib.Path objects -> string representation
+    if isinstance(value, PurePath):
+        logger.debug(f"Converting {type(value).__name__} to string: {value}")
+        return str(value)
+
+    if isinstance(value, datetime):
+        try:
+            result = value.isoformat()
+            logger.debug(f"Converting datetime to ISO string: {value}")
+            return result
+        except Exception as e:
+            raise ValueError(f"Failed to convert datetime to ISO format: {e}") from e
+
+    if isinstance(value, date):
+        try:
+            result = value.isoformat()
+            logger.debug(f"Converting date to ISO string: {value}")
+            return result
+        except Exception as e:
+            raise ValueError(f"Failed to convert date to ISO format: {e}") from e
+
+    if isinstance(value, list):
+        if not value:
+            return []
+        return [normalize_value(item) for item in value]
+
+    if isinstance(value, tuple):
+        logger.debug(f"Converting tuple to list: {len(value)} items")
+        return [normalize_value(item) for item in value]
+
+    if isinstance(value, (set, frozenset)):
+        logger.debug(f"Converting {type(value).__name__} to sorted list: {len(value)} items")
+        try:
+            return [normalize_value(item) for item in sorted(value)]
+        except TypeError:
+            # Fall back to stable conversion for heterogeneous sets/frozensets
+            logger.debug(
+                f"{type(value).__name__} contains heterogeneous types, using repr() for sorting"
+            )
+            return [normalize_value(item) for item in sorted(value, key=lambda x: repr(x))]
+
+    # Handle generic mapping types (Map-like) and dicts
+    if isinstance(value, Mapping):
+        logger.debug(f"Converting {type(value).__name__} to dict: {len(value)} items")
+        try:
+            return {str(k): normalize_value(v) for k, v in value.items()}
+        except Exception as e:
+            raise ValueError(
+                f"Failed to convert mapping to dict: {e}. "
+                "Check that all keys can be converted to strings."
+            ) from e
+
+    # Handle callables -> null
+    if callable(value):
+        logger.debug(f"Converting callable {type(value).__name__} to null")
+        return None
+
+    # Fallback for other types
+    logger.warning(
+        f"Unsupported type {type(value).__name__}, converting to null. Value: {str(value)[:50]}"
+    )
+    return None
+
+
+def is_json_primitive(value: Any) -> TypeGuard[JsonPrimitive]:
+    """Check if value is a JSON primitive type.
+
+    Args:
+        value: Value to check.
+
+    Returns:
+        TypeGuard[JsonPrimitive]: True if value is None, str, int, float, or bool.
+    """
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def is_json_array(value: Any) -> TypeGuard[JsonArray]:
+    """Check if value is a JSON array (Python list).
+
+    Args:
+        value: Value to check.
+
+    Returns:
+        TypeGuard[JsonArray]: True if value is a list.
+    """
+    return isinstance(value, list)
+
+
+def is_json_object(value: Any) -> TypeGuard[JsonObject]:
+    """Check if value is a JSON object (Python dict).
+
+    Args:
+        value: Value to check.
+
+    Returns:
+        TypeGuard[JsonObject]: True if value is a dict.
+    """
+    return isinstance(value, dict)
+
+
+def is_array_of_primitives(value: JsonArray) -> bool:
+    """Check if array contains only primitive values.
+
+    Args:
+        value: List to check.
+
+    Returns:
+        bool: True if all items are primitives. Empty arrays return True.
+    """
+    if not value:
+        return True
+    return all(is_json_primitive(item) for item in value)
+
+
+def is_array_of_arrays(value: JsonArray) -> bool:
+    """Check if array contains only arrays.
+
+    Args:
+        value: List to check.
+
+    Returns:
+        bool: True if all items are lists. Empty arrays return True.
+    """
+    if not value:
+        return True
+    return all(is_json_array(item) for item in value)
+
+
+def is_array_of_objects(value: JsonArray) -> bool:
+    """Check if array contains only objects.
+
+    Args:
+        value: List to check.
+
+    Returns:
+        bool: True if all items are dicts. Empty arrays return True.
+    """
+    if not value:
+        return True
+    return all(is_json_object(item) for item in value)

--- a/src/servicenow_mcp/_vendor/toon_format/primitives.py
+++ b/src/servicenow_mcp/_vendor/toon_format/primitives.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Primitive value encoding utilities.
+
+Handles encoding of primitive values (strings, numbers, booleans, null) and
+array headers. Implements quoting rules, escape sequences, and header formatting
+for inline and tabular array formats.
+"""
+
+import re
+from typing import List, Literal, Optional, Union
+
+from ._string_utils import escape_string
+from ._validation import is_safe_unquoted, is_valid_unquoted_key
+from .constants import (
+    CLOSE_BRACE,
+    CLOSE_BRACKET,
+    COLON,
+    COMMA,
+    CONTROL_CHARS_REGEX,
+    DOUBLE_QUOTE,
+    FALSE_LITERAL,
+    NULL_LITERAL,
+    NUMERIC_REGEX,
+    OCTAL_REGEX,
+    OPEN_BRACE,
+    OPEN_BRACKET,
+    STRUCTURAL_CHARS_REGEX,
+    TRUE_LITERAL,
+    VALID_KEY_REGEX,
+)
+from .logging_config import get_logger
+from .types import Delimiter, JsonPrimitive
+
+# Precompiled patterns for performance
+_STRUCTURAL_CHARS_PATTERN = re.compile(STRUCTURAL_CHARS_REGEX)
+_CONTROL_CHARS_PATTERN = re.compile(CONTROL_CHARS_REGEX)
+_NUMERIC_PATTERN = re.compile(NUMERIC_REGEX, re.IGNORECASE)
+_OCTAL_PATTERN = re.compile(OCTAL_REGEX)
+_VALID_KEY_PATTERN = re.compile(VALID_KEY_REGEX, re.IGNORECASE)
+
+
+logger = get_logger(__name__)
+
+
+def encode_primitive(value: JsonPrimitive, delimiter: str = COMMA) -> str:
+    """Encode a primitive value.
+
+    Args:
+        value: Primitive value
+        delimiter: Current delimiter being used
+
+    Returns:
+        Encoded string
+    """
+    if value is None:
+        return NULL_LITERAL
+    if isinstance(value, bool):
+        return TRUE_LITERAL if value else FALSE_LITERAL
+    if isinstance(value, (int, float)):
+        # Format numbers in decimal form without scientific notation
+        # Per spec Section 2: numbers must be rendered without exponent notation
+        if isinstance(value, int):
+            return str(value)
+        # For floats, use Python's default conversion first
+        formatted = str(value)
+        # Check if Python used scientific notation
+        if "e" in formatted or "E" in formatted:
+            # Convert to fixed-point decimal notation
+            # Use format with enough precision, then strip trailing zeros
+            from decimal import Decimal
+
+            # Convert through Decimal to get exact decimal representation
+            dec = Decimal(str(value))
+            formatted = format(dec, "f")
+        return formatted
+    if isinstance(value, str):
+        return encode_string_literal(value, delimiter)
+    return str(value)
+
+
+# Note: escape_string and is_safe_unquoted are now imported from _string_utils and _validation
+
+
+def encode_string_literal(value: str, delimiter: str = COMMA) -> str:
+    """Encode a string, quoting only if necessary.
+
+    Args:
+        value: String value
+        delimiter: Current delimiter being used
+
+    Returns:
+        Encoded string
+    """
+    if is_safe_unquoted(value, delimiter):
+        return value
+    return f"{DOUBLE_QUOTE}{escape_string(value)}{DOUBLE_QUOTE}"
+
+
+def encode_key(key: str) -> str:
+    """Encode an object key.
+
+    Args:
+        key: Key string
+
+    Returns:
+        Encoded key
+    """
+    # Keys matching /^[A-Z_][\w.]*$/i don't require quotes
+    if is_valid_unquoted_key(key):
+        return key
+    return f"{DOUBLE_QUOTE}{escape_string(key)}{DOUBLE_QUOTE}"
+
+
+def join_encoded_values(values: List[str], delimiter: Delimiter) -> str:
+    """Join encoded primitive values with a delimiter.
+
+    Args:
+        values: List of encoded values
+        delimiter: Delimiter to use
+
+    Returns:
+        Joined string
+    """
+    return delimiter.join(values)
+
+
+def format_header(
+    key: Optional[str],
+    length: int,
+    fields: Optional[List[str]],
+    delimiter: Delimiter,
+    length_marker: Union[str, Literal[False], None],
+) -> str:
+    """Format array/table header.
+
+    Args:
+        key: Optional key name
+        length: Array length
+        fields: Optional field names for tabular format
+        delimiter: Delimiter character
+        length_marker: Optional length marker prefix
+
+    Returns:
+        Formatted header string
+    """
+    # Build length marker
+    marker_prefix = length_marker if length_marker else ""
+
+    # Build fields if provided
+    fields_str = ""
+    if fields:
+        # Encode each field name as a key (may need quoting per Section 7.3)
+        encoded_fields = [encode_key(field) for field in fields]
+        fields_str = f"{OPEN_BRACE}{delimiter.join(encoded_fields)}{CLOSE_BRACE}"
+
+    # Build length string with delimiter when needed
+    # Rules per TOON spec: delimiter is optional in bracket [N<delim?>]
+    # - Only include delimiter if it's NOT comma (comma is the default)
+    # - This applies to both tabular and primitive arrays
+    if delimiter != COMMA:
+        # Non-comma delimiter: show delimiter in bracket
+        length_str = f"{OPEN_BRACKET}{marker_prefix}{length}{delimiter}{CLOSE_BRACKET}"
+    else:
+        # Comma delimiter (default): just [length]
+        length_str = f"{OPEN_BRACKET}{marker_prefix}{length}{CLOSE_BRACKET}"
+
+    # Combine parts
+    if key:
+        return f"{encode_key(key)}{length_str}{fields_str}{COLON}"
+    return f"{length_str}{fields_str}{COLON}"

--- a/src/servicenow_mcp/_vendor/toon_format/types.py
+++ b/src/servicenow_mcp/_vendor/toon_format/types.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Type definitions for TOON format.
+
+Defines type aliases and TypedDict classes for JSON values, encoding/decoding
+options, and internal types used throughout the package.
+"""
+
+from typing import Any, Dict, List, Literal, TypedDict, Union
+
+# JSON-compatible types
+JsonPrimitive = Union[str, int, float, bool, None]
+JsonObject = Dict[str, Any]
+JsonArray = List[Any]
+JsonValue = Union[JsonPrimitive, JsonArray, JsonObject]
+
+# Delimiter type
+Delimiter = str
+DelimiterKey = Literal["comma", "tab", "pipe"]
+
+
+class EncodeOptions(TypedDict, total=False):
+    """Options for TOON encoding.
+
+    Attributes:
+        indent: Number of spaces per indentation level (default: 2)
+        delimiter: Delimiter character for arrays (default: comma)
+        lengthMarker: Optional marker to prefix array lengths (default: False)
+    """
+
+    indent: int
+    delimiter: Delimiter
+    lengthMarker: Union[Literal["#"], Literal[False]]
+
+
+class ResolvedEncodeOptions:
+    """Resolved encoding options with defaults applied."""
+
+    def __init__(
+        self,
+        indent: int = 2,
+        delimiter: str = ",",
+        length_marker: Union[Literal["#"], Literal[False]] = False,
+    ) -> None:
+        self.indent = indent
+        self.delimiter = delimiter
+        self.lengthMarker: Union[str, Literal[False]] = length_marker
+
+
+class DecodeOptions:
+    """Options for TOON decoding.
+
+    Attributes:
+        indent: Number of spaces per indentation level (default: 2)
+        strict: Enable strict validation (default: True)
+    """
+
+    def __init__(self, indent: int = 2, strict: bool = True) -> None:
+        self.indent = indent
+        self.strict = strict
+
+
+# Depth type for tracking indentation level
+Depth = int

--- a/src/servicenow_mcp/_vendor/toon_format/utils.py
+++ b/src/servicenow_mcp/_vendor/toon_format/utils.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Token analysis utilities for TOON format.
+
+This module provides utilities for counting tokens and comparing
+token efficiency between JSON and TOON formats. Useful for:
+- Estimating API costs (tokens are the primary cost driver)
+- Optimizing prompt sizes for LLM context windows
+- Benchmarking TOON's token efficiency
+
+Functions:
+    count_tokens: Count tokens in a text string
+    estimate_savings: Compare JSON vs TOON token counts
+    compare_formats: Generate formatted comparison table
+
+Requirements:
+    tiktoken: Install with `uv add tiktoken` or `uv add toon_format[benchmark]`
+
+Example:
+    >>> import toon_format
+    >>> data = {"name": "Alice", "age": 30}
+    >>> result = toon_format.estimate_savings(data)
+    >>> print(f"TOON saves {result['savings_percent']:.1f}% tokens")
+"""
+
+import functools
+import json
+from typing import Any, Dict
+
+# Import encode from parent package (defined in __init__.py before this module is imported)
+# __init__.py defines encode() before importing utils, so this is safe
+from . import encode
+
+__all__ = ["count_tokens", "estimate_savings", "compare_formats"]
+
+
+_TIKTOKEN_MISSING_MSG = (
+    "tiktoken is required for token counting. "
+    "Install with: uv add tiktoken or uv add toon_format[benchmark]"
+)
+
+
+def _require_tiktoken():
+    try:
+        import tiktoken  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via count_tokens
+        raise RuntimeError(_TIKTOKEN_MISSING_MSG) from exc
+    return tiktoken
+
+
+@functools.lru_cache(maxsize=1)
+def _get_tokenizer():
+    """Get cached tiktoken tokenizer for o200k_base encoding.
+
+    Returns:
+        tiktoken.Encoding: The o200k_base tokenizer (gpt5/gpt5-mini).
+
+    Raises:
+        RuntimeError: If tiktoken is not installed.
+    """
+    tiktoken = _require_tiktoken()
+    return tiktoken.get_encoding("o200k_base")
+
+
+def count_tokens(text: str, encoding: str = "o200k_base") -> int:
+    """Count tokens in a text string using tiktoken.
+
+    Args:
+        text: The string to tokenize.
+        encoding: Tokenizer encoding name (default: 'o200k_base' for gpt5/gpt5-mini).
+                  Other options include 'cl100k_base' (GPT-3.5), 'p50k_base' (older models).
+
+    Returns:
+        int: The number of tokens in the text.
+
+    Example:
+        >>> import toon_format
+        >>> text = "Hello, world!"
+        >>> toon_format.count_tokens(text)
+        4
+
+    Note:
+        Requires tiktoken to be installed: uv add tiktoken or uv add toon_format[benchmark]
+    """
+    if encoding == "o200k_base":
+        enc = _get_tokenizer()
+    else:
+        tiktoken = _require_tiktoken()
+        enc = tiktoken.get_encoding(encoding)
+
+    return len(enc.encode(text))
+
+
+def estimate_savings(data: Any, encoding: str = "o200k_base") -> Dict[str, Any]:
+    """Compare token counts between JSON and TOON formats.
+
+    Args:
+        data: Python dict or list to compare.
+        encoding: Tokenizer encoding name (default: 'o200k_base').
+
+    Returns:
+        dict: Dictionary containing:
+            - json_tokens (int): Token count for JSON format
+            - toon_tokens (int): Token count for TOON format
+            - savings (int): Absolute token savings (json_tokens - toon_tokens)
+            - savings_percent (float): Percentage savings
+
+    Example:
+        >>> import toon_format
+        >>> data = {"employees": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}
+        >>> result = toon_format.estimate_savings(data)
+        >>> print(f"Savings: {result['savings_percent']:.1f}%")
+        Savings: 42.3%
+
+    Note:
+        Significant savings are typically achieved with structured data,
+        especially arrays of uniform objects (tabular data).
+    """
+    # Encode as JSON
+    json_str = json.dumps(data, indent=2, ensure_ascii=False)
+    json_tokens = count_tokens(json_str, encoding)
+
+    # Encode as TOON
+    toon_str = encode(data)
+    toon_tokens = count_tokens(toon_str, encoding)
+
+    # Calculate savings
+    savings = max(0, json_tokens - toon_tokens)
+    savings_percent = (savings / json_tokens * 100.0) if json_tokens > 0 else 0.0
+
+    return {
+        "json_tokens": json_tokens,
+        "toon_tokens": toon_tokens,
+        "savings": savings,
+        "savings_percent": savings_percent,
+    }
+
+
+def compare_formats(data: Any, encoding: str = "o200k_base") -> str:
+    """Generate a formatted comparison table showing JSON vs TOON metrics.
+
+    Args:
+        data: Python dict or list to compare.
+        encoding: Tokenizer encoding name (default: 'o200k_base').
+
+    Returns:
+        str: Formatted table as multi-line string showing token counts,
+             character sizes, and savings percentage.
+
+    Example:
+        >>> import toon_format
+        >>> data = {"users": [{"id": 1, "name": "Alice"}]}
+        >>> print(toon_format.compare_formats(data))
+        Format Comparison
+        ────────────────────────────────────────────────
+        Format      Tokens    Size (chars)
+        JSON         1,234         5,678
+        TOON           789         3,456
+        ────────────────────────────────────────────────
+        Savings: 445 tokens (36.1%)
+
+    Note:
+        This is useful for quick visual comparison during development.
+    """
+    # Get token metrics
+    metrics = estimate_savings(data, encoding)
+
+    # Encode both formats to get character counts
+    json_str = json.dumps(data, indent=2, ensure_ascii=False)
+    toon_str = encode(data)
+
+    json_chars = len(json_str)
+    toon_chars = len(toon_str)
+
+    # Build formatted table
+    separator = "─" * 48
+    lines = [
+        "Format Comparison",
+        separator,
+        "Format      Tokens    Size (chars)",
+        f"JSON      {metrics['json_tokens']:>7,}    {json_chars:>11,}",
+        f"TOON      {metrics['toon_tokens']:>7,}    {toon_chars:>11,}",
+        separator,
+        f"Savings: {metrics['savings']:,} tokens ({metrics['savings_percent']:.1f}%)",
+    ]
+
+    return "\n".join(lines)

--- a/src/servicenow_mcp/_vendor/toon_format/writer.py
+++ b/src/servicenow_mcp/_vendor/toon_format/writer.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 TOON Format Organization
+# SPDX-License-Identifier: MIT
+"""Line writer for managing indented TOON output.
+
+Provides LineWriter class that manages indented text generation with optimized
+indent string caching for performance.
+"""
+
+from typing import Dict, List
+
+from .types import Depth
+
+
+class LineWriter:
+    """Manages indented text output with optimized indent caching."""
+
+    def __init__(self, indent_size: int) -> None:
+        """Initialize the line writer.
+
+        Args:
+            indent_size: Number of spaces per indentation level
+        """
+        self._lines: List[str] = []
+        # Ensure nested structures remain distinguishable even for indent=0
+        normalized_indent = indent_size if indent_size > 0 else 1
+        self._indentation_string = " " * normalized_indent
+        self._indent_cache: Dict[int, str] = {0: ""}
+        self._indent_size = indent_size
+
+    def push(self, depth: Depth, content: str) -> None:
+        """Add a line with appropriate indentation.
+
+        Args:
+            depth: Indentation depth level
+            content: Content to add
+        """
+        # Use cached indent string for performance
+        if depth not in self._indent_cache:
+            if self._indent_size == 0:
+                # indent=0 uses minimal spacing to preserve structure
+                self._indent_cache[depth] = " " * depth
+            else:
+                self._indent_cache[depth] = self._indentation_string * depth
+        indent = self._indent_cache[depth]
+        self._lines.append(indent + content)
+
+    def to_string(self) -> str:
+        """Return all lines joined with newlines.
+
+        Returns:
+            Complete output string
+        """
+        return "\n".join(self._lines)

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -816,6 +816,7 @@ class ServiceNowClient:
 
     async def sc_get_catalog(self, sys_id: str) -> Any:
         """Retrieve details of a specific catalog."""
+        validate_sys_id(sys_id)
         http = self._ensure_client()
         response = await http.get(
             self._sc_url("catalogs", sys_id),
@@ -832,6 +833,7 @@ class ServiceNowClient:
         top_level_only: bool = False,
     ) -> Any:
         """Retrieve categories for a specific catalog."""
+        validate_sys_id(catalog_sys_id)
         http = self._ensure_client()
         params: dict[str, str] = {}
         if limit is not None:
@@ -851,6 +853,7 @@ class ServiceNowClient:
 
     async def sc_get_category(self, sys_id: str) -> Any:
         """Retrieve details of a specific category."""
+        validate_sys_id(sys_id)
         http = self._ensure_client()
         response = await http.get(
             self._sc_url("categories", sys_id),
@@ -889,6 +892,7 @@ class ServiceNowClient:
 
     async def sc_get_item(self, sys_id: str) -> Any:
         """Retrieve details of a specific catalog item."""
+        validate_sys_id(sys_id)
         http = self._ensure_client()
         response = await http.get(
             self._sc_url("items", sys_id),
@@ -899,6 +903,7 @@ class ServiceNowClient:
 
     async def sc_get_item_variables(self, sys_id: str) -> Any:
         """Retrieve variables for a specific catalog item."""
+        validate_sys_id(sys_id)
         http = self._ensure_client()
         response = await http.get(
             self._sc_url("items", sys_id, "variables"),
@@ -914,6 +919,7 @@ class ServiceNowClient:
             item_sys_id: The sys_id of the catalog item.
             variables: Variable name-value pairs for the item.
         """
+        validate_sys_id(item_sys_id)
         http = self._ensure_client()
         body: dict[str, Any] = {}
         if variables:
@@ -935,6 +941,7 @@ class ServiceNowClient:
             item_sys_id: The sys_id of the catalog item.
             variables: Variable name-value pairs for the item.
         """
+        validate_sys_id(item_sys_id)
         http = self._ensure_client()
         body: dict[str, Any] = {}
         if variables:
@@ -997,6 +1004,7 @@ class ServiceNowClient:
         Returns:
             Response dict with at minimum a "snboqId" for tracking the execution.
         """
+        validate_sys_id(test_or_suite_id)
         http = self._ensure_client()
         data = {"suiteId" if is_suite else "testId": test_or_suite_id}
 
@@ -1025,6 +1033,7 @@ class ServiceNowClient:
         Returns:
             Progress dict with fields like "progress" and "state".
         """
+        validate_sys_id(snboq_id)
         http = self._ensure_client()
         params: dict[str, str] = {"snboqId": snboq_id}
 
@@ -1053,6 +1062,7 @@ class ServiceNowClient:
         Returns:
             Result dict confirming cancellation.
         """
+        validate_sys_id(snboq_id)
         http = self._ensure_client()
         data = {"snboqId": snboq_id}
 

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -1,6 +1,7 @@
 """Async ServiceNow REST API client."""
 
 import logging
+import re
 import uuid
 from typing import Any
 from urllib.parse import quote
@@ -13,10 +14,11 @@ from servicenow_mcp.errors import (
     AuthError,
     ForbiddenError,
     NotFoundError,
+    PolicyError,
     ServerError,
     ServiceNowMCPError,
 )
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT
+from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, mask_sensitive_fields
 from servicenow_mcp.sentry import set_sentry_context
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier, validate_sys_id
 
@@ -25,6 +27,14 @@ logger = logging.getLogger(__name__)
 
 
 _ATF_PLUGIN_ERROR = "ATF Cloud Runner plugin (sn_atf_tg) may not be installed"
+
+# Scrubbing constants for error-message sanitization. Long quoted values are
+# almost always row data (cleartext field values) that would bleed to Sentry
+# via the exception message; short quoted values are field names / identifiers
+# and stay readable for triage.
+_ERROR_MESSAGE_MAX_LEN = 500
+_QUOTED_VALUE_MIN_LEN = 32
+_LONG_QUOTE_RE = re.compile(rf"""(['"])([^'"]{{{_QUOTED_VALUE_MIN_LEN},}})\1""")
 
 
 class ServiceNowClient:
@@ -67,6 +77,7 @@ class ServiceNowClient:
         validate_identifier(table)
         base = f"{self._settings.servicenow_instance_url}/api/now/table/{table}"
         if sys_id:
+            validate_sys_id(sys_id)
             base = f"{base}/{sys_id}"
         return base
 
@@ -145,14 +156,22 @@ class ServiceNowClient:
 
     @staticmethod
     def _extract_error_message(response: httpx.Response, default: str) -> str:
-        """Try to extract error message from ServiceNow JSON response."""
+        """Extract a scrubbed error message from a ServiceNow JSON response.
+
+        Long quoted substrings (likely row data) are redacted in-place and
+        the result is truncated to a bounded length so the message is safe
+        to propagate into exception text that Sentry may capture.
+        """
         try:
             body = response.json()
-            if "error" in body and "message" in body["error"]:
-                return body["error"]["message"]
+            message = body["error"]["message"] if "error" in body and "message" in body["error"] else default
         except Exception:
-            pass
-        return default
+            message = default
+
+        message = _LONG_QUOTE_RE.sub(lambda m: f"{m.group(1)}<redacted>{m.group(1)}", message)
+        if len(message) > _ERROR_MESSAGE_MAX_LEN:
+            message = message[:_ERROR_MESSAGE_MAX_LEN] + "... [truncated]"
+        return message
 
     async def get_record(
         self,
@@ -209,6 +228,71 @@ class ServiceNowClient:
         self._raise_for_status(response)
         records = self._extract_result(response.json())
         return {"records": records, "count": self._parse_total_count(response)}
+
+    async def get_records_privileged(
+        self,
+        table: str,
+        *,
+        allowed_tables: frozenset[str] | set[str],
+        query: str = "",
+        fields: str = "",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """INTERNAL USE ONLY - bypass the DENIED_TABLES gate via an explicit allowlist.
+
+        Callers (currently: select investigation modules that must read
+        ``sys_security_acl`` and similar hardened tables) MUST pre-declare
+        the exact tables they intend to read by passing them in
+        *allowed_tables*. Any table outside that set - even one that is
+        NOT on ``DENIED_TABLES`` - is rejected with ``PolicyError``, so
+        the allowlist is the gate and mistakes fail closed.
+
+        ``validate_identifier(table)`` still runs via ``_table_url``, and
+        the returned records are passed through ``mask_sensitive_fields``
+        (table-aware) so credential fields and script bodies are masked
+        on the way out. This method MUST NOT be exposed to tool-call
+        paths: it is only imported by investigation modules that own the
+        decision about which hardened tables they will read.
+
+        Args:
+            table: The ServiceNow table name.
+            allowed_tables: The exact set of tables the caller has
+                pre-declared it intends to read.
+            query: Optional encoded query string.
+            fields: Comma-separated field list (empty for default).
+            limit: Max rows to return.
+            offset: Row offset for pagination.
+
+        Returns:
+            ``{"records": [...], "count": int}`` with credential fields
+            and script bodies masked.
+        """
+        if table not in allowed_tables:
+            raise PolicyError(
+                f"get_records_privileged(): table {table!r} is not in the caller's "
+                f"declared allowlist (allowed={sorted(allowed_tables)}). "
+                "The allowlist is the gate; this is never relaxed to DENIED_TABLES."
+            )
+
+        http = self._ensure_client()
+        params: dict[str, str] = {
+            "sysparm_query": query,
+            "sysparm_limit": str(limit),
+            "sysparm_offset": str(offset),
+        }
+        if fields:
+            params["sysparm_fields"] = fields
+
+        response = await http.get(
+            self._table_url(table),
+            headers=await self._headers(),
+            params=params,
+        )
+        self._raise_for_status(response)
+        records = self._extract_result(response.json())
+        masked = [mask_sensitive_fields(r, table=table) for r in records]
+        return {"records": masked, "count": self._parse_total_count(response)}
 
     async def list_attachments(
         self,
@@ -417,6 +501,7 @@ class ServiceNowClient:
 
     def _email_url(self, email_id: str) -> str:
         """Build the Email API URL."""
+        validate_sys_id(email_id)
         return f"{self._settings.servicenow_instance_url}/api/now/v1/email/{email_id}"
 
     async def get_email(
@@ -443,6 +528,7 @@ class ServiceNowClient:
     def _import_set_url(self, staging_table: str, sys_id: str) -> str:
         """Build the Import Set API URL."""
         validate_identifier(staging_table)
+        validate_sys_id(sys_id)
         return f"{self._settings.servicenow_instance_url}/api/now/import/{staging_table}/{sys_id}"
 
     async def get_import_set_record(
@@ -585,6 +671,7 @@ class ServiceNowClient:
         validate_identifier(class_name)
         base = f"{self._settings.servicenow_instance_url}/api/now/cmdb/instance/{class_name}"
         if sys_id:
+            validate_sys_id(sys_id)
             base = f"{base}/{sys_id}"
         return base
 

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -238,6 +238,7 @@ class ServiceNowClient:
         fields: str = "",
         limit: int = 100,
         offset: int = 0,
+        display_values: bool = False,
     ) -> dict[str, Any]:
         """INTERNAL USE ONLY - bypass the DENIED_TABLES gate via an explicit allowlist.
 
@@ -263,6 +264,7 @@ class ServiceNowClient:
             fields: Comma-separated field list (empty for default).
             limit: Max rows to return.
             offset: Row offset for pagination.
+            display_values: If True, return display values (``sysparm_display_value=true``).
 
         Returns:
             ``{"records": [...], "count": int}`` with credential fields
@@ -283,6 +285,8 @@ class ServiceNowClient:
         }
         if fields:
             params["sysparm_fields"] = fields
+        if display_values:
+            params["sysparm_display_value"] = "true"
 
         response = await http.get(
             self._table_url(table),

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -18,7 +18,11 @@ from servicenow_mcp.errors import (
     ServerError,
     ServiceNowMCPError,
 )
-from servicenow_mcp.policy import INTERNAL_QUERY_LIMIT, mask_sensitive_fields
+from servicenow_mcp.policy import (
+    INTERNAL_QUERY_LIMIT,
+    enforce_privileged_query_safety,
+    mask_sensitive_fields,
+)
 from servicenow_mcp.sentry import set_sentry_context
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier, validate_sys_id
 
@@ -249,6 +253,12 @@ class ServiceNowClient:
         NOT on ``DENIED_TABLES`` - is rejected with ``PolicyError``, so
         the allowlist is the gate and mistakes fail closed.
 
+        "Privileged" means ONLY "bypass DENIED_TABLES" - it does NOT opt
+        out of cost-control clamps or the large-table date-filter
+        requirement. Those invariants are applied here via
+        ``enforce_privileged_query_safety`` so callers do not have to
+        hand-inline them (and drift).
+
         ``validate_identifier(table)`` still runs via ``_table_url``, and
         the returned records are passed through ``mask_sensitive_fields``
         (table-aware) so credential fields and script bodies are masked
@@ -262,13 +272,21 @@ class ServiceNowClient:
                 pre-declared it intends to read.
             query: Optional encoded query string.
             fields: Comma-separated field list (empty for default).
-            limit: Max rows to return.
+            limit: Max rows to return. Clamped to ``settings.max_row_limit``.
             offset: Row offset for pagination.
             display_values: If True, return display values (``sysparm_display_value=true``).
 
         Returns:
-            ``{"records": [...], "count": int}`` with credential fields
-            and script bodies masked.
+            ``{"records": [...], "count": int, "effective_limit": int}``
+            with credential fields and script bodies masked. ``effective_limit``
+            is the clamped limit actually sent to ServiceNow - callers
+            comparing ``len(records)`` against it can emit a truncation
+            warning without re-clamping themselves.
+
+        Raises:
+            PolicyError: If *table* is not in *allowed_tables*.
+            QuerySafetyError: If *table* is on ``settings.large_table_names``
+                and *query* lacks a date-bounded filter.
         """
         if table not in allowed_tables:
             raise PolicyError(
@@ -277,10 +295,12 @@ class ServiceNowClient:
                 "The allowlist is the gate; this is never relaxed to DENIED_TABLES."
             )
 
+        effective_limit = enforce_privileged_query_safety(table, query, limit, self._settings)
+
         http = self._ensure_client()
         params: dict[str, str] = {
             "sysparm_query": query,
-            "sysparm_limit": str(limit),
+            "sysparm_limit": str(effective_limit),
             "sysparm_offset": str(offset),
         }
         if fields:
@@ -296,7 +316,11 @@ class ServiceNowClient:
         self._raise_for_status(response)
         records = self._extract_result(response.json())
         masked = [mask_sensitive_fields(r, table=table) for r in records]
-        return {"records": masked, "count": self._parse_total_count(response)}
+        return {
+            "records": masked,
+            "count": self._parse_total_count(response),
+            "effective_limit": effective_limit,
+        }
 
     async def list_attachments(
         self,

--- a/src/servicenow_mcp/config.py
+++ b/src/servicenow_mcp/config.py
@@ -7,7 +7,9 @@ from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-_DEFAULT_LARGE_TABLES = "syslog,sys_audit,sys_log_transaction,sys_email_log"
+_DEFAULT_LARGE_TABLES = (
+    "syslog,sys_audit,sys_log_transaction,sys_email_log,cmdb_ci,cmdb_rel_ci,cmdb_ci_server,cmdb_ci_service"
+)
 
 
 class Settings(BaseSettings):
@@ -21,9 +23,12 @@ class Settings(BaseSettings):
     max_row_limit: int = 100
     large_table_names_csv: str = _DEFAULT_LARGE_TABLES
     script_allowed_root: str = ""
+    servicenow_allow_dangerous_bypass: bool = False
 
     sentry_dsn: str = ""
     sentry_environment: str = ""
+    sentry_send_pii: bool = False
+    sentry_traces_sample_rate: float = 0.05
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         env_file=[".env", ".env.local"],
@@ -58,6 +63,14 @@ class Settings(BaseSettings):
             get_package(v)
         except ValueError as e:
             raise ValueError(f"Invalid mcp_tool_package: {e}") from e
+        return v
+
+    @field_validator("sentry_traces_sample_rate")
+    @classmethod
+    def validate_sentry_traces_sample_rate(cls, v: float) -> float:
+        """Ensure sentry_traces_sample_rate is between 0.0 and 1.0 inclusive."""
+        if v < 0.0 or v > 1.0:
+            raise ValueError("sentry_traces_sample_rate must be between 0.0 and 1.0")
         return v
 
     @cached_property

--- a/src/servicenow_mcp/config.pyi
+++ b/src/servicenow_mcp/config.pyi
@@ -17,8 +17,11 @@ class Settings(BaseSettings):
     max_row_limit: int
     large_table_names_csv: str
     script_allowed_root: str
+    servicenow_allow_dangerous_bypass: bool
     sentry_dsn: str
     sentry_environment: str
+    sentry_send_pii: bool
+    sentry_traces_sample_rate: float
     def __init__(
         self,
         *,
@@ -30,8 +33,11 @@ class Settings(BaseSettings):
         max_row_limit: int = ...,
         large_table_names_csv: str = ...,
         script_allowed_root: str = ...,
+        servicenow_allow_dangerous_bypass: bool = ...,
         sentry_dsn: str = ...,
         sentry_environment: str = ...,
+        sentry_send_pii: bool = ...,
+        sentry_traces_sample_rate: float = ...,
         _env_file: EnvFileValue = ...,
     ) -> None: ...
     @classmethod
@@ -40,6 +46,8 @@ class Settings(BaseSettings):
     def validate_max_row_limit(cls, v: int) -> int: ...
     @classmethod
     def validate_mcp_tool_package(cls, v: str) -> str: ...
+    @classmethod
+    def validate_sentry_traces_sample_rate(cls, v: float) -> float: ...
     @property
     def large_table_names(self) -> frozenset[str]: ...
     @property

--- a/src/servicenow_mcp/decorators.py
+++ b/src/servicenow_mcp/decorators.py
@@ -5,6 +5,7 @@ import inspect
 from collections.abc import Callable, Coroutine
 from typing import Any, cast
 
+from servicenow_mcp.policy import is_dangerous_bypass_enabled
 from servicenow_mcp.sentry import set_sentry_context, set_sentry_tag
 from servicenow_mcp.types import SignatureMutableCallable
 from servicenow_mcp.utils import generate_correlation_id, safe_tool_call
@@ -34,13 +35,15 @@ def tool_handler(
 
         set_sentry_tag("tool.name", fn.__name__)
         set_sentry_tag("tool.correlation_id", correlation_id)
+        if is_dangerous_bypass_enabled():
+            set_sentry_tag("servicenow.dangerous_bypass", "true")
 
         set_sentry_context(
             "tool",
             {
                 "name": fn.__name__,
                 "correlation_id": correlation_id,
-                "args": {k: v for k, v in kwargs.items() if k != "correlation_id"},
+                "arg_keys": sorted(k for k in kwargs if k != "correlation_id"),
             },
         )
 

--- a/src/servicenow_mcp/investigations/acl_conflicts.py
+++ b/src/servicenow_mcp/investigations/acl_conflicts.py
@@ -8,13 +8,18 @@ from servicenow_mcp.investigation_helpers import build_investigation_result
 from servicenow_mcp.policy import (
     INTERNAL_QUERY_LIMIT,
     check_table_access,
-    mask_sensitive_fields,
 )
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 
+# ``sys_security_acl`` is on ``DENIED_TABLES`` because it discloses security
+# posture. This investigation legitimately needs to read it; we do so via the
+# client's privileged-read path with an explicit, single-entry allowlist.
+_PRIVILEGED_ACL_TABLES: frozenset[str] = frozenset({"sys_security_acl"})
+
+
 async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any]:
-    """Find ACL conflicts for a table — multiple ACLs with the same name.
+    """Find ACL conflicts for a table - multiple ACLs with the same name.
 
     Two or more ACLs with the same name and operation but different conditions
     can cause unpredictable access control behavior.
@@ -30,20 +35,15 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
 
     # Query ACLs for the table name and field-level ACLs
     query = ServiceNowQuery().equals("name", table).or_starts_with("name", f"{table}.").build()
-    acl_result = await client.query_records(
+    acl_result = await client.get_records_privileged(
         "sys_security_acl",
-        query,
-        fields=[
-            "sys_id",
-            "name",
-            "operation",
-            "condition",
-            "script",
-            "active",
-        ],
+        allowed_tables=_PRIVILEGED_ACL_TABLES,
+        query=query,
+        fields="sys_id,name,operation,condition,script,active",
         limit=INTERNAL_QUERY_LIMIT,
     )
-    acls = [mask_sensitive_fields(a) for a in acl_result["records"]]
+    # ``get_records_privileged`` already applies table-aware masking.
+    acls = list(acl_result["records"])
 
     # Group by (name, operation) to find true duplicates
     groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -93,8 +93,19 @@ async def explain(client: ServiceNowClient, element_id: str) -> dict[str, Any]:
     except ValueError as e:
         return {"error": str(e)}
 
-    check_table_access("sys_security_acl")
-    record = mask_sensitive_fields(await client.get_record("sys_security_acl", element_id))
+    # ``sys_security_acl`` is denied for tool callers; this investigation
+    # fetches the single matching row through the privileged-read path.
+    acl_result = await client.get_records_privileged(
+        "sys_security_acl",
+        allowed_tables=_PRIVILEGED_ACL_TABLES,
+        query=ServiceNowQuery().equals("sys_id", element_id).build(),
+        fields="sys_id,name,operation,condition,script,active",
+        limit=1,
+    )
+    records = acl_result["records"]
+    if not records:
+        return {"error": f"ACL with sys_id '{element_id}' not found"}
+    record = records[0]
 
     explanation_parts = [
         f"ACL '{record.get('name', '')}' controls {record.get('operation', '')} access.",

--- a/src/servicenow_mcp/investigations/table_health.py
+++ b/src/servicenow_mcp/investigations/table_health.py
@@ -13,6 +13,14 @@ from servicenow_mcp.policy import (
 from servicenow_mcp.utils import ServiceNowQuery, validate_identifier
 
 
+# ``sys_security_acl`` is on ``DENIED_TABLES``; the health investigation
+# reads it through the client's privileged-read path with an explicit,
+# single-entry allowlist. All other tables this investigation hits
+# (``sys_script``, ``sys_script_client``, ``sys_ui_policy``, ``syslog``)
+# go through the normal ``query_records`` path.
+_PRIVILEGED_ACL_TABLES: frozenset[str] = frozenset({"sys_security_acl"})
+
+
 async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any]:
     """Generate a health report for a specific table.
 
@@ -74,10 +82,11 @@ async def run(client: ServiceNowClient, params: dict[str, Any]) -> dict[str, Any
             fields=["sys_id", "name", "type"],
             limit=INTERNAL_QUERY_LIMIT,
         ),
-        client.query_records(
+        client.get_records_privileged(
             "sys_security_acl",
-            acl_q.build(),
-            fields=["sys_id", "name", "operation"],
+            allowed_tables=_PRIVILEGED_ACL_TABLES,
+            query=acl_q.build(),
+            fields="sys_id,name,operation",
             limit=INTERNAL_QUERY_LIMIT,
         ),
         client.query_records(

--- a/src/servicenow_mcp/policy.py
+++ b/src/servicenow_mcp/policy.py
@@ -10,8 +10,30 @@ from servicenow_mcp.errors import PolicyError, QuerySafetyError
 
 logger = logging.getLogger(__name__)
 
-# Tables that must never be accessed via the MCP server
+# Tables that must never be accessed via the MCP server.
+#
+# Grouping notes:
+#   - Credential / token tables: outright secrets (``sys_credentials``,
+#     ``oauth_credential``, ``sys_ssh_key`` ...).
+#   - PII tables: ``sys_user`` exposes email, phone, manager chain and
+#     employee_number in bulk.
+#   - Config / secret-bearing tables: ``sys_properties`` values routinely
+#     contain API keys and connection strings; ``sys_data_source`` carries
+#     connection info; ``sys_variable_value`` catalog variable values may
+#     include PII submitted by requesters.
+#   - Security-posture tables: ``sys_security_acl`` and ``sys_auth_profile``
+#     disclose enforcement structure useful for privilege escalation.
+#   - MID server tables: ``ecc_agent`` exposes MID topology;
+#     ``ecc_queue`` regularly contains credentials inside probe payloads.
+#   - Outbound email: ``sys_script_email`` bodies leak customer content.
+#
+# Investigation modules that legitimately need to read some of these tables
+# (``sys_security_acl`` in particular) do so via
+# ``ServiceNowClient.get_records_privileged()`` with an explicit per-call
+# allowlist; that method is the ONLY sanctioned bypass of this gate and is
+# not reachable from tool code paths.
 DENIED_TABLES: set[str] = {
+    # Existing entries
     "sys_user_has_password",
     "oauth_credential",
     "oauth_entity",
@@ -20,22 +42,189 @@ DENIED_TABLES: set[str] = {
     "sys_credentials",
     "discovery_credentials",
     "sys_user_token",
+    # Phase 4 additions
+    "sys_user",
+    "sys_properties",
+    "sys_security_acl",
+    "sys_auth_profile",
+    "sys_data_source",
+    "sys_variable_value",
+    "sys_script_email",
+    "ecc_agent",
+    "ecc_queue",
 }
 
-# Field name patterns that trigger masking
-_SENSITIVE_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"password", re.IGNORECASE),
-    re.compile(r"token", re.IGNORECASE),
-    re.compile(r"secret", re.IGNORECASE),
-    re.compile(r"credential", re.IGNORECASE),
-    re.compile(r"api_key", re.IGNORECASE),
-    re.compile(r"private_key", re.IGNORECASE),
-]
+# Field name patterns that trigger masking.
+#
+# Design notes for false-positive avoidance:
+#   - Substring-safe tokens (password, token, secret, credential, bearer,
+#     authorization, webhook, vault, certificate, x509, pkcs, jsessionid,
+#     connection_string, session_id, passphrase, keystore, truststore,
+#     cookie, apikey, privatekey) are matched anywhere in the field name.
+#   - ``cookie`` is deliberately substring-matched even though it appears in
+#     benign names (``cookie_name``); any cookie field is treated as a bearer
+#     credential. Callers are expected to accept the false-positive rate.
+#   - ``apikey`` / ``privatekey`` are the no-underscore variants that would
+#     otherwise slip past the underscore-aware ``api_key`` / ``private_key``
+#     tokens when ServiceNow field names are camel-cased.
+#   - Short/ambiguous tokens that appear as substrings of common non-sensitive
+#     fields are bounded to whole snake_case segments via ``(?:^|_)TOKEN(?:_|$)``
+#     rather than ``\b``. The Python regex ``\b`` treats ``_`` as a word
+#     character, so ``\bdsn\b`` would *not* reject ``primary_dsn``; the
+#     explicit underscore-or-edge boundary is correct.
+#       * ``dsn``    -> avoid matching ``address`` / ``description`` / ``dns_name``
+#       * ``pwd``    -> whole segment only (but ``user_pwd`` matches)
+#       * ``passwd`` -> whole segment only
+#       * ``otp``    -> avoid ``option`` / ``adopt``
+#       * ``kms``    -> avoid embedded acronyms
+#       * ``mfa``    -> avoid embedded acronyms (but ``mfa_secret`` matches)
+#       * ``cert``   -> avoid ``certification_level`` / ``concert`` /
+#                       ``certified_date``; whole-segment keeps ``ssl_cert``
+#                       and bare ``cert`` matching.
+#   - Compound ``_key`` / ``_pem`` / ``_header`` tokens are expressed as
+#     whole segments so that unrelated fields like ``assignment_group`` or
+#     ``company_sys_id`` do not false-positive.
+#   - ``authorization`` intentionally matches ``authorization_code`` because
+#     an authorization-code grant value is itself a bearer-equivalent secret.
+#   - Negative cases documented in ``tests/test_policy.py``:
+#     ``address``, ``description``, ``first_name``, ``assignment_group``,
+#     ``company_sys_id``, ``dns_name``, ``certification_level``,
+#     ``concert_ticket``, ``certified_date``.
+_SENSITIVE_SUBSTRING_RE: re.Pattern[str] = re.compile(
+    r"password"
+    r"|passphrase"
+    r"|token"
+    r"|secret"
+    r"|credential"
+    r"|bearer"
+    r"|authorization"
+    r"|webhook"
+    r"|vault"
+    r"|certificate"
+    r"|x509"
+    r"|pkcs"
+    r"|jsessionid"
+    r"|connection_string"
+    r"|session_id"
+    r"|auth_header"
+    r"|cert_pem"
+    r"|api_key"
+    r"|apikey"
+    r"|private_key"
+    r"|privatekey"
+    r"|ssh_key"
+    r"|rsa_key"
+    r"|signing_key"
+    r"|hmac_key"
+    r"|shared_key"
+    r"|master_key"
+    r"|encryption_key"
+    r"|mfa_secret"
+    r"|keystore"
+    r"|truststore"
+    r"|cookie",
+    re.IGNORECASE,
+)
+
+# Whole-segment match: the keyword must be either the entire field name or
+# bounded by underscores on each relevant side. Prevents e.g. ``dsn`` from
+# matching ``description`` while still catching ``primary_dsn``.
+_SENSITIVE_SEGMENT_RE: re.Pattern[str] = re.compile(
+    r"(?:^|_)(?:pwd|passwd|dsn|otp|kms|mfa|cert)(?:_|$)",
+    re.IGNORECASE,
+)
+
+_SENSITIVE_PATTERNS: list[re.Pattern[str]] = [_SENSITIVE_SUBSTRING_RE, _SENSITIVE_SEGMENT_RE]
 
 MASK_VALUE = "***MASKED***"
 
+# Distinct sentinel for script/markup body omission so callers can tell
+# credential masking and script-body masking apart in tool output.
+SCRIPT_BODY_MASK = "***SCRIPT_BODY_OMITTED***"
+
+# Tables whose records contain executable script or markup bodies. Values
+# are masked by default and returned only when a tool opts in via
+# ``include_script_body=True``. Script bodies often embed hardcoded secrets,
+# so they are treated as sensitive-by-default even though the field *names*
+# themselves (``script``, ``html``, ``xml`` ...) are not credential-like.
+TABLE_SCRIPT_FIELDS: dict[str, frozenset[str]] = {
+    "sys_script": frozenset({"script"}),
+    "sys_script_include": frozenset({"script"}),
+    "sys_script_client": frozenset({"script"}),
+    "sys_ui_policy": frozenset({"script_true", "script_false"}),
+    "sys_ui_action": frozenset({"script"}),
+    "sysauto_script": frozenset({"script"}),
+    "sys_script_fix": frozenset({"script"}),
+    "sp_widget": frozenset({"client_script", "server_script", "template"}),
+    "sys_ui_page": frozenset({"html", "client_script", "processing_script"}),
+    "sys_ui_macro": frozenset({"xml"}),
+    "sys_ui_script": frozenset({"script"}),
+    "sys_processor": frozenset({"script"}),
+    "sys_ws_operation": frozenset({"operation_script"}),
+    "sysevent_email_action": frozenset({"advanced_condition", "body_html"}),
+    "sysevent_script_action": frozenset({"script"}),
+    "ecc_agent_script_include": frozenset({"script"}),
+    "sys_web_service": frozenset({"script"}),
+    "sys_security_acl": frozenset({"script", "condition"}),
+    # Legacy Workflow Engine and Flow Designer tables. Their script-bearing
+    # columns are normally reached via the dedicated ``workflow_*`` / ``flow_*``
+    # tools (which already mask or opt-in). Registering them here closes the
+    # gap for generic ``record_get`` / ``table_query`` readers that bypass
+    # those tool-specific masking paths.
+    "wf_transition": frozenset({"condition"}),
+    "wf_workflow_version": frozenset({"condition"}),
+    "wf_activity": frozenset({"script"}),
+    "sys_hub_flow": frozenset({"condition"}),
+    "sys_hub_action_instance": frozenset({"condition", "script"}),
+}
+
 # Standard limit for internal/metadata queries (not user-facing)
 INTERNAL_QUERY_LIMIT: int = 1000
+
+# Module-level dangerous-bypass flag. Set once from server.py bootstrap.
+# When True, denied-table, write-gate and query-safety checks are skipped.
+# Field masking is NOT bypassed.
+_dangerous_bypass_enabled: bool = False
+# Sentinel enforcing one-shot assignment of the bypass flag. After the first
+# call to set_dangerous_bypass(), further calls raise RuntimeError. Tests that
+# need to toggle the flag must reset this module-level state directly.
+_bypass_locked: bool = False
+
+
+def set_dangerous_bypass(enabled: bool) -> None:
+    """Enable or disable the dangerous policy bypass (one-shot, bootstrap-only).
+
+    This setter may be called exactly once, from ``server.py`` at startup.
+    Subsequent calls raise ``RuntimeError`` so that no tool-call path can
+    flip the flag at runtime. Tool functions are never given access to this
+    setter, which combined with the one-shot sentinel makes the flag
+    effectively immutable for the lifetime of the process.
+    """
+    global _dangerous_bypass_enabled, _bypass_locked  # noqa: PLW0603
+    if _bypass_locked:
+        raise RuntimeError(
+            "set_dangerous_bypass() may only be called once, at server bootstrap. "
+            "Current state cannot be changed from tool call paths."
+        )
+    _dangerous_bypass_enabled = enabled
+    _bypass_locked = True
+
+
+def is_dangerous_bypass_enabled() -> bool:
+    """Return True if the dangerous policy bypass is currently enabled."""
+    return _dangerous_bypass_enabled
+
+
+def is_table_denied(table: str) -> bool:
+    """Return True if `table` is on the deny list AND the dangerous bypass is not active.
+
+    Prefer this over direct `DENIED_TABLES` membership checks so bypass semantics
+    remain centralized.
+    """
+    if _dangerous_bypass_enabled:
+        return False
+    return table.lower() in DENIED_TABLES
+
 
 # Date field patterns used to detect date-bounded filters
 _DATE_FIELD_PATTERNS: list[str] = [
@@ -59,6 +248,8 @@ def check_table_access(table: str) -> None:
 
     Returns None if access is allowed.
     """
+    if _dangerous_bypass_enabled:
+        return
     if table.lower() in DENIED_TABLES:
         raise PolicyError(f"Access to table '{table}' is denied by policy")
 
@@ -68,12 +259,43 @@ def is_sensitive_field(field_name: str) -> bool:
     return any(pattern.search(field_name) for pattern in _SENSITIVE_PATTERNS)
 
 
-def mask_sensitive_fields(record: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of the record with sensitive fields masked."""
+def mask_sensitive_fields(
+    record: dict[str, Any],
+    table: str | None = None,
+    *,
+    include_script_body: bool = False,
+) -> dict[str, Any]:
+    """Return a copy of ``record`` with sensitive fields masked.
+
+    Two independent masking passes run in order:
+
+    1. Credential masking: any field matching the sensitive-name regex is
+       replaced with ``MASK_VALUE``.
+    2. Script-body masking: when ``table`` is known to contain executable
+       script/markup (see ``TABLE_SCRIPT_FIELDS``) and the caller has not
+       opted in via ``include_script_body=True``, the registered fields are
+       replaced with ``SCRIPT_BODY_MASK``.
+
+    The credential pass runs first so a field matching both (contrived case)
+    reports the stronger ``MASK_VALUE`` sentinel rather than the script-body
+    one. Backward compatibility: calling with just ``record`` behaves as
+    before - no script-body masking is applied without a table context.
+    """
     masked = dict(record)
     for key in masked:
         if is_sensitive_field(key):
             masked[key] = MASK_VALUE
+
+    if table is None or include_script_body:
+        return masked
+
+    script_fields = TABLE_SCRIPT_FIELDS.get(table.lower())
+    if not script_fields:
+        return masked
+
+    for key in script_fields:
+        if key in masked and masked[key] != MASK_VALUE:
+            masked[key] = SCRIPT_BODY_MASK
     return masked
 
 
@@ -120,6 +342,10 @@ def enforce_query_safety(
     Returns a dict with the validated 'limit' value.
     Raises QuerySafetyError if constraints are violated.
     """
+    if _dangerous_bypass_enabled:
+        effective_limit = limit if limit is not None else settings.max_row_limit
+        return {"limit": max(1, effective_limit)}
+
     check_table_access(table)
 
     # Cap limit at max_row_limit
@@ -191,6 +417,8 @@ def write_blocked_reason(table: str, settings: Settings) -> str | None:
 
     Returns a reason string if writes are blocked, or None if allowed.
     """
+    if _dangerous_bypass_enabled:
+        return None
     if table.lower() in DENIED_TABLES:
         return f"Write operations are blocked for table '{table}' (restricted table)"
     if settings.is_production:

--- a/src/servicenow_mcp/policy.py
+++ b/src/servicenow_mcp/policy.py
@@ -365,6 +365,41 @@ def enforce_query_safety(
     return {"limit": effective_limit}
 
 
+def enforce_privileged_query_safety(
+    table: str,
+    query: str,
+    limit: int | None,
+    settings: Settings,
+) -> int:
+    """Apply the non-deny-list parts of query safety to a privileged read.
+
+    Privileged reads (``ServiceNowClient.get_records_privileged``) bypass
+    ``check_table_access`` by design - the caller's allowlist is the gate.
+    But "privileged" should mean ONLY "bypass DENIED_TABLES", not also
+    "opt out of cost-control clamps and large-table date-filter
+    requirements". This helper applies those two invariants so each
+    privileged caller does not hand-inline them (and drift).
+
+    Returns the effective clamped limit. Raises ``QuerySafetyError`` if
+    the table is large and ``query`` lacks a date-bounded filter.
+    """
+    if _dangerous_bypass_enabled:
+        effective_limit = limit if limit is not None else settings.max_row_limit
+        return max(1, effective_limit)
+
+    effective_limit = settings.max_row_limit if limit is None or limit > settings.max_row_limit else limit
+    effective_limit = max(1, effective_limit)
+
+    if table in settings.large_table_names and not _has_date_filter(query):
+        raise QuerySafetyError(
+            f"Table '{table}' is large and requires a date-bounded filter "
+            f"(e.g., sys_created_on>=YYYY-MM-DD). "
+            f"Add a date field constraint to your query."
+        )
+
+    return effective_limit
+
+
 def write_gate(table: str, settings: Settings, correlation_id: str) -> str | None:
     """Check write access and return a JSON error envelope if blocked, or None if allowed.
 

--- a/src/servicenow_mcp/sentry.py
+++ b/src/servicenow_mcp/sentry.py
@@ -8,7 +8,7 @@ when the package is missing or no DSN is configured.
 
 import logging
 from importlib.metadata import version as pkg_version
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 
 if TYPE_CHECKING:
@@ -94,9 +94,9 @@ def setup_sentry(settings: "Settings") -> None:
         dsn=dsn,
         environment=environment,
         release=_RELEASE,
-        send_default_pii=True,
+        send_default_pii=settings.sentry_send_pii,
         integrations=integrations,
-        traces_sample_rate=1.0,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
         profiles_sample_rate=None,
     )
 
@@ -117,6 +117,24 @@ def capture_exception(exc: BaseException | None = None) -> None:
     if not HAS_SENTRY or not _initialized:
         return
     sentry_sdk.capture_exception(exc)
+
+
+def capture_message(
+    message: str,
+    level: Literal["fatal", "critical", "error", "warning", "info", "debug"] = "warning",
+) -> None:
+    """Capture a message event and send it to Sentry.
+
+    No-ops when sentry-sdk is not installed or Sentry has not been
+    initialized (no DSN configured).
+
+    Args:
+        message: The message text to capture.
+        level: Severity level (e.g. ``"info"``, ``"warning"``, ``"error"``).
+    """
+    if not HAS_SENTRY or not _initialized:
+        return
+    sentry_sdk.capture_message(message, level=level)
 
 
 def set_sentry_tag(key: str, value: str) -> None:

--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -10,8 +10,9 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.config import Settings
 from servicenow_mcp.mcp_state import attach_servicenow_state
 from servicenow_mcp.packages import _TOOL_GROUP_MODULES, get_package, list_packages
+from servicenow_mcp.policy import set_dangerous_bypass
 from servicenow_mcp.sentry import capture_exception as sentry_capture
-from servicenow_mcp.sentry import set_sentry_context, setup_sentry, shutdown_sentry
+from servicenow_mcp.sentry import capture_message, set_sentry_context, set_sentry_tag, setup_sentry, shutdown_sentry
 from servicenow_mcp.state import QueryTokenStore
 from servicenow_mcp.utils import serialize
 
@@ -33,6 +34,24 @@ def create_mcp_server() -> FastMCP:
             "tool_package": settings.mcp_tool_package,
         },
     )
+
+    if settings.servicenow_allow_dangerous_bypass and settings.is_production:
+        raise RuntimeError(
+            "SERVICENOW_ALLOW_DANGEROUS_BYPASS is not permitted in production. Unset the flag or change SERVICENOW_ENV."
+        )
+
+    set_dangerous_bypass(settings.servicenow_allow_dangerous_bypass)
+    if settings.servicenow_allow_dangerous_bypass:
+        set_sentry_context(
+            "dangerous_bypass",
+            {
+                "dangerous_bypass": True,
+                "is_production": settings.is_production,
+            },
+        )
+        set_sentry_tag("servicenow.dangerous_bypass", "true")
+        logger.warning("DANGEROUS_BYPASS enabled - policy checks disabled (env=%s)", settings.servicenow_env)
+        capture_message("DANGEROUS_BYPASS enabled", level="warning")
 
     mcp = FastMCP("servicenow-platform-mcp")
 

--- a/src/servicenow_mcp/state.py
+++ b/src/servicenow_mcp/state.py
@@ -88,6 +88,27 @@ class QueryTokenStore(_BaseTokenStore):
     Tokens are UUID strings mapped to validated query payloads.
     Unlike PreviewTokenStore, tokens are reusable within their TTL.
     Expired tokens are automatically rejected on get.
+
+    Every payload MUST include a ``table`` key - the ServiceNow table
+    the query was built for. This binding lets ``resolve_query_token``
+    reject a token that is presented against a different table, closing
+    a cross-table token-replay class of bugs.
     """
 
     _store_label: str = "Query token"
+
+    def create(self, payload: dict[str, Any]) -> str:
+        """Store a payload and return a new UUID token.
+
+        Raises:
+            ValueError: if *payload* does not contain a non-empty ``table``
+                key. This is a hard structural requirement; callers that
+                need an unbound token should use ``PreviewTokenStore``.
+        """
+        table = payload.get("table")
+        if not isinstance(table, str) or not table:
+            raise ValueError(
+                "QueryTokenStore payload must include a non-empty 'table' key "
+                "so resolve_query_token can enforce per-table binding."
+            )
+        return super().create(payload)

--- a/src/servicenow_mcp/tools/_attachment_common.py
+++ b/src/servicenow_mcp/tools/_attachment_common.py
@@ -9,6 +9,14 @@ from servicenow_mcp.utils import resolve_ref_value, validate_identifier, validat
 
 MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
 
+# Base64 encodes 3 input bytes into 4 output characters (padding rounds up).
+# A valid payload of MAX_ATTACHMENT_BYTES decoded bytes is at most:
+#     ((MAX_ATTACHMENT_BYTES + 2) // 3) * 4 base64 characters
+# We allow a small slack for incidental whitespace / padding variance so that
+# a caller-side byte-accurate payload is not rejected by this pre-check.
+_BASE64_WHITESPACE_SLACK = 16
+MAX_BASE64_LENGTH = ((MAX_ATTACHMENT_BYTES + 2) // 3) * 4 + _BASE64_WHITESPACE_SLACK
+
 
 def ensure_attachment_size_value_within_limit(size_bytes: int, *, operation: str) -> None:
     """Raise ValueError when an attachment size exceeds the supported MCP transfer limit."""
@@ -23,6 +31,22 @@ def ensure_attachment_size_value_within_limit(size_bytes: int, *, operation: str
 def ensure_attachment_size_within_limit(content: bytes, *, operation: str) -> None:
     """Raise ValueError when attachment bytes exceed the supported MCP transfer limit."""
     ensure_attachment_size_value_within_limit(len(content), operation=operation)
+
+
+def ensure_base64_size_within_limit(content_base64: str, *, operation: str = "upload") -> None:
+    """Pre-decode guard: reject oversized base64 payloads before allocating the decoded buffer.
+
+    A base64 string that decodes to more than ``MAX_ATTACHMENT_BYTES`` bytes
+    must necessarily be longer than ``MAX_BASE64_LENGTH`` characters. Checking
+    the string length first avoids allocating a large decoded bytes object for
+    a payload that would be rejected by the post-decode size check anyway.
+    """
+    if len(content_base64) <= MAX_BASE64_LENGTH:
+        return
+    raise ValueError(
+        f"Attachment {operation} base64 payload of {len(content_base64)} characters exceeds the "
+        f"maximum supported size of {MAX_ATTACHMENT_BYTES} bytes (after decoding)"
+    )
 
 
 def decode_content_base64(content_base64: str) -> bytes:

--- a/src/servicenow_mcp/tools/_attachment_common.py
+++ b/src/servicenow_mcp/tools/_attachment_common.py
@@ -107,14 +107,25 @@ def get_attachment_size_bytes(metadata: dict[str, Any]) -> int:
     return size_bytes
 
 
-def build_attachment_download_payload(metadata: dict[str, Any], content: bytes) -> dict[str, Any]:
-    """Build a stable attachment download response payload."""
+def build_attachment_metadata_payload(metadata: dict[str, Any], size_bytes: int) -> dict[str, Any]:
+    """Build a metadata-only attachment response payload (no ``content_base64``).
+
+    ``size_bytes`` is the authoritative size in bytes. When the caller has
+    already downloaded the content, pass ``len(content)``; when only metadata
+    was fetched, pass ``get_attachment_size_bytes(metadata)``.
+    """
     return {
         "sys_id": get_attachment_sys_id(metadata),
         "table_name": get_attachment_table_name(metadata),
         "table_sys_id": get_attachment_table_sys_id(metadata),
         "file_name": get_attachment_field(metadata, "file_name"),
         "content_type": resolve_ref_value(metadata.get("content_type", "")),
-        "size_bytes": len(content),
-        "content_base64": encode_content_base64(content),
+        "size_bytes": size_bytes,
     }
+
+
+def build_attachment_download_payload(metadata: dict[str, Any], content: bytes) -> dict[str, Any]:
+    """Build a full attachment download response payload including base64 content."""
+    payload = build_attachment_metadata_payload(metadata, len(content))
+    payload["content_base64"] = encode_content_base64(content)
+    return payload

--- a/src/servicenow_mcp/tools/artifact_write.py
+++ b/src/servicenow_mcp/tools/artifact_write.py
@@ -1,4 +1,14 @@
-"""Write operations for ServiceNow platform artifacts."""
+"""Write operations for ServiceNow platform artifacts.
+
+All mutations flow through a preview/apply pair so callers must explicitly
+confirm a destructive change before it reaches ServiceNow. The preview step
+validates, classifies and describes the operation; the apply step consumes
+the preview token (single-use) and performs the write.
+
+The preview envelope never echoes script bodies verbatim and never echoes
+values for fields matched by :func:`policy.is_sensitive_field`. Script
+content is summarised by size and a short head snippet only.
+"""
 
 import json
 import logging
@@ -11,7 +21,15 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields, write_gate
+from servicenow_mcp.policy import (
+    MASK_VALUE,
+    TABLE_SCRIPT_FIELDS,
+    check_table_access,
+    is_sensitive_field,
+    mask_sensitive_fields,
+    write_gate,
+)
+from servicenow_mcp.state import PreviewTokenStore
 from servicenow_mcp.utils import format_response, validate_identifier, validate_sys_id
 
 
@@ -52,6 +70,16 @@ SCRIPT_FIELD_MAP: dict[str, str] = {
     "ui_macro": "xml",
     "notification_script": "advanced_condition",
 }
+
+# TTL for stored preview payloads; also echoed in the preview envelope so the
+# caller knows how long they have to apply.
+_PREVIEW_TTL_SECONDS: int = 300
+
+# Number of characters of the script body echoed back in the preview. A short
+# snippet helps a human verify they are applying the intended file; the full
+# body is deliberately withheld so leak-by-echo on denied applies cannot
+# reveal production script content.
+_SCRIPT_HEAD_CHARS: int = 80
 
 
 def _resolve_writable_artifact_table(artifact_type: str) -> str:
@@ -112,7 +140,11 @@ def _read_script_file(script_path: str, allowed_root: str) -> str:
     return resolved.read_text(encoding="utf-8")
 
 
-TOOL_NAMES: list[str] = ["artifact_create", "artifact_update"]
+TOOL_NAMES: list[str] = [
+    "artifact_create_preview",
+    "artifact_update_preview",
+    "artifact_apply",
+]
 
 
 def _parse_and_validate_payload(
@@ -122,11 +154,13 @@ def _parse_and_validate_payload(
     script_path: str,
     allowed_root: str,
     correlation_id: str,
-) -> tuple[dict[str, Any], list[str]] | str:
+) -> tuple[dict[str, Any], list[str], str | None] | str:
     """Parse, validate, and enrich a JSON payload for artifact write operations.
 
-    Returns a ``(data_dict, warnings)`` tuple on success, or a formatted error
-    response string when validation fails.
+    Returns a ``(data_dict, warnings, script_field)`` tuple on success, or a
+    formatted error response string when validation fails. ``script_field``
+    is the name of the field that received script-file content, or ``None``
+    when ``script_path`` was empty.
 
     Args:
         raw_json: The raw JSON string from the caller.
@@ -150,6 +184,7 @@ def _parse_and_validate_payload(
         validate_identifier(key)
 
     warnings: list[str] = []
+    script_field: str | None = None
 
     if script_path:
         content = _read_script_file(script_path, allowed_root)
@@ -158,22 +193,155 @@ def _parse_and_validate_payload(
             warnings.append(f"'{script_field}' field in {param_name} was overridden by script_path content.")
         payload[script_field] = content
 
-    return payload, warnings
+    return payload, warnings, script_field
+
+
+def _script_fields_for(table: str, explicit_script_field: str | None) -> frozenset[str]:
+    """Return the set of fields that should be treated as script bodies.
+
+    Combines the per-table registry from ``TABLE_SCRIPT_FIELDS`` with the
+    explicit field that received content from ``script_path`` (if any). The
+    explicit field matters for artifacts whose table is not in the registry.
+    """
+    registered = TABLE_SCRIPT_FIELDS.get(table.lower(), frozenset())
+    if explicit_script_field is None:
+        return registered
+    return registered | {explicit_script_field}
+
+
+def _summarise_field(
+    field_name: str,
+    value: Any,
+    *,
+    script_fields: frozenset[str],
+) -> Any:
+    """Return a preview-safe summary of a single field value.
+
+    Masks sensitive-named fields with ``MASK_VALUE``. Script-body fields are
+    replaced with a ``{"size_bytes", "head"}`` summary so the caller can
+    verify the script without the full body leaking through the envelope.
+    """
+    if is_sensitive_field(field_name):
+        return MASK_VALUE
+
+    if field_name in script_fields:
+        text = value if isinstance(value, str) else "" if value is None else str(value)
+        return {
+            "size_bytes": len(text.encode("utf-8")),
+            "head": text[:_SCRIPT_HEAD_CHARS],
+        }
+
+    return value
+
+
+def _summarise_payload(
+    payload: dict[str, Any],
+    *,
+    script_fields: frozenset[str],
+) -> dict[str, Any]:
+    """Produce a preview-safe view of a full payload dict."""
+    return {key: _summarise_field(key, value, script_fields=script_fields) for key, value in payload.items()}
+
+
+def _build_preview_diff(
+    changes: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    script_fields: frozenset[str],
+) -> dict[str, dict[str, Any]]:
+    """Build an update preview diff that masks credentials and summarises script bodies."""
+    diff: dict[str, dict[str, Any]] = {}
+    for field, new_value in changes.items():
+        old_value = current.get(field, "")
+        if is_sensitive_field(field):
+            diff[field] = {"old": MASK_VALUE, "new": MASK_VALUE}
+            continue
+        if field in script_fields:
+            diff[field] = {
+                "old": _script_summary(old_value) if old_value != "" else None,
+                "new": _script_summary(new_value),
+            }
+            continue
+        diff[field] = {"old": old_value, "new": new_value}
+    return diff
+
+
+def _script_summary(value: Any) -> dict[str, Any]:
+    """Return a ``{"size_bytes", "head"}`` summary for a script-body value."""
+    text = value if isinstance(value, str) else "" if value is None else str(value)
+    return {"size_bytes": len(text.encode("utf-8")), "head": text[:_SCRIPT_HEAD_CHARS]}
+
+
+def _mask_current_for_diff(current: dict[str, Any], table: str) -> dict[str, Any]:
+    """Mask the full current record for the ``before`` side of the diff envelope."""
+    return mask_sensitive_fields(current, table=table)
+
+
+async def _execute_apply(
+    client: ServiceNowClient,
+    payload: dict[str, Any],
+    correlation_id: str,
+) -> str:
+    """Execute the write stored in a preview payload and return the tool response."""
+    action = payload["action"]
+    table = payload["table"]
+    artifact_type = payload["artifact_type"]
+
+    if action == "create":
+        created = await client.create_record(table, payload["data"])
+        return format_response(
+            data={
+                "action": "create",
+                "table": table,
+                "artifact_type": artifact_type,
+                "sys_id": created["sys_id"],
+                "record": mask_sensitive_fields(created, table=table),
+            },
+            correlation_id=correlation_id,
+        )
+
+    if action == "update":
+        sys_id = payload["sys_id"]
+        updated = await client.update_record(table, sys_id, payload["changes"])
+        return format_response(
+            data={
+                "action": "update",
+                "table": table,
+                "artifact_type": artifact_type,
+                "sys_id": sys_id,
+                "record": mask_sensitive_fields(updated, table=table),
+            },
+            correlation_id=correlation_id,
+        )
+
+    return format_response(
+        data=None,
+        correlation_id=correlation_id,
+        status="error",
+        error=f"Unknown preview action: '{action}'",
+    )
 
 
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """Register artifact write tools on the MCP server."""
 
+    # Closure-local preview store so token scope is bounded by the MCP
+    # instance lifetime. Matches record_write's shape.
+    preview_store = PreviewTokenStore(ttl_seconds=_PREVIEW_TTL_SECONDS)
+
     @mcp.tool()
     @tool_handler
-    async def artifact_create(
+    async def artifact_create_preview(
         artifact_type: str,
         data: str,
         script_path: str = "",
         *,
         correlation_id: str = "",
     ) -> str:
-        """Create a new platform artifact in ServiceNow.
+        """Preview creating a platform artifact. Returns a token for artifact_apply.
+
+        The preview never echoes script bodies or values for sensitive fields.
+        Script content is summarised as ``{size_bytes, head}`` (first 80 chars).
 
         Args:
             artifact_type: The artifact type (e.g. 'business_rule', 'script_include', 'client_script').
@@ -192,17 +360,29 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         )
         if isinstance(result, str):
             return result
-        data_dict, warnings = result
+        data_dict, warnings, script_field = result
 
-        async with ServiceNowClient(settings, auth_provider) as client:
-            created = await client.create_record(table, data_dict)
-
-        return format_response(
-            data={
+        token = preview_store.create(
+            {
+                "action": "create",
                 "table": table,
                 "artifact_type": artifact_type,
-                "sys_id": created["sys_id"],
-                "record": mask_sensitive_fields(created),
+                "data": data_dict,
+            }
+        )
+
+        script_fields = _script_fields_for(table, script_field)
+        summary = _summarise_payload(data_dict, script_fields=script_fields)
+        return format_response(
+            data={
+                "token": token,
+                "action": "create",
+                "table": table,
+                "artifact_type": artifact_type,
+                "fields": sorted(data_dict.keys()),
+                "summary": summary,
+                "script_field": script_field,
+                "ttl_seconds": _PREVIEW_TTL_SECONDS,
             },
             correlation_id=correlation_id,
             warnings=warnings or None,
@@ -210,7 +390,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def artifact_update(
+    async def artifact_update_preview(
         artifact_type: str,
         sys_id: str,
         changes: str,
@@ -218,7 +398,11 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         *,
         correlation_id: str = "",
     ) -> str:
-        """Update an existing platform artifact in ServiceNow.
+        """Preview updating a platform artifact. Returns a token for artifact_apply.
+
+        Fetches the current record and returns a field-level diff that masks
+        sensitive fields on both sides and summarises script-body fields as
+        ``{size_bytes, head}`` rather than echoing their content.
 
         Args:
             artifact_type: The artifact type (e.g. 'business_rule', 'script_include', 'client_script').
@@ -240,18 +424,69 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         )
         if isinstance(result, str):
             return result
-        changes_dict, warnings = result
+        changes_dict, warnings, script_field = result
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            updated = await client.update_record(table, sys_id, changes_dict)
+            current = await client.get_record(table, sys_id)
 
-        return format_response(
-            data={
+        script_fields = _script_fields_for(table, script_field)
+        diff = _build_preview_diff(changes_dict, current, script_fields=script_fields)
+
+        token = preview_store.create(
+            {
+                "action": "update",
                 "table": table,
                 "artifact_type": artifact_type,
                 "sys_id": sys_id,
-                "record": mask_sensitive_fields(updated),
+                "changes": changes_dict,
+            }
+        )
+
+        return format_response(
+            data={
+                "token": token,
+                "action": "update",
+                "table": table,
+                "artifact_type": artifact_type,
+                "sys_id": sys_id,
+                "fields": sorted(changes_dict.keys()),
+                "diff": diff,
+                "before": _mask_current_for_diff(current, table),
+                "script_field": script_field,
+                "ttl_seconds": _PREVIEW_TTL_SECONDS,
             },
             correlation_id=correlation_id,
             warnings=warnings or None,
         )
+
+    @mcp.tool()
+    @tool_handler
+    async def artifact_apply(preview_token: str, *, correlation_id: str = "") -> str:
+        """Apply a previously previewed artifact create/update using its token.
+
+        Re-evaluates :func:`check_table_access` and :func:`write_gate` at
+        apply time so a policy change between preview and apply cannot be
+        ratified by a previously-issued token. Tokens are single-use and
+        expire after the preview TTL.
+
+        Args:
+            preview_token: The single-use token returned by artifact_create_preview or artifact_update_preview.
+        """
+        payload = preview_store.consume(preview_token)
+        if payload is None:
+            return format_response(
+                data=None,
+                correlation_id=correlation_id,
+                status="error",
+                error="Invalid or expired preview token",
+            )
+
+        table = payload["table"]
+        check_table_access(table)
+
+        blocked = write_gate(table, settings, correlation_id)
+        if blocked:
+            return blocked
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            return await _execute_apply(client, payload, correlation_id)

--- a/src/servicenow_mcp/tools/attachment.py
+++ b/src/servicenow_mcp/tools/attachment.py
@@ -13,6 +13,7 @@ from servicenow_mcp.errors import NotFoundError, PolicyError
 from servicenow_mcp.policy import check_table_access, enforce_query_safety, mask_sensitive_fields
 from servicenow_mcp.tools._attachment_common import (
     build_attachment_download_payload,
+    build_attachment_metadata_payload,
     ensure_attachment_size_value_within_limit,
     ensure_attachment_size_within_limit,
     get_attachment_size_bytes,
@@ -227,16 +228,38 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def attachment_download(sys_id: str, *, correlation_id: str = "") -> str:
-        """Download attachment content by attachment sys_id.
+    async def attachment_download(
+        sys_id: str,
+        include_content: bool = False,
+        *,
+        correlation_id: str = "",
+    ) -> str:
+        """Download attachment metadata by attachment sys_id.
+
+        Returns metadata only by default (``sys_id``, ``table_name``,
+        ``table_sys_id``, ``file_name``, ``content_type``, ``size_bytes``).
+        Pass ``include_content=True`` to additionally fetch and base64-encode
+        the bytes into ``content_base64``. The metadata-only path never
+        transfers the attachment body, so it also never counts against the
+        10 MB transfer cap.
 
         Args:
             sys_id: The sys_id of the attachment to download.
+            include_content: When True, include base64-encoded content. Defaults to False (metadata only).
         """
         validate_sys_id(sys_id)
         async with ServiceNowClient(settings, auth_provider) as client:
             metadata = await _get_attachment_metadata_checked(client, sys_id)
-            ensure_attachment_size_value_within_limit(get_attachment_size_bytes(metadata), operation="download")
+            size_bytes = get_attachment_size_bytes(metadata)
+
+            if not include_content:
+                masked_metadata = mask_sensitive_fields(metadata)
+                return format_response(
+                    data=build_attachment_metadata_payload(masked_metadata, size_bytes),
+                    correlation_id=correlation_id,
+                )
+
+            ensure_attachment_size_value_within_limit(size_bytes, operation="download")
             content = _require_bytes_content(await client.download_attachment(sys_id))
 
         ensure_attachment_size_within_limit(content, operation="download")
@@ -252,15 +275,20 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         table_name: str,
         table_sys_id: str,
         file_name: str,
+        include_content: bool = False,
         *,
         correlation_id: str = "",
     ) -> str:
-        """Download attachment content by source record and file name.
+        """Download attachment metadata by source record and file name.
+
+        Returns metadata only by default. Pass ``include_content=True`` to
+        additionally fetch and base64-encode the bytes into ``content_base64``.
 
         Args:
             table_name: The source table name.
             table_sys_id: The source record sys_id.
             file_name: The attachment file name.
+            include_content: When True, include base64-encoded content. Defaults to False (metadata only).
         """
         validate_identifier(table_name)
         validate_sys_id(table_sys_id)
@@ -273,7 +301,17 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 table_sys_id,
                 file_name,
             )
-            ensure_attachment_size_value_within_limit(get_attachment_size_bytes(metadata), operation="download")
+            size_bytes = get_attachment_size_bytes(metadata)
+
+            if not include_content:
+                masked_metadata = mask_sensitive_fields(metadata)
+                return format_response(
+                    data=build_attachment_metadata_payload(masked_metadata, size_bytes),
+                    correlation_id=correlation_id,
+                    warnings=warnings,
+                )
+
+            ensure_attachment_size_value_within_limit(size_bytes, operation="download")
             content = _require_bytes_content(await client.download_attachment(attachment_sys_id))
 
         ensure_attachment_size_within_limit(content, operation="download")

--- a/src/servicenow_mcp/tools/attachment_write.py
+++ b/src/servicenow_mcp/tools/attachment_write.py
@@ -12,6 +12,7 @@ from servicenow_mcp.policy import check_table_access, write_gate
 from servicenow_mcp.tools._attachment_common import (
     decode_content_base64,
     ensure_attachment_size_within_limit,
+    ensure_base64_size_within_limit,
     get_attachment_table_name,
 )
 from servicenow_mcp.utils import format_response, validate_identifier, validate_sys_id
@@ -61,6 +62,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         if blocked:
             return blocked
 
+        ensure_base64_size_within_limit(content_base64, operation="upload")
         content = decode_content_base64(content_base64)
         ensure_attachment_size_within_limit(content, operation="upload")
 

--- a/src/servicenow_mcp/tools/changes.py
+++ b/src/servicenow_mcp/tools/changes.py
@@ -1,6 +1,7 @@
 """Change intelligence tools for inspecting update sets, diffs, and audit trails."""
 
 import difflib
+import re
 from collections import defaultdict
 from typing import Any
 
@@ -12,6 +13,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     INTERNAL_QUERY_LIMIT,
+    SCRIPT_BODY_MASK,
     check_table_access,
     mask_audit_entry,
     mask_sensitive_fields,
@@ -151,6 +153,20 @@ def _build_release_notes_markdown(
     return us_name, "\n".join(lines)
 
 
+# Regex that matches a <script>...</script> block in an update-set payload
+# XML. Used to strip script bodies before diffing when the caller has not
+# opted in to seeing raw script contents.
+_PAYLOAD_SCRIPT_RE: re.Pattern[str] = re.compile(
+    r"(<script[^>]*>)(.*?)(</script>)",
+    re.DOTALL,
+)
+
+
+def _strip_payload_script_bodies(payload: str) -> str:
+    """Replace ``<script>...</script>`` bodies with the script-mask sentinel."""
+    return _PAYLOAD_SCRIPT_RE.sub(rf"\1{SCRIPT_BODY_MASK}\3", payload)
+
+
 # ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
@@ -198,7 +214,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def changes_diff_artifact(table: str, sys_id: str, *, correlation_id: str) -> str:
+    async def changes_diff_artifact(
+        table: str,
+        sys_id: str,
+        include_script_body: bool = False,
+        *,
+        correlation_id: str,
+    ) -> str:
         """Show a text diff between the two most recent versions of an artifact.
 
         Queries sys_update_version for the artifact's version history and produces
@@ -207,6 +229,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             table: The artifact table name (e.g., 'sys_script_include').
             sys_id: The sys_id of the artifact record.
+            include_script_body: If True, diff the raw payloads including
+                script/markup bodies. Script/markup bodies are masked by
+                default (both sides of the diff have their ``<script>`` bodies
+                replaced with a sentinel before diffing). Set True only when
+                you need to inspect the code itself; script bodies may
+                contain hardcoded secrets.
         """
         validate_identifier(table)
         check_table_access(table)
@@ -237,6 +265,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         new_payload = new_version.get("payload", "")
         old_date = old_version.get("sys_recorded_at", "unknown")
         new_date = new_version.get("sys_recorded_at", "unknown")
+
+        if not include_script_body:
+            old_payload = _strip_payload_script_bodies(old_payload)
+            new_payload = _strip_payload_script_bodies(new_payload)
 
         diff_lines = list(
             difflib.unified_diff(

--- a/src/servicenow_mcp/tools/documentation.py
+++ b/src/servicenow_mcp/tools/documentation.py
@@ -42,7 +42,15 @@ def _resolve_artifact_table(artifact_type: str, correlation_id: str) -> tuple[st
 
 
 async def _fetch_artifact_script(client: ServiceNowClient, table: str, sys_id: str) -> tuple[dict[str, Any], str]:
-    """Fetch an artifact record and return (masked_record, script_body)."""
+    """Fetch an artifact record and return (raw_record, script_body).
+
+    The record is returned with credential fields masked but script/markup
+    bodies intact so callers can perform internal analysis (dependency
+    extraction, anti-pattern scanning, scenario generation). Callers that
+    forward the record to tool output MUST re-mask via
+    ``mask_sensitive_fields(record, table=table, include_script_body=...)``
+    to honor the caller's opt-in preference.
+    """
     record = mask_sensitive_fields(await client.get_record(table, sys_id))
     script = record.get("script", "") or ""
     return record, script
@@ -217,7 +225,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def docs_artifact_summary(artifact_type: str, sys_id: str, *, correlation_id: str) -> str:
+    async def docs_artifact_summary(
+        artifact_type: str,
+        sys_id: str,
+        include_script_body: bool = False,
+        *,
+        correlation_id: str,
+    ) -> str:
         """Generate a summary for a platform artifact including dependencies.
 
         Parses the artifact's script for referenced GlideRecord tables and uses
@@ -226,6 +240,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             artifact_type: The artifact type (e.g. business_rule, script_include).
             sys_id: The sys_id of the artifact.
+            include_script_body: If True, include the raw script/markup body
+                on the returned artifact record. Script/markup bodies are
+                masked by default. Set True only when you need to inspect the
+                code itself; script bodies may contain hardcoded secrets.
         """
         table, err = _resolve_artifact_table(artifact_type, correlation_id)
         if err:
@@ -249,9 +267,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 except Exception:
                     pass
 
+        # Re-mask the artifact dict before returning so script body masking
+        # honors the caller's opt-in (the inner parsing above used the raw
+        # script, which we deliberately do not expose unless asked).
+        artifact = mask_sensitive_fields(record, table=table, include_script_body=include_script_body)
+
         return format_response(
             data={
-                "artifact": record,
+                "artifact": artifact,
                 "referenced_tables": referenced_tables,
                 "referenced_by": referenced_by,
                 "summary": (
@@ -264,7 +287,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def docs_test_scenarios(artifact_type: str, sys_id: str, *, correlation_id: str) -> str:
+    async def docs_test_scenarios(
+        artifact_type: str,
+        sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
         """Analyze an artifact's script and suggest test scenarios.
 
         Detects patterns like operation checks, conditional branches, role checks,
@@ -300,7 +328,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def docs_review_notes(artifact_type: str, sys_id: str, *, correlation_id: str) -> str:
+    async def docs_review_notes(
+        artifact_type: str,
+        sys_id: str,
+        *,
+        correlation_id: str,
+    ) -> str:
         """Scan an artifact's script for anti-patterns and generate review notes.
 
         Detects: GlideRecord in loop, hardcoded sys_ids, unbounded queries,

--- a/src/servicenow_mcp/tools/domains/cmdb.py
+++ b/src/servicenow_mcp/tools/domains/cmdb.py
@@ -10,7 +10,7 @@ from servicenow_mcp.choices import ChoiceRegistry
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
-from servicenow_mcp.policy import check_table_access, mask_sensitive_fields
+from servicenow_mcp.policy import check_table_access, enforce_query_safety, mask_sensitive_fields
 from servicenow_mcp.utils import ServiceNowQuery, format_response
 
 
@@ -104,6 +104,7 @@ def register_tools(
     async def cmdb_list(
         ci_class: str = "cmdb_ci",
         operational_status: str = "",
+        filter_query: str = "",
         fields: str = "name,sys_class_name,operational_status,sys_id,sys_updated_on",
         limit: int = 20,
         *,
@@ -114,6 +115,9 @@ def register_tools(
         Args:
             ci_class: CMDB table/class to query (default "cmdb_ci")
             operational_status: Filter by operational status (operational=1, non_operational=2, etc.)
+            filter_query: Additional encoded-query string AND'd into the final
+                query (e.g. "sys_updated_on>=javascript:gs.daysAgoStart(30)").
+                Required for large CMDB tables which enforce a date-bounded filter.
             fields: Comma-separated list of fields to return (empty for all)
             limit: Maximum results to return (default 20)
         """
@@ -127,8 +131,12 @@ def register_tools(
                 else operational_status
             )
             q = q.equals("operational_status", status_value)
-        query = q.build()
+        base_query = q.build()
+        query = f"{base_query}^{filter_query}" if base_query and filter_query else (base_query or filter_query)
         field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
+
+        safety = enforce_query_safety(ci_class, query, limit, settings)
+        effective_limit = safety["limit"]
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -136,7 +144,7 @@ def register_tools(
                 query=query,
                 fields=field_list,
                 display_values=True,
-                limit=limit,
+                limit=effective_limit,
             )
             masked = [mask_sensitive_fields(r) for r in result["records"]]
             return format_response(data=masked, correlation_id=correlation_id)

--- a/src/servicenow_mcp/tools/flow_designer.py
+++ b/src/servicenow_mcp/tools/flow_designer.py
@@ -15,6 +15,7 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     INTERNAL_QUERY_LIMIT,
+    SCRIPT_BODY_MASK,
     check_table_access,
     enforce_query_safety,
     mask_sensitive_fields,
@@ -57,6 +58,36 @@ _SCRIPT_KEYWORD_PATTERN: re.Pattern[str] = re.compile(
 def _contains_script_code(text: str) -> bool:
     """Return True when *text* contains patterns indicating executable script."""
     return bool(_SCRIPT_OBJECT_PATTERN.search(text) or _SCRIPT_KEYWORD_PATTERN.search(text))
+
+
+def _mask_script_variable(
+    variable: dict[str, Any],
+    *,
+    include_script_body: bool,
+) -> dict[str, Any]:
+    """Mask ``value`` on variable dicts whose ``variable`` name is a known script slot.
+
+    Uses ``STRICT_SCRIPT_VARIABLE_NAMES`` plus the heuristic that any
+    variable name ending in ``_script`` or typed as ``script`` /
+    ``condition_string`` carries executable code. Runs credential masking
+    first so sensitive-name fields retain ``MASK_VALUE``.
+    """
+    masked = mask_sensitive_fields(variable)
+    if include_script_body:
+        return masked
+    name = str(masked.get("variable", masked.get("name", ""))).lower().strip()
+    var_type = str(masked.get("type", "")).lower().strip()
+    is_script_slot = (
+        name in STRICT_SCRIPT_VARIABLE_NAMES
+        or name in CODE_AWARE_SCRIPT_VARIABLE_NAMES
+        or name.endswith("_script")
+        or var_type in {"script", "condition_string"}
+    )
+    if is_script_slot and "value" in masked and masked["value"]:
+        masked["value"] = SCRIPT_BODY_MASK
+    if is_script_slot and "default_value" in masked and masked["default_value"]:
+        masked["default_value"] = SCRIPT_BODY_MASK
+    return masked
 
 
 # Maps legacy workflow activity type names to their Flow Designer equivalents.
@@ -776,6 +807,8 @@ def _assemble_migration_response(
     vars_by_activity: dict[str, list[dict[str, Any]]],
     extracted_scripts: list[dict[str, str]],
     version_record: dict[str, Any],
+    *,
+    include_script_body: bool = False,
 ) -> dict[str, Any]:
     """Build the complete migration analysis response from pre-fetched data.
 
@@ -801,7 +834,28 @@ def _assemble_migration_response(
 
     workflow_name = resolve_ref_value(version_record.get("name", ""))
     workflow_table = resolve_ref_value(version_record.get("table", ""))
-    workflow_condition = resolve_ref_value(version_record.get("condition", ""))
+    workflow_condition_raw = resolve_ref_value(version_record.get("condition", ""))
+    workflow_condition = (
+        workflow_condition_raw if include_script_body else (SCRIPT_BODY_MASK if workflow_condition_raw else "")
+    )
+
+    masked_transitions: list[dict[str, Any]] = []
+    for t in transitions:
+        t_masked = mask_sensitive_fields(t)
+        if not include_script_body and t_masked.get("condition"):
+            t_masked["condition"] = SCRIPT_BODY_MASK
+        masked_transitions.append(t_masked)
+
+    # Mask script bodies in the extracted_scripts payload unless opted in.
+    scripts_out: list[dict[str, str]] = []
+    for entry in extracted_scripts:
+        if include_script_body:
+            scripts_out.append(entry)
+            continue
+        masked_entry = dict(entry)
+        if "script_body" in masked_entry:
+            masked_entry["script_body"] = SCRIPT_BODY_MASK
+        scripts_out.append(masked_entry)
 
     return {
         "workflow": {
@@ -813,12 +867,12 @@ def _assemble_migration_response(
         },
         "topology": {
             "activities": [mask_sensitive_fields(a) for a in activities],
-            "transitions": [mask_sensitive_fields(t) for t in transitions],
+            "transitions": masked_transitions,
             "cycles": cycles,
         },
         "migration_blockers": migration_blockers,
         "activity_mapping": activity_mapping,
-        "extracted_scripts": extracted_scripts,
+        "extracted_scripts": scripts_out,
         "complexity": {
             "score": complexity_score,
             "breakdown": {
@@ -935,6 +989,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     @tool_handler
     async def flow_get(
         flow_sys_id: str,
+        include_script_body: bool = False,
         *,
         correlation_id: str = "",
     ) -> str:
@@ -942,6 +997,11 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         Args:
             flow_sys_id: The sys_id of the sys_hub_flow record.
+            include_script_body: If True, return flow variable default values
+                that carry script/condition bodies verbatim. Script/markup
+                bodies are masked by default. Set True only when you need to
+                inspect the code itself; script bodies may contain hardcoded
+                secrets.
         """
         validate_identifier(flow_sys_id)
         check_table_access("sys_hub_flow")
@@ -971,7 +1031,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         return format_response(
             data={
                 "flow": mask_sensitive_fields(flow_record),
-                "variables": [mask_sensitive_fields(v) for v in var_result["records"]],
+                "variables": [
+                    _mask_script_variable(v, include_script_body=include_script_body) for v in var_result["records"]
+                ],
             },
             correlation_id=correlation_id,
         )
@@ -1291,6 +1353,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     @tool_handler
     async def workflow_migration_analysis(
         workflow_version_sys_id: str,
+        include_script_body: bool = False,
         *,
         correlation_id: str = "",
     ) -> str:
@@ -1302,6 +1365,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         Args:
             workflow_version_sys_id: The sys_id of the wf_workflow_version record to analyze.
+            include_script_body: If True, return extracted script bodies and
+                transition condition bodies verbatim. Script/markup bodies are
+                masked by default. Set True only when you need to inspect the
+                code itself; script bodies may contain hardcoded secrets.
         """
         validate_identifier(workflow_version_sys_id)
 
@@ -1318,7 +1385,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         all_warnings = topo_warnings + vars_warnings
 
         result = _assemble_migration_response(
-            activities, transitions, cycles, activity_name_lookup, vars_by_activity, extracted_scripts, version_record
+            activities,
+            transitions,
+            cycles,
+            activity_name_lookup,
+            vars_by_activity,
+            extracted_scripts,
+            version_record,
+            include_script_body=include_script_body,
         )
 
         return format_response(

--- a/src/servicenow_mcp/tools/flow_designer.py
+++ b/src/servicenow_mcp/tools/flow_designer.py
@@ -686,19 +686,19 @@ async def _extract_activity_scripts(
         return vars_by_activity, [], []
 
     vars_query = ServiceNowQuery().equals("document", "wf_activity").in_list("document_key", activity_sys_ids).build()
-    # Preserve prior clamp against ``max_row_limit`` now that we bypass
-    # ``enforce_query_safety`` for this table.
-    vars_limit = min(INTERNAL_QUERY_LIMIT, settings.max_row_limit)
+    # ``get_records_privileged`` clamps against ``settings.max_row_limit``
+    # internally, so pass the desired cap directly.
     vars_result = await client.get_records_privileged(
         "sys_variable_value",
         allowed_tables=_PRIVILEGED_VARIABLE_TABLES,
         query=vars_query,
         fields="sys_id,variable,value,document_key",
-        limit=vars_limit,
+        limit=INTERNAL_QUERY_LIMIT,
     )
+    effective_limit = vars_result["effective_limit"]
     warnings: list[str] = []
-    if len(vars_result["records"]) >= vars_limit:
-        warnings.append(f"Activity variables may be truncated at {vars_limit} records")
+    if len(vars_result["records"]) >= effective_limit:
+        warnings.append(f"Activity variables may be truncated at {effective_limit} records")
     for v in vars_result["records"]:
         key = resolve_ref_value(v.get("document_key", ""))
         vars_by_activity.setdefault(key, []).append(mask_sensitive_fields(v))

--- a/src/servicenow_mcp/tools/flow_designer.py
+++ b/src/servicenow_mcp/tools/flow_designer.py
@@ -45,6 +45,12 @@ FIELD_ACTIVITY_DEF_NAME = "activity_definition.name"
 # Known variable names that reliably contain script bodies in workflow activities.
 STRICT_SCRIPT_VARIABLE_NAMES: frozenset[str] = frozenset({"script", "run_script", "script_body"})
 CODE_AWARE_SCRIPT_VARIABLE_NAMES: frozenset[str] = frozenset({"condition"})
+
+# ``sys_variable_value`` is on ``DENIED_TABLES``. The migration-analysis
+# helper below legitimately needs to read it to surface embedded script
+# bodies; it does so via the client's privileged-read path with an
+# explicit, single-entry allowlist so any future caller mistake fails closed.
+_PRIVILEGED_VARIABLE_TABLES: frozenset[str] = frozenset({"sys_variable_value"})
 _SCRIPT_OBJECT_PATTERN: re.Pattern[str] = re.compile(
     r"\b(?:gs|current|workflow|answer|inputs|outputs)\s*\.|answer\s*=",
     re.IGNORECASE,
@@ -671,24 +677,28 @@ async def _extract_activity_scripts(
         groups variable records by activity sys_id, extracted_scripts contains
         script bodies found in those variables, and warnings lists any truncation notices.
     """
-    check_table_access("sys_variable_value")
+    # ``sys_variable_value`` is denied for general callers; this helper owns
+    # the decision to read it and routes through the privileged-read path
+    # with a narrow allowlist (see ``_PRIVILEGED_VARIABLE_TABLES``).
 
     vars_by_activity: dict[str, list[dict[str, Any]]] = {}
     if not activity_sys_ids:
         return vars_by_activity, [], []
 
     vars_query = ServiceNowQuery().equals("document", "wf_activity").in_list("document_key", activity_sys_ids).build()
-    vars_safety = enforce_query_safety("sys_variable_value", vars_query, INTERNAL_QUERY_LIMIT, settings)
-    vars_result = await client.query_records(
+    # Preserve prior clamp against ``max_row_limit`` now that we bypass
+    # ``enforce_query_safety`` for this table.
+    vars_limit = min(INTERNAL_QUERY_LIMIT, settings.max_row_limit)
+    vars_result = await client.get_records_privileged(
         "sys_variable_value",
-        vars_query,
-        fields=["sys_id", "variable", "value", "document_key"],
-        limit=vars_safety["limit"],
-        display_values=False,
+        allowed_tables=_PRIVILEGED_VARIABLE_TABLES,
+        query=vars_query,
+        fields="sys_id,variable,value,document_key",
+        limit=vars_limit,
     )
     warnings: list[str] = []
-    if len(vars_result["records"]) >= vars_safety["limit"]:
-        warnings.append(f"Activity variables may be truncated at {vars_safety['limit']} records")
+    if len(vars_result["records"]) >= vars_limit:
+        warnings.append(f"Activity variables may be truncated at {vars_limit} records")
     for v in vars_result["records"]:
         key = resolve_ref_value(v.get("document_key", ""))
         vars_by_activity.setdefault(key, []).append(mask_sensitive_fields(v))

--- a/src/servicenow_mcp/tools/metadata.py
+++ b/src/servicenow_mcp/tools/metadata.py
@@ -130,6 +130,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         artifact_type: str,
         query_token: str = "",
         limit: int = 100,
+        include_script_body: bool = False,
         *,
         correlation_id: str,
     ) -> str:
@@ -141,12 +142,16 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 Use build_query to create a query first, then pass the returned query_token here.
                 Leave empty for no additional filter.
             limit: Maximum number of artifacts to return.
+            include_script_body: If True, return script/markup body fields
+                verbatim. Script/markup bodies are masked by default. Set True
+                only when you need to inspect the code itself; script bodies
+                may contain hardcoded secrets.
         """
         table = _resolve_artifact_table(artifact_type)
 
         check_table_access(table)
 
-        query = resolve_query_token(query_token, query_store, correlation_id)
+        query = resolve_query_token(query_token, query_store, table, correlation_id)
         encoded_query = query
         safety = enforce_query_safety(table, encoded_query, limit, settings)
         effective_limit = safety["limit"]
@@ -162,7 +167,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             data={
                 "artifact_type": artifact_type,
                 "table": table,
-                "artifacts": [mask_sensitive_fields(r) for r in result["records"]],
+                "artifacts": [
+                    mask_sensitive_fields(r, table=table, include_script_body=include_script_body)
+                    for r in result["records"]
+                ],
                 "total": result["count"],
             },
             correlation_id=correlation_id,
@@ -173,6 +181,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     async def meta_get_artifact(
         artifact_type: str,
         sys_id: str,
+        include_script_body: bool = False,
         *,
         correlation_id: str,
     ) -> str:
@@ -181,13 +190,21 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             artifact_type: The type of artifact (business_rule, script_include, etc.).
             sys_id: The sys_id of the artifact to retrieve.
+            include_script_body: If True, return the artifact's script/markup
+                body verbatim. Script/markup bodies are masked by default. Set
+                True only when you need to inspect the code itself; script
+                bodies may contain hardcoded secrets.
         """
         table = _resolve_artifact_table(artifact_type)
 
         check_table_access(table)
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            record = mask_sensitive_fields(await client.get_record(table, sys_id))
+            record = mask_sensitive_fields(
+                await client.get_record(table, sys_id),
+                table=table,
+                include_script_body=include_script_body,
+            )
 
         return format_response(data=record, correlation_id=correlation_id)
 
@@ -234,6 +251,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     async def meta_what_writes(
         table: str,
         field: str = "",
+        include_script_body: bool = False,
         *,
         correlation_id: str,
     ) -> str:
@@ -242,6 +260,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         Args:
             table: The ServiceNow table to investigate (e.g., 'incident').
             field: Optional field name to narrow results. When provided, only returns writers whose script references this field.
+            include_script_body: If True, return the business rule script
+                bodies verbatim. Script/markup bodies are masked by default.
+                Set True only when you need to inspect the code itself; script
+                bodies may contain hardcoded secrets.
         """
         validate_identifier(table)
         if field:
@@ -263,7 +285,13 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 # If a field is specified, only include BRs that reference it
                 if field and field not in script:
                     continue
-                writers.append(mask_sensitive_fields(record))
+                writers.append(
+                    mask_sensitive_fields(
+                        record,
+                        table="sys_script",
+                        include_script_body=include_script_body,
+                    )
+                )
 
         return format_response(
             data={

--- a/src/servicenow_mcp/tools/record.py
+++ b/src/servicenow_mcp/tools/record.py
@@ -11,9 +11,9 @@ from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
-    DENIED_TABLES,
     INTERNAL_QUERY_LIMIT,
     check_table_access,
+    is_table_denied,
     mask_sensitive_fields,
 )
 from servicenow_mcp.utils import (
@@ -63,7 +63,7 @@ def _filter_reference_fields(records: list[dict[str, Any]]) -> list[tuple[str, s
         ref_field = field.get("element", "")
         if not ref_table or not ref_field:
             continue
-        if ref_table.lower() in DENIED_TABLES:
+        if is_table_denied(ref_table):
             continue
         if ref_table.startswith(("var__m_", "sys_variable_value")):
             continue
@@ -165,6 +165,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         sys_id: str,
         fields: str = "",
         display_values: bool = False,
+        include_script_body: bool = False,
         *,
         correlation_id: str = "",
     ) -> str:
@@ -175,13 +176,17 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             sys_id: The sys_id of the record to fetch.
             fields: Comma-separated list of fields to return (empty for all).
             display_values: If True, return display values instead of raw values.
+            include_script_body: If True, return script/markup body fields
+                verbatim. Script/markup bodies are masked by default. Set True
+                only when you need to inspect the code itself; script bodies
+                may contain hardcoded secrets.
         """
         validate_identifier(table)
         check_table_access(table)
         field_list = [f.strip() for f in fields.split(",") if f.strip()] if fields else None
         async with ServiceNowClient(settings, auth_provider) as client:
             record = await client.get_record(table, sys_id, fields=field_list, display_values=display_values)
-        record = mask_sensitive_fields(record)
+        record = mask_sensitive_fields(record, table=table, include_script_body=include_script_body)
         return format_response(data=record, correlation_id=correlation_id)
 
     # ------------------------------------------------------------------
@@ -222,18 +227,32 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
     @mcp.tool()
     @tool_handler
-    async def rel_references_from(table: str, sys_id: str, *, correlation_id: str = "") -> str:
+    async def rel_references_from(
+        table: str,
+        sys_id: str,
+        include_script_body: bool = False,
+        *,
+        correlation_id: str = "",
+    ) -> str:
         """Find what a record references by inspecting its reference fields.
 
         Args:
             table: The table of the source record.
             sys_id: The sys_id of the source record.
+            include_script_body: If True, return script/markup body fields
+                verbatim. Script/markup bodies are masked by default. Set True
+                only when you need to inspect the code itself; script bodies
+                may contain hardcoded secrets.
         """
         validate_identifier(table)
         check_table_access(table)
         async with ServiceNowClient(settings, auth_provider) as client:
             # Get the record
-            record = mask_sensitive_fields(await client.get_record(table, sys_id, display_values=True))
+            record = mask_sensitive_fields(
+                await client.get_record(table, sys_id, display_values=True),
+                table=table,
+                include_script_body=include_script_body,
+            )
 
             # Resolve full table hierarchy (e.g. incident -> task) so we
             # pick up inherited reference fields from parent tables.

--- a/src/servicenow_mcp/tools/record_write.py
+++ b/src/servicenow_mcp/tools/record_write.py
@@ -163,6 +163,32 @@ def _validate_write_request(table: str, settings: Settings, correlation_id: str)
     return write_gate(table, settings, correlation_id)
 
 
+def _parse_write_payload(
+    raw_json: str,
+    param_name: str,
+    correlation_id: str,
+) -> dict[str, Any] | str:
+    """Parse a JSON payload string into a dict of field-value pairs and validate keys.
+
+    Returns the parsed dict on success or a serialized error envelope string
+    when the input is not a JSON object. ``validate_identifier()`` on each
+    key raises ``ValueError`` on invalid field names; the ``@tool_handler``
+    decorator converts that to an error envelope automatically.
+    """
+    parsed = json.loads(raw_json)
+    if not isinstance(parsed, dict):
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"'{param_name}' must be a JSON object, not {type(parsed).__name__}",
+        )
+    payload: dict[str, Any] = parsed
+    for key in payload:
+        validate_identifier(key)
+    return payload
+
+
 def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """Register record write operation tools on the MCP server."""
 
@@ -186,7 +212,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         if blocked:
             return blocked
 
-        record_data = json.loads(data)
+        parsed = _parse_write_payload(data, "data", correlation_id)
+        if isinstance(parsed, str):
+            return parsed
+        record_data = parsed
 
         async with ServiceNowClient(settings, auth_provider) as client:
             err = await _check_mandatory_or_error(client, table, record_data, correlation_id)
@@ -216,7 +245,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         if blocked:
             return blocked
 
-        record_data = json.loads(data)
+        parsed = _parse_write_payload(data, "data", correlation_id)
+        if isinstance(parsed, str):
+            return parsed
+        record_data = parsed
 
         async with ServiceNowClient(settings, auth_provider) as client:
             err = await _check_mandatory_or_error(client, table, record_data, correlation_id)
@@ -258,7 +290,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         validate_sys_id(sys_id)
 
-        changes_dict = json.loads(changes)
+        parsed = _parse_write_payload(changes, "changes", correlation_id)
+        if isinstance(parsed, str):
+            return parsed
+        changes_dict = parsed
 
         async with ServiceNowClient(settings, auth_provider) as client:
             updated = await client.update_record(table, sys_id, changes_dict)
@@ -288,7 +323,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         validate_sys_id(sys_id)
 
-        changes_dict = json.loads(changes)
+        parsed = _parse_write_payload(changes, "changes", correlation_id)
+        if isinstance(parsed, str):
+            return parsed
+        changes_dict = parsed
 
         async with ServiceNowClient(settings, auth_provider) as client:
             current = await client.get_record(table, sys_id)

--- a/src/servicenow_mcp/tools/table.py
+++ b/src/servicenow_mcp/tools/table.py
@@ -331,14 +331,17 @@ def _apply_condition(
 
 def _build_query_impl(
     conditions_list: list[Any],
+    table: str,
     query_store: QueryTokenStore,
     correlation_id: str,
 ) -> str:
     """Process a parsed conditions list and return a formatted TOON response.
 
     Iterates over each condition dict, applies it to a ``ServiceNowQuery``,
-    stores the built query string in *query_store*, and returns the serialized
-    response.
+    stores the built query string in *query_store* bound to *table*, and
+    returns the serialized response. The ``table`` binding is enforced by
+    ``resolve_query_token`` so tokens cannot be replayed against a
+    different table.
     """
     query = ServiceNowQuery()
     for idx, condition in enumerate(conditions_list):
@@ -354,9 +357,9 @@ def _build_query_impl(
             return err
 
     built = query.build()
-    query_token = query_store.create({"query": built})
+    query_token = query_store.create({"query": built, "table": table})
     return format_response(
-        data={"query": built, "query_token": query_token},
+        data={"query": built, "query_token": query_token, "table": table},
         correlation_id=correlation_id,
     )
 
@@ -452,6 +455,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         offset: int = 0,
         order_by: str = "",
         display_values: bool = False,
+        include_script_body: bool = False,
         *,
         correlation_id: str = "",
     ) -> str:
@@ -467,10 +471,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             offset: Number of records to skip for pagination.
             order_by: Field to sort results by (empty for default).
             display_values: If True, return display values instead of raw values.
+            include_script_body: If True, return script/markup body fields
+                verbatim. Script/markup bodies are masked by default. Set True
+                only when you need to inspect the code itself; script bodies
+                may contain hardcoded secrets.
         """
         warnings: list[str] = []
 
-        query = resolve_query_token(query_token, query_store, correlation_id)
+        query = resolve_query_token(query_token, query_store, table, correlation_id)
         validate_identifier(table)
         check_table_access(table)
         safety = enforce_query_safety(table, query, limit, settings)
@@ -496,7 +504,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         if table == "sys_audit":
             masked_records = [mask_audit_entry(r) for r in result["records"]]
         else:
-            masked_records = [mask_sensitive_fields(r) for r in result["records"]]
+            masked_records = [
+                mask_sensitive_fields(r, table=table, include_script_body=include_script_body)
+                for r in result["records"]
+            ]
 
         return format_response(
             data=masked_records,
@@ -525,46 +536,60 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         """Compute aggregate statistics for a table (counts, min, max, avg, sum).
 
         Count is always included. For field-specific stats, provide comma-separated
-        field names (e.g. avg_fields="priority,impact").
+        field names (e.g. avg_fields="priority,impact"). Each field name is
+        validated via the shared identifier rules; empty entries between commas
+        are rejected.
 
         Args:
             table: The ServiceNow table name.
             query_token: Token from the build_query tool representing a ServiceNow encoded query.
                 Use build_query to create a query first, then pass the returned query_token here.
                 Leave empty for no filter.
-            group_by: Field to group results by (empty for no grouping).
+            group_by: Comma-separated fields to group results by (empty for no grouping).
             avg_fields: Comma-separated fields to compute average for.
             min_fields: Comma-separated fields to compute minimum for.
             max_fields: Comma-separated fields to compute maximum for.
             sum_fields: Comma-separated fields to compute sum for.
         """
-        query = resolve_query_token(query_token, query_store, correlation_id)
+        query = resolve_query_token(query_token, query_store, table, correlation_id)
         validate_identifier(table)
         check_table_access(table)
         enforce_query_safety(table, query, None, settings)
-        group = group_by or None
 
-        def _split(s: str) -> list[str] | None:
-            parts = [p.strip() for p in s.split(",") if p.strip()]
-            return parts or None
+        def _split_validated(raw: str, label: str) -> list[str] | None:
+            if not raw:
+                return None
+            parts = [p.strip() for p in raw.split(",")]
+            if any(not p for p in parts):
+                raise ValueError(f"{label} contains empty field name")
+            for p in parts:
+                validate_identifier(p)
+            return parts
+
+        group_parts = _split_validated(group_by, "group_by")
+        group = ",".join(group_parts) if group_parts else None
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.aggregate(
                 table,
                 query,
                 group_by=group,
-                avg_fields=_split(avg_fields),
-                min_fields=_split(min_fields),
-                max_fields=_split(max_fields),
-                sum_fields=_split(sum_fields),
+                avg_fields=_split_validated(avg_fields, "avg_fields"),
+                min_fields=_split_validated(min_fields, "min_fields"),
+                max_fields=_split_validated(max_fields, "max_fields"),
+                sum_fields=_split_validated(sum_fields, "sum_fields"),
             )
 
         return format_response(data=result, correlation_id=correlation_id)
 
     @mcp.tool()
     @tool_handler
-    async def build_query(conditions: str, correlation_id: str = "") -> str:
+    async def build_query(table: str, conditions: str, correlation_id: str = "") -> str:
         """Build a ServiceNow encoded query string from a JSON array of conditions.
+
+        The returned ``query_token`` is bound to *table* - it can only be
+        used with tools that query the same table. Attempting to use it
+        against a different table is rejected by policy.
 
         Each condition is an object with:
           - operator: The query operator (see groups below).
@@ -594,11 +619,15 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
           **Ordering:** order_by (optional ``descending``: boolean)
 
         Args:
+            table: The ServiceNow table name the query will be run against.
+                Binds the returned token to this table.
             conditions: JSON array of condition objects.
 
         Returns a response containing both the built query string and a query_token.
-        The query_token must be passed to other tools that accept query parameters.
+        The query_token must be passed to other tools that accept query parameters
+        and must match *table*.
         """
+        validate_identifier(table)
         try:
             parsed = json.loads(conditions)
         except json.JSONDecodeError as e:
@@ -617,4 +646,4 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 error="conditions must be a JSON array",
             )
 
-        return _build_query_impl(parsed, query_store, correlation_id)
+        return _build_query_impl(parsed, table, query_store, correlation_id)

--- a/src/servicenow_mcp/tools/testing.py
+++ b/src/servicenow_mcp/tools/testing.py
@@ -276,7 +276,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         default_fields = "sys_id,name,description,active,sys_updated_on,test_origin"
         field_list = fields or default_fields
 
-        query_str = resolve_query_token(query_token, query_store, correlation_id)
+        query_str = resolve_query_token(query_token, query_store, "sys_atf_test", correlation_id)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(
@@ -363,7 +363,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         check_table_access("sys_atf_test_suite")
         check_table_access("sys_atf_test_suite_test")
 
-        query = resolve_query_token(query_token, query_store, correlation_id)
+        query = resolve_query_token(query_token, query_store, "sys_atf_test_suite", correlation_id)
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.query_records(

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -12,9 +12,14 @@ from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.policy import (
     INTERNAL_QUERY_LIMIT,
+    SCRIPT_BODY_MASK,
     check_table_access,
     enforce_query_safety,
     mask_sensitive_fields,
+)
+from servicenow_mcp.tools.flow_designer import (
+    CODE_AWARE_SCRIPT_VARIABLE_NAMES,
+    STRICT_SCRIPT_VARIABLE_NAMES,
 )
 from servicenow_mcp.utils import (
     ServiceNowQuery,
@@ -25,6 +30,25 @@ from servicenow_mcp.utils import (
 
 
 logger = logging.getLogger(__name__)
+
+
+# Derived union of Flow Designer's two script-variable sets. Single source of
+# truth lives in ``flow_designer``; any field added there (strict or
+# code-aware) propagates here automatically, so legacy workflow activity
+# variables stay aligned with flow action variables without manual edits.
+SCRIPT_VARIABLE_NAMES: frozenset[str] = STRICT_SCRIPT_VARIABLE_NAMES | CODE_AWARE_SCRIPT_VARIABLE_NAMES
+
+
+def _mask_variable_value(variable: dict[str, Any], *, include_script_body: bool) -> dict[str, Any]:
+    """Return the variable dict with its ``value`` masked when it names a script body."""
+    masked = mask_sensitive_fields(variable)
+    if include_script_body:
+        return masked
+    name = str(masked.get("variable", "")).lower()
+    is_script_slot = name in SCRIPT_VARIABLE_NAMES or name.endswith("_script")
+    if is_script_slot and "value" in masked:
+        masked["value"] = SCRIPT_BODY_MASK
+    return masked
 
 
 # ------------------------------------------------------------------
@@ -58,6 +82,8 @@ async def _fetch_and_attach_variables(
     client: ServiceNowClient,
     activity_records: list[dict[str, Any]],
     settings: Settings,
+    *,
+    include_script_body: bool = False,
 ) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
     """Bulk-fetch activity variables and group them by activity sys_id.
 
@@ -86,7 +112,9 @@ async def _fetch_and_attach_variables(
             warnings.append(f"Activity variables may be truncated at {vars_safety['limit']} records")
         for v in vars_result["records"]:
             key = resolve_ref_value(v.get("document_key", ""))
-            vars_by_activity.setdefault(key, []).append(mask_sensitive_fields(v))
+            vars_by_activity.setdefault(key, []).append(
+                _mask_variable_value(v, include_script_body=include_script_body)
+            )
     except Exception as exc:
         warnings.append(f"Could not fetch activity variables: {exc}")
 
@@ -223,6 +251,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     @tool_handler
     async def workflow_map(
         workflow_version_sys_id: str,
+        include_script_body: bool = False,
         *,
         correlation_id: str,
     ) -> str:
@@ -233,6 +262,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         Args:
             workflow_version_sys_id: The sys_id of the wf_workflow_version record.
+            include_script_body: If True, return activity variable values that
+                carry script/condition bodies verbatim. Script/markup bodies
+                are masked by default. Set True only when you need to inspect
+                the code itself; script bodies may contain hardcoded secrets.
         """
         validate_identifier(workflow_version_sys_id)
         check_table_access("wf_workflow_version")
@@ -318,7 +351,12 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                 warnings.append(f"Transitions may be truncated at {trans_safety['limit']} records")
 
             activity_records = activity_result["records"]
-            vars_by_activity, var_warnings = await _fetch_and_attach_variables(client, activity_records, settings)
+            vars_by_activity, var_warnings = await _fetch_and_attach_variables(
+                client,
+                activity_records,
+                settings,
+                include_script_body=include_script_body,
+            )
             warnings.extend(var_warnings)
 
         # Attach variables to each activity
@@ -328,11 +366,20 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             masked["variables"] = vars_by_activity.get(resolve_ref_value(a["sys_id"]), [])
             activities.append(masked)
 
+        # wf_transition.condition carries scriptable condition bodies; mask
+        # them when the caller has not opted in.
+        masked_transitions: list[dict[str, Any]] = []
+        for t in transition_result["records"]:
+            t_masked = mask_sensitive_fields(t)
+            if not include_script_body and "condition" in t_masked and t_masked["condition"]:
+                t_masked["condition"] = SCRIPT_BODY_MASK
+            masked_transitions.append(t_masked)
+
         return format_response(
             data={
                 "version": mask_sensitive_fields(version_record),
                 "activities": activities,
-                "transitions": [mask_sensitive_fields(t) for t in transition_result["records"]],
+                "transitions": masked_transitions,
             },
             correlation_id=correlation_id,
             warnings=warnings if warnings else None,
@@ -419,6 +466,7 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
     @tool_handler
     async def workflow_activity_detail(
         activity_sys_id: str,
+        include_script_body: bool = False,
         *,
         correlation_id: str,
     ) -> str:
@@ -428,6 +476,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
 
         Args:
             activity_sys_id: The sys_id of the wf_activity record.
+            include_script_body: If True, return activity variable values that
+                carry script/condition bodies verbatim. Script/markup bodies
+                are masked by default. Set True only when you need to inspect
+                the code itself; script bodies may contain hardcoded secrets.
         """
         validate_identifier(activity_sys_id)
         check_table_access("wf_activity")
@@ -467,7 +519,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             data={
                 "activity": mask_sensitive_fields(display_activity),
                 "definition": mask_sensitive_fields(definition_record) if definition_record else None,
-                "variables": [mask_sensitive_fields(v) for v in variables_result["records"]],
+                "variables": [
+                    _mask_variable_value(v, include_script_body=include_script_body)
+                    for v in variables_result["records"]
+                ],
             },
             correlation_id=correlation_id,
             warnings=warnings if warnings else None,

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 SCRIPT_VARIABLE_NAMES: frozenset[str] = STRICT_SCRIPT_VARIABLE_NAMES | CODE_AWARE_SCRIPT_VARIABLE_NAMES
 
 
+# ``sys_variable_value`` is on ``DENIED_TABLES`` because it can hold secrets
+# pasted into workflow activity variables. Legitimate workflow introspection
+# needs to read it; we do so via the client's privileged-read path with an
+# explicit, single-entry allowlist so any future caller mistake fails closed.
+_PRIVILEGED_VARIABLE_TABLES: frozenset[str] = frozenset({"sys_variable_value"})
+
+
 def _mask_variable_value(variable: dict[str, Any], *, include_script_body: bool) -> dict[str, Any]:
     """Return the variable dict with its ``value`` masked when it names a script body."""
     masked = mask_sensitive_fields(variable)
@@ -100,16 +107,20 @@ async def _fetch_and_attach_variables(
         vars_query = (
             ServiceNowQuery().equals("document", "wf_activity").in_list("document_key", activity_sys_ids).build()
         )
-        vars_safety = enforce_query_safety("sys_variable_value", vars_query, INTERNAL_QUERY_LIMIT, settings)
-        vars_result = await client.query_records(
+        # ``sys_variable_value`` is denied for general callers; this helper
+        # owns the decision to read it and routes through the privileged
+        # path with a narrow allowlist. Preserve the prior clamp against
+        # ``max_row_limit`` so large instances stay bounded.
+        vars_limit = min(INTERNAL_QUERY_LIMIT, settings.max_row_limit)
+        vars_result = await client.get_records_privileged(
             "sys_variable_value",
-            vars_query,
-            fields=["sys_id", "variable", "value", "document_key"],
-            limit=vars_safety["limit"],
-            display_values=False,
+            allowed_tables=_PRIVILEGED_VARIABLE_TABLES,
+            query=vars_query,
+            fields="sys_id,variable,value,document_key",
+            limit=vars_limit,
         )
-        if len(vars_result["records"]) >= vars_safety["limit"]:
-            warnings.append(f"Activity variables may be truncated at {vars_safety['limit']} records")
+        if len(vars_result["records"]) >= vars_limit:
+            warnings.append(f"Activity variables may be truncated at {vars_limit} records")
         for v in vars_result["records"]:
             key = resolve_ref_value(v.get("document_key", ""))
             vars_by_activity.setdefault(key, []).append(
@@ -271,7 +282,8 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         check_table_access("wf_workflow_version")
         check_table_access("wf_activity")
         check_table_access("wf_transition")
-        check_table_access("sys_variable_value")
+        # ``sys_variable_value`` is handled by ``_fetch_and_attach_variables``
+        # via the privileged-read path (see ``_PRIVILEGED_VARIABLE_TABLES``).
 
         activity_query = ServiceNowQuery().equals("workflow_version", workflow_version_sys_id).order_by("x").build()
         transition_query = ServiceNowQuery().equals("from.workflow_version", workflow_version_sys_id).build()
@@ -483,12 +495,14 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         """
         validate_identifier(activity_sys_id)
         check_table_access("wf_activity")
-        check_table_access("sys_variable_value")
+        # ``sys_variable_value`` is denied for general callers; this tool
+        # routes it through the privileged-read path with a narrow allowlist
+        # (see ``_PRIVILEGED_VARIABLE_TABLES``).
 
         variables_query = (
             ServiceNowQuery().equals("document", "wf_activity").equals("document_key", activity_sys_id).build()
         )
-        vars_safety = enforce_query_safety("sys_variable_value", variables_query, 50, settings)
+        vars_limit = min(50, settings.max_row_limit)
 
         warnings: list[str] = []
 
@@ -500,16 +514,17 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
             # Phase 2: critical fetches (display activity + variables)
             display_activity, variables_result = await asyncio.gather(
                 client.get_record("wf_activity", activity_sys_id, display_values=True),
-                client.query_records(
+                client.get_records_privileged(
                     "sys_variable_value",
-                    variables_query,
-                    fields=["sys_id", "variable", "value", "document_key"],
-                    limit=vars_safety["limit"],
+                    allowed_tables=_PRIVILEGED_VARIABLE_TABLES,
+                    query=variables_query,
+                    fields="sys_id,variable,value,document_key",
+                    limit=vars_limit,
                     display_values=True,
                 ),
             )
-            if len(variables_result["records"]) >= vars_safety["limit"]:
-                warnings.append(f"Activity variables may be truncated at {vars_safety['limit']} records")
+            if len(variables_result["records"]) >= vars_limit:
+                warnings.append(f"Activity variables may be truncated at {vars_limit} records")
 
             # Non-critical: element definition (may be inaccessible on some instances)
             definition_record, def_warnings = await _fetch_activity_definition(client, definition_sys_id)

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -111,18 +111,18 @@ async def _fetch_and_attach_variables(
         )
         # ``sys_variable_value`` is denied for general callers; this helper
         # owns the decision to read it and routes through the privileged
-        # path with a narrow allowlist. Preserve the prior clamp against
-        # ``max_row_limit`` so large instances stay bounded.
-        vars_limit = min(INTERNAL_QUERY_LIMIT, settings.max_row_limit)
+        # path with a narrow allowlist. Clamping against ``max_row_limit``
+        # happens inside ``get_records_privileged``.
         vars_result = await client.get_records_privileged(
             "sys_variable_value",
             allowed_tables=_PRIVILEGED_VARIABLE_TABLES,
             query=vars_query,
             fields="sys_id,variable,value,document_key",
-            limit=vars_limit,
+            limit=INTERNAL_QUERY_LIMIT,
         )
-        if len(vars_result["records"]) >= vars_limit:
-            warnings.append(f"Activity variables may be truncated at {vars_limit} records")
+        effective_limit = vars_result["effective_limit"]
+        if len(vars_result["records"]) >= effective_limit:
+            warnings.append(f"Activity variables may be truncated at {effective_limit} records")
         for v in vars_result["records"]:
             key = resolve_ref_value(v.get("document_key", ""))
             vars_by_activity.setdefault(key, []).append(
@@ -521,7 +521,10 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
         variables_query = (
             ServiceNowQuery().equals("document", "wf_activity").equals("document_key", activity_sys_id).build()
         )
-        vars_limit = min(50, settings.max_row_limit)
+        # Per-tool narrow cap: a single activity should never need more than 50
+        # variables; ``get_records_privileged`` will further clamp against
+        # ``settings.max_row_limit``.
+        vars_limit = 50
 
         warnings: list[str] = []
 
@@ -542,8 +545,9 @@ def register_tools(mcp: FastMCP, settings: Settings, auth_provider: BasicAuthPro
                     display_values=True,
                 ),
             )
-            if len(variables_result["records"]) >= vars_limit:
-                warnings.append(f"Activity variables may be truncated at {vars_limit} records")
+            effective_limit = variables_result["effective_limit"]
+            if len(variables_result["records"]) >= effective_limit:
+                warnings.append(f"Activity variables may be truncated at {effective_limit} records")
 
             # Non-critical: element definition (may be inaccessible on some instances)
             definition_record, def_warnings = await _fetch_activity_definition(client, definition_sys_id)

--- a/src/servicenow_mcp/tools/workflow.py
+++ b/src/servicenow_mcp/tools/workflow.py
@@ -4,12 +4,14 @@ import asyncio
 import logging
 from typing import Any
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.client import ServiceNowClient
 from servicenow_mcp.config import Settings
 from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.errors import PolicyError, ServiceNowMCPError
 from servicenow_mcp.policy import (
     INTERNAL_QUERY_LIMIT,
     SCRIPT_BODY_MASK,
@@ -126,7 +128,14 @@ async def _fetch_and_attach_variables(
             vars_by_activity.setdefault(key, []).append(
                 _mask_variable_value(v, include_script_body=include_script_body)
             )
-    except Exception as exc:
+    except PolicyError:
+        # An allowlist misconfiguration or deny-list gate is a programmer
+        # bug - propagate so it fails loud at call sites and in tests.
+        raise
+    except (httpx.HTTPError, ServiceNowMCPError) as exc:
+        # Best-effort enrichment: tolerate transient HTTP failures and
+        # ServiceNow-side errors (NotFoundError, ServerError, etc.) by
+        # degrading to a warning.
         warnings.append(f"Could not fetch activity variables: {exc}")
 
     return vars_by_activity, warnings
@@ -153,7 +162,17 @@ async def _fetch_activity_definition(
             display_values=True,
         )
         return record, warnings
-    except Exception as exc:
+    except PolicyError:
+        # Deny-list gate misconfiguration is a programmer bug - fail loud.
+        raise
+    except (httpx.HTTPError, ServiceNowMCPError, ValueError) as exc:
+        # Best-effort enrichment. Tolerate:
+        #   - httpx.HTTPError / ServiceNowMCPError: transient HTTP or
+        #     ServiceNow-side issues (NotFound, ServerError, etc.).
+        #   - ValueError: ``definition_sys_id`` is a reference value taken
+        #     from a ServiceNow record; an untrusted value that fails
+        #     ``validate_sys_id`` means "no definition linked" for this
+        #     activity, not a programmer bug.
         logger.warning("Could not fetch element definition %s: %s", definition_sys_id, exc)
         warnings.append(f"Could not fetch activity definition from wf_element_definition: {exc}")
         return None, warnings

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, override
 
 from toon_format import encode as toon_encode
 
-from servicenow_mcp.errors import ForbiddenError
+from servicenow_mcp.errors import ForbiddenError, PolicyError
 from servicenow_mcp.sentry import capture_exception as sentry_capture
 
 
@@ -724,15 +724,31 @@ class ServiceNowQuery:
         return self.build()
 
 
-def resolve_query_token(query_token: str, query_store: "QueryTokenStore", correlation_id: str) -> str:
+def resolve_query_token(
+    query_token: str,
+    query_store: "QueryTokenStore",
+    expected_table: str,
+    correlation_id: str,
+) -> str:
     """Resolve a query token to the encoded query string it represents.
 
     Args:
         query_token: The token from build_query, or empty string for no filter.
         query_store: The shared QueryTokenStore instance.
+        expected_table: The table the caller is about to query with this
+            token. If the token was built for a different table, a
+            ``PolicyError`` is raised. This prevents cross-table token
+            replay (e.g. a token built for ``sys_properties`` being
+            presented to an ``incident`` query).
         correlation_id: Request correlation ID for error formatting.
 
-    Returns the encoded query string. Raises ValueError if the token is invalid or expired.
+    Returns:
+        The encoded query string.
+
+    Raises:
+        ValueError: If the token is invalid or expired.
+        PolicyError: If the token's bound table does not match
+            *expected_table*.
     """
     _ = correlation_id  # Kept for API consistency across tool helpers
     if not query_token:
@@ -740,6 +756,12 @@ def resolve_query_token(query_token: str, query_store: "QueryTokenStore", correl
     payload = query_store.get(query_token)
     if payload is None:
         raise ValueError("Invalid or expired query token. Use the build_query tool to create a query first.")
+    token_table = payload.get("table")
+    if token_table != expected_table:
+        raise PolicyError(
+            f"Query token was built for table {token_table!r} but used against table {expected_table!r}. "
+            "Rebuild the query with the correct table."
+        )
     return payload["query"]
 
 

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -99,7 +99,7 @@ def validate_identifier(name: str | dict[str, Any] | None) -> None:
     """
     if not isinstance(name, str):
         name = resolve_ref_value(name)
-    if not _IDENTIFIER_RE.match(name):
+    if not _IDENTIFIER_RE.fullmatch(name):
         raise ValueError(
             f"Invalid identifier: {name!r}. "
             "Only lowercase alphanumeric characters, underscores, and dot-walked segments are allowed."
@@ -110,7 +110,7 @@ def validate_sys_id(value: str) -> None:
     """Raise ValueError if *value* is not a valid ServiceNow sys_id (32-char hex)."""
     if not isinstance(value, str):
         value = resolve_ref_value(value)
-    if not _SYS_ID_RE.match(value):
+    if not _SYS_ID_RE.fullmatch(value):
         raise ValueError(f"Invalid sys_id: {value!r}. Expected a 32-character lowercase hexadecimal string.")
 
 

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -7,8 +7,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, override
 
-from toon_format import encode as toon_encode
-
+from servicenow_mcp._vendor.toon_format import encode as toon_encode
 from servicenow_mcp.errors import ForbiddenError, PolicyError
 from servicenow_mcp.sentry import capture_exception as sentry_capture
 

--- a/tests/domains/test_change.py
+++ b/tests/domains/test_change.py
@@ -42,12 +42,12 @@ class TestChangeList:
                 json={
                     "result": [
                         {
-                            "sys_id": "id1",
+                            "sys_id": "4e89d81a2e6fb4be2578d245fd8511c1",
                             "number": "CHG0010001",
                             "short_description": "Test change 1",
                         },
                         {
-                            "sys_id": "id2",
+                            "sys_id": "867d5f8110f8aa79dd63d7440f217242",
                             "number": "CHG0010002",
                             "short_description": "Test change 2",
                         },
@@ -104,7 +104,7 @@ class TestChangeGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "CHG0010001",
                             "short_description": "Test change",
                         }
@@ -119,7 +119,7 @@ class TestChangeGet:
 
         assert data["status"] == "success"
         assert data["data"]["number"] == "CHG0010001"
-        assert data["data"]["sys_id"] == "abc123"
+        assert data["data"]["sys_id"] == "6367c48dd193d56ea7b0baad25b19455"
 
     @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -157,7 +157,7 @@ class TestChangeCreate:
                 201,
                 json={
                     "result": {
-                        "sys_id": "new001",
+                        "sys_id": "7902e27f95800a66bf6fcbfe1fa5e403",
                         "number": "CHG0010123",
                         "short_description": "New change",
                         "type": "normal",
@@ -185,13 +185,13 @@ class TestChangeCreate:
                 201,
                 json={
                     "result": {
-                        "sys_id": "new002",
+                        "sys_id": "f20eedc7e49805bc6b96e5c163161426",
                         "number": "CHG0010124",
                         "short_description": "Full change",
                         "type": "emergency",
                         "description": "Detailed desc",
                         "risk": "high",
-                        "assignment_group": "grp001",
+                        "assignment_group": "d82fd21c333207af2b8697ceb8a9345e",
                         "start_date": "2026-04-01 08:00:00",
                         "end_date": "2026-04-01 12:00:00",
                     }
@@ -205,7 +205,7 @@ class TestChangeCreate:
             description="Detailed desc",
             type="emergency",
             risk="high",
-            assignment_group="grp001",
+            assignment_group="d82fd21c333207af2b8697ceb8a9345e",
             start_date="2026-04-01 08:00:00",
             end_date="2026-04-01 12:00:00",
         )
@@ -219,7 +219,7 @@ class TestChangeCreate:
         request_body = json.loads(route.calls.last.request.content)
         assert request_body["description"] == "Detailed desc"
         assert request_body["risk"] == "high"
-        assert request_body["assignment_group"] == "grp001"
+        assert request_body["assignment_group"] == "d82fd21c333207af2b8697ceb8a9345e"
         assert request_body["start_date"] == "2026-04-01 08:00:00"
         assert request_body["end_date"] == "2026-04-01 12:00:00"
 
@@ -269,7 +269,7 @@ class TestChangeUpdate:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "CHG0010001",
                             "short_description": "Old",
                         }
@@ -277,12 +277,12 @@ class TestChangeUpdate:
                 },
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/change_request/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/change_request/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "CHG0010001",
                         "short_description": "Updated",
                     }
@@ -346,15 +346,15 @@ class TestChangeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/change_request").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "CHG0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "CHG0010001"}]},
             )
         )
-        route = respx.patch(f"{BASE_URL}/api/now/table/change_request/abc123").mock(
+        route = respx.patch(f"{BASE_URL}/api/now/table/change_request/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "CHG0010001",
                         "short_description": "Updated",
                     }
@@ -369,7 +369,7 @@ class TestChangeUpdate:
             description="New detailed desc",
             type="emergency",
             risk="high",
-            assignment_group="grp001",
+            assignment_group="d82fd21c333207af2b8697ceb8a9345e",
             state="implement",
         )
         data = decode_response(result)
@@ -382,7 +382,7 @@ class TestChangeUpdate:
         assert request_body["description"] == "New detailed desc"
         assert request_body["type"] == "emergency"
         assert request_body["risk"] == "high"
-        assert request_body["assignment_group"] == "grp001"
+        assert request_body["assignment_group"] == "d82fd21c333207af2b8697ceb8a9345e"
         assert request_body["state"] == "-1"
 
     @pytest.mark.asyncio()
@@ -392,7 +392,7 @@ class TestChangeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/change_request").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "CHG0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "CHG0010001"}]},
             )
         )
 
@@ -417,12 +417,12 @@ class TestChangeTasks:
                 json={
                     "result": [
                         {
-                            "sys_id": "task1",
+                            "sys_id": "d95216b77e0cd834ca43caef2322e8fd",
                             "number": "CTASK0010001",
                             "short_description": "Task 1",
                         },
                         {
-                            "sys_id": "task2",
+                            "sys_id": "7c83d7b877a6404c368370bdcfeee47a",
                             "number": "CTASK0010002",
                             "short_description": "Task 2",
                         },
@@ -478,15 +478,15 @@ class TestChangeAddComment:
         respx.get(f"{BASE_URL}/api/now/table/change_request").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "CHG0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "CHG0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/change_request/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/change_request/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "CHG0010001",
                         "comments": "User comment added",
                     }
@@ -510,15 +510,15 @@ class TestChangeAddComment:
         respx.get(f"{BASE_URL}/api/now/table/change_request").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "CHG0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "CHG0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/change_request/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/change_request/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "CHG0010001",
                         "work_notes": "Internal work note",
                     }

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -87,7 +87,9 @@ class TestCmdbList:
             )
         )
 
-        result = await cmdb_list(ci_class="cmdb_ci_server", filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)")
+        result = await cmdb_list(
+            ci_class="cmdb_ci_server", filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)"
+        )
         data = toon_decode(result)
         assert isinstance(data, dict)
 
@@ -120,7 +122,9 @@ class TestCmdbList:
             )
         )
 
-        result = await cmdb_list(operational_status="operational", filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)")
+        result = await cmdb_list(
+            operational_status="operational", filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)"
+        )
         data = toon_decode(result)
         assert isinstance(data, dict)
 

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -57,7 +57,7 @@ class TestCmdbList:
             )
         )
 
-        result = await cmdb_list()
+        result = await cmdb_list(filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)")
         data = toon_decode(result)
         assert isinstance(data, dict)
 
@@ -87,7 +87,7 @@ class TestCmdbList:
             )
         )
 
-        result = await cmdb_list(ci_class="cmdb_ci_server")
+        result = await cmdb_list(ci_class="cmdb_ci_server", filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)")
         data = toon_decode(result)
         assert isinstance(data, dict)
 
@@ -120,7 +120,7 @@ class TestCmdbList:
             )
         )
 
-        result = await cmdb_list(operational_status="operational")
+        result = await cmdb_list(operational_status="operational", filter_query="sys_updated_on>=javascript:gs.daysAgoStart(30)")
         data = toon_decode(result)
         assert isinstance(data, dict)
 

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -43,12 +43,12 @@ class TestCmdbList:
                 json={
                     "result": [
                         {
-                            "sys_id": "ci1",
+                            "sys_id": "d5f759f849bd82f4d43947407ffce511",
                             "name": "server-01",
                             "operational_status": "1",
                         },
                         {
-                            "sys_id": "ci2",
+                            "sys_id": "6f7aa3d044bfc90517430647fcbddac7",
                             "name": "server-02",
                             "operational_status": "1",
                         },
@@ -78,7 +78,7 @@ class TestCmdbList:
                 json={
                     "result": [
                         {
-                            "sys_id": "srv1",
+                            "sys_id": "5c2a24d29e9808883ba0a350e7dc48e5",
                             "name": "web-server-01",
                             "operational_status": "1",
                         },
@@ -111,7 +111,7 @@ class TestCmdbList:
                 json={
                     "result": [
                         {
-                            "sys_id": "ci1",
+                            "sys_id": "d5f759f849bd82f4d43947407ffce511",
                             "name": "server-01",
                             "operational_status": "1",
                         },
@@ -177,7 +177,7 @@ class TestCmdbGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "ci1",
+                            "sys_id": "d5f759f849bd82f4d43947407ffce511",
                             "name": "server-01",
                             "operational_status": "1",
                         },
@@ -235,14 +235,14 @@ class TestCmdbRelationships:
                 json={
                     "result": [
                         {
-                            "sys_id": "rel1",
-                            "parent": {"value": "parent1"},
+                            "sys_id": "e25a989db0d225460c84b6adc8379e40",
+                            "parent": {"value": "411f59c16d07dfbc60fb633faa920142"},
                             "child": {"value": sys_id},
                         },
                         {
-                            "sys_id": "rel2",
+                            "sys_id": "8985c6e32965ad99e9b8530d98b8d41f",
                             "parent": {"value": sys_id},
-                            "child": {"value": "child1"},
+                            "child": {"value": "821c07a03badb405e8ccaea45217e56e"},
                         },
                     ]
                 },
@@ -270,8 +270,8 @@ class TestCmdbRelationships:
                 json={
                     "result": [
                         {
-                            "sys_id": "rel1",
-                            "parent": {"value": "parent1"},
+                            "sys_id": "e25a989db0d225460c84b6adc8379e40",
+                            "parent": {"value": "411f59c16d07dfbc60fb633faa920142"},
                             "child": {"value": sys_id},
                         },
                     ]
@@ -314,8 +314,8 @@ class TestCmdbRelationships:
                 json={
                     "result": [
                         {
-                            "sys_id": "rel1",
-                            "parent": {"value": "parent1"},
+                            "sys_id": "e25a989db0d225460c84b6adc8379e40",
+                            "parent": {"value": "411f59c16d07dfbc60fb633faa920142"},
                             "child": {"value": "resolved_sys_id"},
                         },
                     ]
@@ -365,9 +365,9 @@ class TestCmdbRelationships:
                 json={
                     "result": [
                         {
-                            "sys_id": "rel1",
+                            "sys_id": "e25a989db0d225460c84b6adc8379e40",
                             "parent": {"value": sys_id},
-                            "child": {"value": "child1"},
+                            "child": {"value": "821c07a03badb405e8ccaea45217e56e"},
                         },
                     ]
                 },

--- a/tests/domains/test_cmdb.py
+++ b/tests/domains/test_cmdb.py
@@ -5,8 +5,8 @@ from typing import Any
 import pytest
 import respx
 from httpx import Response
-from toon_format import decode as toon_decode
 
+from servicenow_mcp._vendor.toon_format import decode as toon_decode
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 from servicenow_mcp.tools.domains import cmdb

--- a/tests/domains/test_helpers.py
+++ b/tests/domains/test_helpers.py
@@ -3,8 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from toon_format import decode as toon_decode
 
+from servicenow_mcp._vendor.toon_format import decode as toon_decode
 from servicenow_mcp.tools.domains._helpers import (
     fetch_record_by_number,
     lookup_record_by_number,

--- a/tests/domains/test_incident.py
+++ b/tests/domains/test_incident.py
@@ -59,12 +59,12 @@ class TestIncidentList:
                 json={
                     "result": [
                         {
-                            "sys_id": "id1",
+                            "sys_id": "4e89d81a2e6fb4be2578d245fd8511c1",
                             "number": "INC0010001",
                             "short_description": "Test 1",
                         },
                         {
-                            "sys_id": "id2",
+                            "sys_id": "867d5f8110f8aa79dd63d7440f217242",
                             "number": "INC0010002",
                             "short_description": "Test 2",
                         },
@@ -121,7 +121,7 @@ class TestIncidentGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "INC0010001",
                             "short_description": "Test incident",
                         }
@@ -136,7 +136,7 @@ class TestIncidentGet:
 
         assert data["status"] == "success"
         assert data["data"]["number"] == "INC0010001"
-        assert data["data"]["sys_id"] == "abc123"
+        assert data["data"]["sys_id"] == "6367c48dd193d56ea7b0baad25b19455"
 
     @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -174,7 +174,7 @@ class TestIncidentCreate:
                 201,
                 json={
                     "result": {
-                        "sys_id": "new001",
+                        "sys_id": "7902e27f95800a66bf6fcbfe1fa5e403",
                         "number": "INC0010123",
                         "short_description": "New incident",
                         "state": "1",
@@ -255,7 +255,7 @@ class TestIncidentCreate:
                 201,
                 json={
                     "result": {
-                        "sys_id": "new002",
+                        "sys_id": "f20eedc7e49805bc6b96e5c163161426",
                         "number": "INC0010200",
                         "short_description": "Full incident",
                     }
@@ -301,7 +301,7 @@ class TestIncidentUpdate:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "INC0010001",
                             "short_description": "Old",
                         }
@@ -309,12 +309,12 @@ class TestIncidentUpdate:
                 },
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0010001",
                         "short_description": "Updated",
                     }
@@ -375,7 +375,7 @@ class TestIncidentUpdate:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0010001"}]},
             )
         )
 
@@ -393,15 +393,15 @@ class TestIncidentUpdate:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0010001"}]},
             )
         )
-        route = respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        route = respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0010001",
                         "short_description": "Updated",
                     }
@@ -453,7 +453,7 @@ class TestIncidentResolve:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "INC0010001",
                             "state": "2",
                         }
@@ -461,12 +461,12 @@ class TestIncidentResolve:
                 },
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0010001",
                         "state": "6",
                         "close_code": "Solved (Permanently)",
@@ -574,7 +574,7 @@ class TestIncidentResolve:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "INC0010001",
                             "state": "2",
                         }
@@ -582,12 +582,12 @@ class TestIncidentResolve:
                 },
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0010001",
                         "state": "6",
                         "close_code": "Solved (Permanently)",
@@ -619,15 +619,15 @@ class TestIncidentAddComment:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0010001",
                         "comments": "User comment added",
                     }
@@ -651,15 +651,15 @@ class TestIncidentAddComment:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "INC0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0010001",
                         "work_notes": "Internal work note",
                     }

--- a/tests/domains/test_knowledge.py
+++ b/tests/domains/test_knowledge.py
@@ -42,12 +42,12 @@ class TestKnowledgeSearch:
                 json={
                     "result": [
                         {
-                            "sys_id": "kb1",
+                            "sys_id": "7c619f62967fb08716b0990029693c5f",
                             "number": "KB0010001",
                             "short_description": "How to reset password",
                         },
                         {
-                            "sys_id": "kb2",
+                            "sys_id": "b558b88d797966be4a15e865ac316489",
                             "number": "KB0010002",
                             "short_description": "Password policy guide",
                         },
@@ -105,7 +105,7 @@ class TestKnowledgeGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "kb123",
+                            "sys_id": "6130004ffc6243feb8a9d8cec33c263b",
                             "number": "KB0010001",
                             "short_description": "Test article",
                         }
@@ -238,8 +238,8 @@ class TestKnowledgeCreate:
                         "short_description": "New article",
                         "text": "Content",
                         "workflow_state": "draft",
-                        "kb_knowledge_base": "base123",
-                        "kb_category": "cat456",
+                        "kb_knowledge_base": "84e801a553d572fa894b3d74e1a0f240",
+                        "kb_category": "9ac848b24a0fbf6b8156d31c0431deea",
                     }
                 },
             )
@@ -249,21 +249,21 @@ class TestKnowledgeCreate:
         result = await tools["knowledge_create"](
             short_description="New article",
             text="Content",
-            kb_knowledge_base="base123",
-            kb_category="cat456",
+            kb_knowledge_base="84e801a553d572fa894b3d74e1a0f240",
+            kb_category="9ac848b24a0fbf6b8156d31c0431deea",
         )
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["kb_knowledge_base"] == "base123"
-        assert data["data"]["kb_category"] == "cat456"
+        assert data["data"]["kb_knowledge_base"] == "84e801a553d572fa894b3d74e1a0f240"
+        assert data["data"]["kb_category"] == "9ac848b24a0fbf6b8156d31c0431deea"
 
         # Verify the POST body included both optional fields
         import json
 
         request_body = json.loads(respx.calls.last.request.content)
-        assert request_body["kb_knowledge_base"] == "base123"
-        assert request_body["kb_category"] == "cat456"
+        assert request_body["kb_knowledge_base"] == "84e801a553d572fa894b3d74e1a0f240"
+        assert request_body["kb_category"] == "9ac848b24a0fbf6b8156d31c0431deea"
 
     @pytest.mark.asyncio()
     async def test_create_production_blocked(
@@ -288,15 +288,15 @@ class TestKnowledgeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+                json={"result": [{"sys_id": "6130004ffc6243feb8a9d8cec33c263b", "number": "KB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/kb123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/6130004ffc6243feb8a9d8cec33c263b").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "kb123",
+                        "sys_id": "6130004ffc6243feb8a9d8cec33c263b",
                         "number": "KB0010001",
                         "short_description": "Updated title",
                     }
@@ -379,7 +379,7 @@ class TestKnowledgeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+                json={"result": [{"sys_id": "6130004ffc6243feb8a9d8cec33c263b", "number": "KB0010001"}]},
             )
         )
 
@@ -411,19 +411,19 @@ class TestKnowledgeUpdate:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+                json={"result": [{"sys_id": "6130004ffc6243feb8a9d8cec33c263b", "number": "KB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/kb123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/kb_knowledge/6130004ffc6243feb8a9d8cec33c263b").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "kb123",
+                        "sys_id": "6130004ffc6243feb8a9d8cec33c263b",
                         "number": "KB0010001",
                         "workflow_state": "published",
-                        "kb_knowledge_base": "base789",
-                        "kb_category": "cat012",
+                        "kb_knowledge_base": "587292a058efc3bab6512dd94cecb291",
+                        "kb_category": "f424021bde94bfa660418bee7c99fdeb",
                     }
                 },
             )
@@ -433,23 +433,23 @@ class TestKnowledgeUpdate:
         result = await tools["knowledge_update"](
             number_or_sys_id="KB0010001",
             workflow_state="published",
-            kb_knowledge_base="base789",
-            kb_category="cat012",
+            kb_knowledge_base="587292a058efc3bab6512dd94cecb291",
+            kb_category="f424021bde94bfa660418bee7c99fdeb",
         )
         data = decode_response(result)
 
         assert data["status"] == "success"
         assert data["data"]["workflow_state"] == "published"
-        assert data["data"]["kb_knowledge_base"] == "base789"
-        assert data["data"]["kb_category"] == "cat012"
+        assert data["data"]["kb_knowledge_base"] == "587292a058efc3bab6512dd94cecb291"
+        assert data["data"]["kb_category"] == "f424021bde94bfa660418bee7c99fdeb"
 
         # Verify the PATCH body included all three optional fields
         import json
 
         request_body = json.loads(respx.calls.last.request.content)
         assert request_body["workflow_state"] == "published"
-        assert request_body["kb_knowledge_base"] == "base789"
-        assert request_body["kb_category"] == "cat012"
+        assert request_body["kb_knowledge_base"] == "587292a058efc3bab6512dd94cecb291"
+        assert request_body["kb_category"] == "f424021bde94bfa660418bee7c99fdeb"
 
 
 class TestKnowledgeFeedback:
@@ -462,7 +462,7 @@ class TestKnowledgeFeedback:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+                json={"result": [{"sys_id": "6130004ffc6243feb8a9d8cec33c263b", "number": "KB0010001"}]},
             )
         )
         respx.post(f"{BASE_URL}/api/now/table/kb_feedback").mock(
@@ -470,8 +470,8 @@ class TestKnowledgeFeedback:
                 201,
                 json={
                     "result": {
-                        "sys_id": "fb001",
-                        "article": "kb123",
+                        "sys_id": "1fc91770103833a7b6221b1a79c3e4c9",
+                        "article": "6130004ffc6243feb8a9d8cec33c263b",
                         "rating": "5",
                     }
                 },
@@ -483,7 +483,7 @@ class TestKnowledgeFeedback:
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["article"] == "kb123"
+        assert data["data"]["article"] == "6130004ffc6243feb8a9d8cec33c263b"
         assert data["data"]["rating"] == "5"
 
     @pytest.mark.asyncio()
@@ -493,7 +493,7 @@ class TestKnowledgeFeedback:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+                json={"result": [{"sys_id": "6130004ffc6243feb8a9d8cec33c263b", "number": "KB0010001"}]},
             )
         )
         respx.post(f"{BASE_URL}/api/now/table/kb_feedback").mock(
@@ -501,8 +501,8 @@ class TestKnowledgeFeedback:
                 201,
                 json={
                     "result": {
-                        "sys_id": "fb002",
-                        "article": "kb123",
+                        "sys_id": "a7a140263c8ad16a53bb98c1359610a1",
+                        "article": "6130004ffc6243feb8a9d8cec33c263b",
                         "comments": "Very helpful",
                     }
                 },
@@ -514,7 +514,7 @@ class TestKnowledgeFeedback:
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["article"] == "kb123"
+        assert data["data"]["article"] == "6130004ffc6243feb8a9d8cec33c263b"
         assert data["data"]["comments"] == "Very helpful"
 
     @pytest.mark.asyncio()
@@ -524,7 +524,7 @@ class TestKnowledgeFeedback:
         respx.get(f"{BASE_URL}/api/now/table/kb_knowledge").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "kb123", "number": "KB0010001"}]},
+                json={"result": [{"sys_id": "6130004ffc6243feb8a9d8cec33c263b", "number": "KB0010001"}]},
             )
         )
         respx.post(f"{BASE_URL}/api/now/table/kb_feedback").mock(
@@ -532,8 +532,8 @@ class TestKnowledgeFeedback:
                 201,
                 json={
                     "result": {
-                        "sys_id": "fb003",
-                        "article": "kb123",
+                        "sys_id": "1c19684601aea2164d28b87d816c0144",
+                        "article": "6130004ffc6243feb8a9d8cec33c263b",
                         "rating": "4",
                         "comments": "Good article",
                     }
@@ -619,7 +619,7 @@ class TestKnowledgeFeedback:
                 201,
                 json={
                     "result": {
-                        "sys_id": "fb010",
+                        "sys_id": "1554b2d3b27083dd0079295310f73361",
                         "article": "abc123def456abc123def456abc12345",
                         "rating": "3",
                     }

--- a/tests/domains/test_problem.py
+++ b/tests/domains/test_problem.py
@@ -95,8 +95,8 @@ class TestProblemList:
         url_str = str(request.url)
         assert "state%3D2" in url_str
         assert "priority%3D1" in url_str
-        assert "assigned_to%3Duser123" in url_str
-        assert "assignment_group%3Dgroup456" in url_str
+        assert "assigned_to%3D95c946bf622ef93b0a211cd0fd028dfd" in url_str
+        assert "assignment_group%3D948e04007eb5c3b60182c0a3ed3b6e7e" in url_str
 
     @pytest.mark.asyncio()
     @respx.mock

--- a/tests/domains/test_problem.py
+++ b/tests/domains/test_problem.py
@@ -42,12 +42,12 @@ class TestProblemList:
                 json={
                     "result": [
                         {
-                            "sys_id": "id1",
+                            "sys_id": "4e89d81a2e6fb4be2578d245fd8511c1",
                             "number": "PRB0010001",
                             "short_description": "Test 1",
                         },
                         {
-                            "sys_id": "id2",
+                            "sys_id": "867d5f8110f8aa79dd63d7440f217242",
                             "number": "PRB0010002",
                             "short_description": "Test 2",
                         },
@@ -87,8 +87,8 @@ class TestProblemList:
         await tools["problem_list"](
             state="in_progress",
             priority="1",
-            assigned_to="user123",
-            assignment_group="group456",
+            assigned_to="95c946bf622ef93b0a211cd0fd028dfd",
+            assignment_group="948e04007eb5c3b60182c0a3ed3b6e7e",
         )
 
         request = respx.calls.last.request
@@ -140,7 +140,7 @@ class TestProblemGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "PRB0010001",
                             "short_description": "Test problem",
                         }
@@ -155,7 +155,7 @@ class TestProblemGet:
 
         assert data["status"] == "success"
         assert data["data"]["number"] == "PRB0010001"
-        assert data["data"]["sys_id"] == "abc123"
+        assert data["data"]["sys_id"] == "6367c48dd193d56ea7b0baad25b19455"
 
     @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -190,7 +190,7 @@ class TestProblemGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "PRB0010001",
                             "short_description": "Test",
                         }
@@ -221,7 +221,7 @@ class TestProblemCreate:
                 201,
                 json={
                     "result": {
-                        "sys_id": "new123",
+                        "sys_id": "bdb8465ce041d94a0e490564f2162dcc",
                         "number": "PRB0010002",
                         "short_description": "New problem",
                         "state": "1",
@@ -250,12 +250,12 @@ class TestProblemCreate:
                 201,
                 json={
                     "result": {
-                        "sys_id": "new456",
+                        "sys_id": "e57f9bd335aea54e5336fa986ee8c7b7",
                         "number": "PRB0010003",
                         "short_description": "Full problem",
                         "description": "Detailed info",
-                        "assigned_to": "user123",
-                        "assignment_group": "group456",
+                        "assigned_to": "95c946bf622ef93b0a211cd0fd028dfd",
+                        "assignment_group": "948e04007eb5c3b60182c0a3ed3b6e7e",
                         "category": "software",
                         "subcategory": "os",
                     }
@@ -267,8 +267,8 @@ class TestProblemCreate:
         result = await tools["problem_create"](
             short_description="Full problem",
             description="Detailed info",
-            assigned_to="user123",
-            assignment_group="group456",
+            assigned_to="95c946bf622ef93b0a211cd0fd028dfd",
+            assignment_group="948e04007eb5c3b60182c0a3ed3b6e7e",
             category="software",
             subcategory="os",
         )
@@ -277,7 +277,7 @@ class TestProblemCreate:
         assert data["status"] == "success"
         assert data["data"]["number"] == "PRB0010003"
         assert data["data"]["description"] == "Detailed info"
-        assert data["data"]["assigned_to"] == "user123"
+        assert data["data"]["assigned_to"] == "95c946bf622ef93b0a211cd0fd028dfd"
 
     @pytest.mark.asyncio()
     async def test_create_missing_short_description(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -365,7 +365,7 @@ class TestProblemUpdate:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "PRB0010001",
                             "short_description": "Old",
                         }
@@ -373,12 +373,12 @@ class TestProblemUpdate:
                 },
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/problem/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "PRB0010001",
                         "short_description": "Updated",
                     }
@@ -426,7 +426,7 @@ class TestProblemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "PRB0010001"}]},
             )
         )
 
@@ -444,15 +444,15 @@ class TestProblemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "PRB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/problem/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "PRB0010001",
                         "state": "3",
                     }
@@ -478,15 +478,15 @@ class TestProblemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "PRB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/problem/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "PRB0010001",
                         "short_description": "Updated desc",
                         "urgency": "2",
@@ -494,8 +494,8 @@ class TestProblemUpdate:
                         "priority": "1",
                         "state": "5",
                         "description": "Full description",
-                        "assigned_to": "user789",
-                        "assignment_group": "group321",
+                        "assigned_to": "da469dabaacf11c033fabc4a90cd8895",
+                        "assignment_group": "a69b441f09f0379a23331ecd0c52e140",
                         "category": "hardware",
                         "subcategory": "disk",
                     }
@@ -512,8 +512,8 @@ class TestProblemUpdate:
             priority=1,
             state="fix_in_progress",
             description="Full description",
-            assigned_to="user789",
-            assignment_group="group321",
+            assigned_to="da469dabaacf11c033fabc4a90cd8895",
+            assignment_group="a69b441f09f0379a23331ecd0c52e140",
             category="hardware",
             subcategory="disk",
         )
@@ -548,15 +548,15 @@ class TestProblemRootCause:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "PRB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/problem/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "PRB0010001",
                         "cause_notes": "Root cause identified",
                     }
@@ -581,15 +581,15 @@ class TestProblemRootCause:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "PRB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/problem/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "PRB0010001",
                         "cause_notes": "Memory leak in module X",
                         "fix_notes": "Patch applied to module X",
@@ -691,15 +691,15 @@ class TestProblemRootCause:
         respx.get(f"{BASE_URL}/api/now/table/problem").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "abc123", "number": "PRB0010001"}]},
+                json={"result": [{"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "PRB0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/problem/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/problem/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "PRB0010001",
                         "cause_notes": "Memory leak in module X",
                     }

--- a/tests/domains/test_request.py
+++ b/tests/domains/test_request.py
@@ -87,7 +87,7 @@ class TestRequestList:
         await tools["request_list"](requested_for="95c946bf622ef93b0a211cd0fd028dfd")
 
         request = respx.calls.last.request
-        assert "requested_for%3Duser123" in str(request.url)
+        assert "requested_for%3D95c946bf622ef93b0a211cd0fd028dfd" in str(request.url)
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -101,8 +101,8 @@ class TestRequestList:
         request = respx.calls.last.request
         url = str(request.url)
         assert "state%3D1" in url
-        assert "requested_for%3Duser123" in url
-        assert "assignment_group%3Dgroup456" in url
+        assert "requested_for%3D95c946bf622ef93b0a211cd0fd028dfd" in url
+        assert "assignment_group%3D948e04007eb5c3b60182c0a3ed3b6e7e" in url
 
 
 class TestRequestGet:

--- a/tests/domains/test_request.py
+++ b/tests/domains/test_request.py
@@ -96,7 +96,11 @@ class TestRequestList:
         respx.get(f"{BASE_URL}/api/now/table/sc_request").mock(return_value=Response(200, json={"result": []}))
 
         tools = _register_and_get_tools(settings, auth_provider)
-        await tools["request_list"](state="1", requested_for="95c946bf622ef93b0a211cd0fd028dfd", assignment_group="948e04007eb5c3b60182c0a3ed3b6e7e")
+        await tools["request_list"](
+            state="1",
+            requested_for="95c946bf622ef93b0a211cd0fd028dfd",
+            assignment_group="948e04007eb5c3b60182c0a3ed3b6e7e",
+        )
 
         request = respx.calls.last.request
         url = str(request.url)

--- a/tests/domains/test_request.py
+++ b/tests/domains/test_request.py
@@ -43,12 +43,12 @@ class TestRequestList:
                 json={
                     "result": [
                         {
-                            "sys_id": "id1",
+                            "sys_id": "4e89d81a2e6fb4be2578d245fd8511c1",
                             "number": "REQ0010001",
                             "short_description": "Request 1",
                         },
                         {
-                            "sys_id": "id2",
+                            "sys_id": "867d5f8110f8aa79dd63d7440f217242",
                             "number": "REQ0010002",
                             "short_description": "Request 2",
                         },
@@ -84,7 +84,7 @@ class TestRequestList:
         respx.get(f"{BASE_URL}/api/now/table/sc_request").mock(return_value=Response(200, json={"result": []}))
 
         tools = _register_and_get_tools(settings, auth_provider)
-        await tools["request_list"](requested_for="user123")
+        await tools["request_list"](requested_for="95c946bf622ef93b0a211cd0fd028dfd")
 
         request = respx.calls.last.request
         assert "requested_for%3Duser123" in str(request.url)
@@ -96,7 +96,7 @@ class TestRequestList:
         respx.get(f"{BASE_URL}/api/now/table/sc_request").mock(return_value=Response(200, json={"result": []}))
 
         tools = _register_and_get_tools(settings, auth_provider)
-        await tools["request_list"](state="1", requested_for="user123", assignment_group="group456")
+        await tools["request_list"](state="1", requested_for="95c946bf622ef93b0a211cd0fd028dfd", assignment_group="948e04007eb5c3b60182c0a3ed3b6e7e")
 
         request = respx.calls.last.request
         url = str(request.url)
@@ -118,7 +118,7 @@ class TestRequestGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "REQ0010001",
                             "short_description": "Test request",
                         },
@@ -133,7 +133,7 @@ class TestRequestGet:
 
         assert data["status"] == "success"
         assert data["data"]["number"] == "REQ0010001"
-        assert data["data"]["sys_id"] == "abc123"
+        assert data["data"]["sys_id"] == "6367c48dd193d56ea7b0baad25b19455"
 
     @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -168,7 +168,7 @@ class TestRequestGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "abc123",
+                            "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                             "number": "REQ0010001",
                             "short_description": "Test request",
                         },
@@ -201,12 +201,12 @@ class TestRequestItems:
                 json={
                     "result": [
                         {
-                            "sys_id": "item1",
+                            "sys_id": "4e702d8dacb758a70499bd7a1cd42590",
                             "number": "RITM0010001",
                             "short_description": "Item 1",
                         },
                         {
-                            "sys_id": "item2",
+                            "sys_id": "cbc7e024367097309a6aba1dc0023de5",
                             "number": "RITM0010002",
                             "short_description": "Item 2",
                         },
@@ -263,7 +263,7 @@ class TestRequestItemGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "item123",
+                            "sys_id": "41857183a56ba0402914ad20df39a464",
                             "number": "RITM0010001",
                             "short_description": "Test item",
                         },
@@ -278,7 +278,7 @@ class TestRequestItemGet:
 
         assert data["status"] == "success"
         assert data["data"]["number"] == "RITM0010001"
-        assert data["data"]["sys_id"] == "item123"
+        assert data["data"]["sys_id"] == "41857183a56ba0402914ad20df39a464"
 
     @pytest.mark.asyncio()
     async def test_get_invalid_prefix(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -317,15 +317,15 @@ class TestRequestItemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/sc_req_item").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "item123", "number": "RITM0010001"}]},
+                json={"result": [{"sys_id": "41857183a56ba0402914ad20df39a464", "number": "RITM0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/sc_req_item/item123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/sc_req_item/41857183a56ba0402914ad20df39a464").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "item123",
+                        "sys_id": "41857183a56ba0402914ad20df39a464",
                         "number": "RITM0010001",
                         "state": "3",
                     }
@@ -350,18 +350,18 @@ class TestRequestItemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/sc_req_item").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "item123", "number": "RITM0010001"}]},
+                json={"result": [{"sys_id": "41857183a56ba0402914ad20df39a464", "number": "RITM0010001"}]},
             )
         )
-        respx.patch(f"{BASE_URL}/api/now/table/sc_req_item/item123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/sc_req_item/41857183a56ba0402914ad20df39a464").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "item123",
+                        "sys_id": "41857183a56ba0402914ad20df39a464",
                         "number": "RITM0010001",
-                        "assignment_group": "group456",
-                        "assigned_to": "user789",
+                        "assignment_group": "948e04007eb5c3b60182c0a3ed3b6e7e",
+                        "assigned_to": "da469dabaacf11c033fabc4a90cd8895",
                     }
                 },
             )
@@ -370,14 +370,14 @@ class TestRequestItemUpdate:
         tools = _register_and_get_tools(settings, auth_provider)
         result = await tools["request_item_update"](
             number="RITM0010001",
-            assignment_group="group456",
-            assigned_to="user789",
+            assignment_group="948e04007eb5c3b60182c0a3ed3b6e7e",
+            assigned_to="da469dabaacf11c033fabc4a90cd8895",
         )
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["assignment_group"] == "group456"
-        assert data["data"]["assigned_to"] == "user789"
+        assert data["data"]["assignment_group"] == "948e04007eb5c3b60182c0a3ed3b6e7e"
+        assert data["data"]["assigned_to"] == "da469dabaacf11c033fabc4a90cd8895"
 
     @pytest.mark.asyncio()
     @patch("servicenow_mcp.policy.write_gate", return_value=None)
@@ -418,7 +418,7 @@ class TestRequestItemUpdate:
         respx.get(f"{BASE_URL}/api/now/table/sc_req_item").mock(
             return_value=Response(
                 200,
-                json={"result": [{"sys_id": "item123", "number": "RITM0010001"}]},
+                json={"result": [{"sys_id": "41857183a56ba0402914ad20df39a464", "number": "RITM0010001"}]},
             )
         )
 

--- a/tests/domains/test_service_catalog.py
+++ b/tests/domains/test_service_catalog.py
@@ -107,19 +107,19 @@ class TestScCatalogGet:
     @respx.mock
     async def test_get_catalog(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should fetch a specific catalog by sys_id."""
-        respx.get(f"{SC_BASE}/catalogs/cat123").mock(
+        respx.get(f"{SC_BASE}/catalogs/ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca").mock(
             return_value=Response(
                 200,
-                json={"result": {"sys_id": "cat123", "title": "Service Catalog"}},
+                json={"result": {"sys_id": "ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca", "title": "Service Catalog"}},
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_catalog_get"](sys_id="cat123")
+        result = await tools["sc_catalog_get"](sys_id="ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca")
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["sys_id"] == "cat123"
+        assert data["data"]["sys_id"] == "ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca"
         assert data["data"]["title"] == "Service Catalog"
 
 
@@ -133,7 +133,7 @@ class TestScCategoriesList:
     @respx.mock
     async def test_list_categories(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should list categories for a catalog."""
-        respx.get(f"{SC_BASE}/catalogs/cat123/categories").mock(
+        respx.get(f"{SC_BASE}/catalogs/ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca/categories").mock(
             return_value=Response(
                 200,
                 json={
@@ -146,7 +146,7 @@ class TestScCategoriesList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_categories_list"](catalog_sys_id="cat123")
+        result = await tools["sc_categories_list"](catalog_sys_id="ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca")
         data = decode_response(result)
 
         assert data["status"] == "success"
@@ -157,10 +157,12 @@ class TestScCategoriesList:
     @respx.mock
     async def test_list_categories_with_pagination(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should pass limit and offset parameters."""
-        respx.get(f"{SC_BASE}/catalogs/cat123/categories").mock(return_value=Response(200, json={"result": []}))
+        respx.get(f"{SC_BASE}/catalogs/ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca/categories").mock(
+            return_value=Response(200, json={"result": []})
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        await tools["sc_categories_list"](catalog_sys_id="cat123", limit=10, offset=5)
+        await tools["sc_categories_list"](catalog_sys_id="ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca", limit=10, offset=5)
 
         request = respx.calls.last.request
         url = str(request.url)
@@ -171,10 +173,12 @@ class TestScCategoriesList:
     @respx.mock
     async def test_list_categories_top_level_only(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should pass top_level_only parameter."""
-        respx.get(f"{SC_BASE}/catalogs/cat123/categories").mock(return_value=Response(200, json={"result": []}))
+        respx.get(f"{SC_BASE}/catalogs/ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca/categories").mock(
+            return_value=Response(200, json={"result": []})
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        await tools["sc_categories_list"](catalog_sys_id="cat123", top_level_only=True)
+        await tools["sc_categories_list"](catalog_sys_id="ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca", top_level_only=True)
 
         request = respx.calls.last.request
         assert "sysparm_top_level_only=true" in str(request.url)
@@ -190,19 +194,19 @@ class TestScCategoryGet:
     @respx.mock
     async def test_get_category(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should fetch a specific category by sys_id."""
-        respx.get(f"{SC_BASE}/categories/categ123").mock(
+        respx.get(f"{SC_BASE}/categories/ca7e00ca7e00ca7e00ca7e00ca7e00ca").mock(
             return_value=Response(
                 200,
-                json={"result": {"sys_id": "categ123", "title": "Hardware"}},
+                json={"result": {"sys_id": "ca7e00ca7e00ca7e00ca7e00ca7e00ca", "title": "Hardware"}},
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_category_get"](sys_id="categ123")
+        result = await tools["sc_category_get"](sys_id="ca7e00ca7e00ca7e00ca7e00ca7e00ca")
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["sys_id"] == "categ123"
+        assert data["data"]["sys_id"] == "ca7e00ca7e00ca7e00ca7e00ca7e00ca"
         assert data["data"]["title"] == "Hardware"
 
 
@@ -245,7 +249,7 @@ class TestScItemsList:
         tools = _register_and_get_tools(settings, auth_provider)
         await tools["sc_items_list"](
             text="laptop",
-            catalog="cat123",
+            catalog="ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca",
             category="categ456",
             limit=10,
             offset=5,
@@ -254,7 +258,7 @@ class TestScItemsList:
         request = respx.calls.last.request
         url = str(request.url)
         assert "sysparm_text=laptop" in url
-        assert "sysparm_catalog=cat123" in url
+        assert "sysparm_catalog=ca7ca7ca7ca7ca7ca7ca7ca7ca7ca7ca" in url
         assert "sysparm_category=categ456" in url
         assert "sysparm_limit=10" in url
         assert "sysparm_offset=5" in url
@@ -270,12 +274,12 @@ class TestScItemGet:
     @respx.mock
     async def test_get_item(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should fetch a specific catalog item by sys_id."""
-        respx.get(f"{SC_BASE}/items/item123").mock(
+        respx.get(f"{SC_BASE}/items/17e417e417e417e417e417e417e417e4").mock(
             return_value=Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "item123",
+                        "sys_id": "17e417e417e417e417e417e417e417e4",
                         "name": "Laptop",
                         "price": "$1200",
                     }
@@ -284,11 +288,11 @@ class TestScItemGet:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_item_get"](sys_id="item123")
+        result = await tools["sc_item_get"](sys_id="17e417e417e417e417e417e417e417e4")
         data = decode_response(result)
 
         assert data["status"] == "success"
-        assert data["data"]["sys_id"] == "item123"
+        assert data["data"]["sys_id"] == "17e417e417e417e417e417e417e417e4"
         assert data["data"]["name"] == "Laptop"
 
 
@@ -302,7 +306,7 @@ class TestScItemVariables:
     @respx.mock
     async def test_get_variables(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Should fetch variables for a catalog item."""
-        respx.get(f"{SC_BASE}/items/item123/variables").mock(
+        respx.get(f"{SC_BASE}/items/17e417e417e417e417e417e417e417e4/variables").mock(
             return_value=Response(
                 200,
                 json={
@@ -323,7 +327,7 @@ class TestScItemVariables:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_item_variables"](sys_id="item123")
+        result = await tools["sc_item_variables"](sys_id="17e417e417e417e417e417e417e417e4")
         data = decode_response(result)
 
         assert data["status"] == "success"
@@ -344,7 +348,7 @@ class TestScOrderNow:
         self, _mock_write_gate: Any, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """Should order an item without variables."""
-        respx.post(f"{SC_BASE}/items/item123/order_now").mock(
+        respx.post(f"{SC_BASE}/items/17e417e417e417e417e417e417e417e4/order_now").mock(
             return_value=Response(
                 200,
                 json={"result": {"sys_id": "req123", "number": "REQ0010001"}},
@@ -352,7 +356,7 @@ class TestScOrderNow:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_order_now"](item_sys_id="item123")
+        result = await tools["sc_order_now"](item_sys_id="17e417e417e417e417e417e417e417e4")
         data = decode_response(result)
 
         assert data["status"] == "success"
@@ -365,7 +369,7 @@ class TestScOrderNow:
         self, _mock_write_gate: Any, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """Should order an item with variables JSON."""
-        respx.post(f"{SC_BASE}/items/item123/order_now").mock(
+        respx.post(f"{SC_BASE}/items/17e417e417e417e417e417e417e417e4/order_now").mock(
             return_value=Response(
                 200,
                 json={"result": {"sys_id": "req123", "number": "REQ0010001"}},
@@ -374,7 +378,7 @@ class TestScOrderNow:
 
         tools = _register_and_get_tools(settings, auth_provider)
         result = await tools["sc_order_now"](
-            item_sys_id="item123",
+            item_sys_id="17e417e417e417e417e417e417e417e4",
             variables='{"urgency": "1"}',
         )
         data = decode_response(result)
@@ -388,7 +392,7 @@ class TestScOrderNow:
     ) -> None:
         """Should block ordering in production."""
         tools = _register_and_get_tools(prod_settings, prod_auth_provider)
-        result = await tools["sc_order_now"](item_sys_id="item123")
+        result = await tools["sc_order_now"](item_sys_id="17e417e417e417e417e417e417e417e4")
         data = decode_response(result)
 
         assert data["status"] == "error"
@@ -408,15 +412,15 @@ class TestScAddToCart:
         self, _mock_write_gate: Any, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """Should add item to cart without variables."""
-        respx.post(f"{SC_BASE}/items/item123/add_to_cart").mock(
+        respx.post(f"{SC_BASE}/items/17e417e417e417e417e417e417e417e4/add_to_cart").mock(
             return_value=Response(
                 200,
-                json={"result": {"cart_item_id": "ci123", "item_id": "item123"}},
+                json={"result": {"cart_item_id": "ci123", "item_id": "17e417e417e417e417e417e417e417e4"}},
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        result = await tools["sc_add_to_cart"](item_sys_id="item123")
+        result = await tools["sc_add_to_cart"](item_sys_id="17e417e417e417e417e417e417e417e4")
         data = decode_response(result)
 
         assert data["status"] == "success"
@@ -429,16 +433,16 @@ class TestScAddToCart:
         self, _mock_write_gate: Any, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """Should add item to cart with variables JSON."""
-        respx.post(f"{SC_BASE}/items/item123/add_to_cart").mock(
+        respx.post(f"{SC_BASE}/items/17e417e417e417e417e417e417e417e4/add_to_cart").mock(
             return_value=Response(
                 200,
-                json={"result": {"cart_item_id": "ci123", "item_id": "item123"}},
+                json={"result": {"cart_item_id": "ci123", "item_id": "17e417e417e417e417e417e417e417e4"}},
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
         result = await tools["sc_add_to_cart"](
-            item_sys_id="item123",
+            item_sys_id="17e417e417e417e417e417e417e417e4",
             variables='{"quantity": "2"}',
         )
         data = decode_response(result)
@@ -452,7 +456,7 @@ class TestScAddToCart:
     ) -> None:
         """Should block add-to-cart in production."""
         tools = _register_and_get_tools(prod_settings, prod_auth_provider)
-        result = await tools["sc_add_to_cart"](item_sys_id="item123")
+        result = await tools["sc_add_to_cart"](item_sys_id="17e417e417e417e417e417e417e417e4")
         data = decode_response(result)
 
         assert data["status"] == "error"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,8 @@ from collections.abc import Callable
 from typing import Any, Protocol, cast
 
 from mcp.server.fastmcp import FastMCP
-from toon_format import decode as toon_decode
+
+from servicenow_mcp._vendor.toon_format import decode as toon_decode
 
 
 class RegisteredToolLike(Protocol):

--- a/tests/test_artifact_write.py
+++ b/tests/test_artifact_write.py
@@ -1,4 +1,4 @@
-"""Tests for artifact write tools (artifact_create, artifact_update)."""
+"""Tests for artifact write tools (preview/apply flow)."""
 
 import json
 from typing import Any
@@ -10,6 +10,7 @@ import respx
 
 from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
+from servicenow_mcp.policy import MASK_VALUE
 from servicenow_mcp.tools.artifact_write import (
     MAX_SCRIPT_FILE_BYTES,
     SCRIPT_FIELD_MAP,
@@ -26,7 +27,7 @@ from tests.helpers import decode_response, get_tool_functions
 BASE_URL = "https://test.service-now.com"
 
 # Valid 32-char hex sys_ids for tests (validate_sys_id requires this format)
-SYS_ID_ART001 = "a" * 32  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+SYS_ID_ART001 = "a" * 32
 
 
 @pytest.fixture()
@@ -208,12 +209,13 @@ class TestParseAndValidatePayload:
     """Tests for the _parse_and_validate_payload helper."""
 
     def test_valid_json_object(self) -> None:
-        """Returns (dict, warnings) for valid JSON object with no script_path."""
+        """Returns (dict, warnings, script_field) for valid JSON object with no script_path."""
         result = _parse_and_validate_payload('{"name": "Test"}', "data", "script_include", "", "", "corr-1")
         assert isinstance(result, tuple)
-        payload, warnings = result
+        payload, warnings, script_field = result
         assert payload == {"name": "Test"}
         assert warnings == []
+        assert script_field is None
 
     def test_non_dict_returns_error_string(self) -> None:
         """Returns formatted error string for non-dict JSON."""
@@ -232,9 +234,10 @@ class TestParseAndValidatePayload:
 
         result = _parse_and_validate_payload('{"name": "M"}', "data", "ui_macro", str(script), str(tmp_path), "corr-1")
         assert isinstance(result, tuple)
-        payload, warnings = result
+        payload, warnings, script_field = result
         assert payload["xml"] == "<hello/>"
         assert warnings == []
+        assert script_field == "xml"
 
     def test_script_path_warns_on_override(self, tmp_path: Any) -> None:
         """Emits warning when script_path overrides existing field."""
@@ -245,29 +248,282 @@ class TestParseAndValidatePayload:
             '{"script": "old"}', "changes", "script_include", str(script), str(tmp_path), "corr-1"
         )
         assert isinstance(result, tuple)
-        payload, warnings = result
+        payload, warnings, script_field = result
         assert payload["script"] == "new"
         assert len(warnings) == 1
         assert "overridden" in warnings[0].lower()
+        assert script_field == "script"
 
 
-# -- artifact_create -----------------------------------------------------------
+# -- artifact_create_preview ---------------------------------------------------
 
 
-class TestArtifactCreate:
-    """Tests for the artifact_create tool."""
+class TestArtifactCreatePreview:
+    """Tests for artifact_create_preview."""
+
+    @pytest.mark.asyncio()
+    async def test_returns_token_and_summary(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Preview validates input and returns a token plus safe summary."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "TestInclude", "script": "var x = 1;", "api_key": "leaked"}),
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["action"] == "create"
+        assert data["table"] == "sys_script_include"
+        assert data["artifact_type"] == "script_include"
+        assert isinstance(data["token"], str)
+        assert data["token"]
+        assert set(data["fields"]) == {"name", "script", "api_key"}
+        # Script body is summarised, not echoed
+        assert data["summary"]["script"]["size_bytes"] == len("var x = 1;")
+        assert data["summary"]["script"]["head"] == "var x = 1;"
+        # Sensitive field value never appears in the envelope
+        assert data["summary"]["api_key"] == MASK_VALUE
+        assert data["ttl_seconds"] > 0
+
+    @pytest.mark.asyncio()
+    async def test_script_body_head_truncated(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Script body 'head' is truncated to the configured character budget."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        long_body = "a" * 500
+        raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "Long", "script": long_body}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "success"
+        head = result["data"]["summary"]["script"]["head"]
+        assert len(head) <= 80
+        assert result["data"]["summary"]["script"]["size_bytes"] == 500
+
+    @pytest.mark.asyncio()
+    async def test_script_path_size_summarised(
+        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
+    ) -> None:
+        """script_path content is summarised by size, not echoed verbatim."""
+        script_file = tmp_path / "inc.js"
+        script_file.write_text("function test() { return 42; }", encoding="utf-8")
+
+        tools = _register_and_get_tools(script_settings, script_auth_provider)
+        raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "FromFile"}),
+            script_path=str(script_file),
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["script_field"] == "script"
+        assert data["summary"]["script"]["size_bytes"] == len("function test() { return 42; }")
+        assert data["summary"]["script"]["head"].startswith("function test()")
+
+    @pytest.mark.asyncio()
+    async def test_script_path_size_limit_enforced_at_preview(
+        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
+    ) -> None:
+        """script_path exceeding 1 MB is rejected before any token is issued."""
+        oversize = tmp_path / "huge.js"
+        oversize.write_bytes(b"x" * (MAX_SCRIPT_FILE_BYTES + 1))
+
+        tools = _register_and_get_tools(script_settings, script_auth_provider)
+        raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "Huge"}),
+            script_path=str(oversize),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+        assert "too large" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio()
+    async def test_invalid_key_blocked_at_preview(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Invalid payload keys fail at preview time, before any token is issued."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"INVALID-KEY!": "value"}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio()
+    async def test_blocked_in_prod(self, prod_settings: Settings, prod_auth_provider: BasicAuthProvider) -> None:
+        """Preview is blocked in production environments."""
+        tools = _register_and_get_tools(prod_settings, prod_auth_provider)
+        raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "Test"}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+        assert "production" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio()
+    async def test_unknown_artifact_type(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Unknown artifact_type fails at preview time."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_create_preview"](
+            artifact_type="nonexistent_type",
+            data=json.dumps({"name": "Test"}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+        assert "unknown" in result["error"]["message"].lower()
+
+
+# -- artifact_update_preview ---------------------------------------------------
+
+
+class TestArtifactUpdatePreview:
+    """Tests for artifact_update_preview."""
 
     @pytest.mark.asyncio()
     @respx.mock
-    async def test_creates_artifact_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Creates an artifact and returns the masked record."""
-        respx.post(f"{BASE_URL}/api/now/table/sys_script_include").mock(
+    async def test_returns_diff_with_masked_sensitive_fields(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Update preview fetches current record and masks sensitive fields in the diff."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/{SYS_ID_ART001}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "sys_id": SYS_ID_ART001,
+                        "name": "OldName",
+                        "script": "var old = 1;",
+                        "api_key": "OLD_SECRET",  # NOSONAR
+                    }
+                },
+            )
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_update_preview"](
+            artifact_type="script_include",
+            sys_id=SYS_ID_ART001,
+            changes=json.dumps({"name": "NewName", "api_key": "NEW_SECRET", "script": "var n = 2;"}),  # NOSONAR
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["action"] == "update"
+        assert data["sys_id"] == SYS_ID_ART001
+        # Non-sensitive, non-script field echoes both sides
+        assert data["diff"]["name"] == {"old": "OldName", "new": "NewName"}
+        # Sensitive field masked on both sides
+        assert data["diff"]["api_key"] == {"old": MASK_VALUE, "new": MASK_VALUE}
+        # Script body summarised on both sides
+        assert data["diff"]["script"]["new"]["size_bytes"] == len("var n = 2;")
+        assert data["diff"]["script"]["old"]["size_bytes"] == len("var old = 1;")
+        # Full current record is also masked for 'before' context
+        assert data["before"]["api_key"] == MASK_VALUE
+        # sys_script_include has 'script' in TABLE_SCRIPT_FIELDS -> masked in before
+        assert data["before"]["script"] != "var old = 1;"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_script_content_never_echoed(
+        self,
+        script_settings: Settings,
+        script_auth_provider: BasicAuthProvider,
+        tmp_path: Any,
+    ) -> None:
+        """A full script file read via script_path is summarised, not echoed."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/{SYS_ID_ART001}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": SYS_ID_ART001, "name": "Inc", "script": ""}},
+            )
+        )
+
+        script_file = tmp_path / "body.js"
+        full_body = "function leaked() { return 'super secret body content that must not appear verbatim'; }"
+        script_file.write_text(full_body, encoding="utf-8")
+
+        tools = _register_and_get_tools(script_settings, script_auth_provider)
+        raw = await tools["artifact_update_preview"](
+            artifact_type="script_include",
+            sys_id=SYS_ID_ART001,
+            changes=json.dumps({"name": "Inc"}),
+            script_path=str(script_file),
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        # The full body must not appear anywhere in the serialized envelope
+        assert "super secret body content that must not appear verbatim" not in raw
+        assert result["data"]["diff"]["script"]["new"]["size_bytes"] == len(full_body)
+
+    @pytest.mark.asyncio()
+    async def test_invalid_sys_id_rejected(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """sys_id validation runs before any current-record fetch."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_update_preview"](
+            artifact_type="script_include",
+            sys_id="not-a-valid-hex-id",
+            changes=json.dumps({"name": "x"}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio()
+    async def test_invalid_key_blocked_at_preview(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """Invalid change keys are rejected at preview time."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_update_preview"](
+            artifact_type="script_include",
+            sys_id=SYS_ID_ART001,
+            changes=json.dumps({"INVALID-KEY!": "value"}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio()
+    async def test_blocked_in_prod(self, prod_settings: Settings, prod_auth_provider: BasicAuthProvider) -> None:
+        """Update preview blocked in production."""
+        tools = _register_and_get_tools(prod_settings, prod_auth_provider)
+        raw = await tools["artifact_update_preview"](
+            artifact_type="script_include",
+            sys_id=SYS_ID_ART001,
+            changes=json.dumps({"name": "x"}),
+        )
+        result = decode_response(raw)
+        assert result["status"] == "error"
+        assert "production" in result["error"]["message"].lower()
+
+
+# -- artifact_apply ------------------------------------------------------------
+
+
+class TestArtifactApply:
+    """Tests for artifact_apply."""
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_apply_create(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """artifact_apply consumes a create-preview token and writes the record."""
+        tools = _register_and_get_tools(settings, auth_provider)
+
+        preview_raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "TestInc", "script": "var x = 1;"}),
+        )
+        token = decode_response(preview_raw)["data"]["token"]
+
+        route = respx.post(f"{BASE_URL}/api/now/table/sys_script_include").mock(
             return_value=httpx.Response(
                 201,
                 json={
                     "result": {
                         "sys_id": "new001",
-                        "name": "TestScriptInclude",
+                        "name": "TestInc",
                         "script": "var x = 1;",
                         "password": "s3cret",  # NOSONAR
                     }
@@ -275,560 +531,99 @@ class TestArtifactCreate:
             )
         )
 
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="script_include",
-            data=json.dumps({"name": "TestScriptInclude", "script": "var x = 1;"}),
-        )
+        raw = await tools["artifact_apply"](preview_token=token)
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["table"] == "sys_script_include"
-        assert result["data"]["artifact_type"] == "script_include"
+        assert result["data"]["action"] == "create"
         assert result["data"]["sys_id"] == "new001"
-        assert result["data"]["record"]["name"] == "TestScriptInclude"
-        assert result["data"]["record"]["password"] == "***MASKED***"  # NOSONAR
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_creates_artifact_with_script_path(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """Reads script content from a local file and sets it as the script field."""
-        script_file = tmp_path / "my_script.js"
-        script_file.write_text("function test() { return true; }", encoding="utf-8")
-
-        route = respx.post(f"{BASE_URL}/api/now/table/sys_script_include").mock(
-            return_value=httpx.Response(
-                201,
-                json={
-                    "result": {
-                        "sys_id": "new002",
-                        "name": "FileScript",
-                        "script": "function test() { return true; }",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="script_include",
-            data=json.dumps({"name": "FileScript"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["sys_id"] == "new002"
-
-        # Verify outbound request body contains the script content
+        assert result["data"]["record"]["password"] == MASK_VALUE
         assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["script"] == "function test() { return true; }"
-        assert request_body["name"] == "FileScript"
+        # Outbound body must carry the full script even though the preview
+        # envelope never did.
+        body = json.loads(route.calls[0].request.content)
+        assert body["script"] == "var x = 1;"
 
     @pytest.mark.asyncio()
     @respx.mock
-    async def test_script_path_warns_on_override(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """Warns when script_path overrides an existing 'script' key in data."""
-        script_file = tmp_path / "override.js"
-        script_file.write_text("new content", encoding="utf-8")
-
-        respx.post(f"{BASE_URL}/api/now/table/sys_script_include").mock(
-            return_value=httpx.Response(
-                201,
-                json={
-                    "result": {
-                        "sys_id": "new003",
-                        "name": "Override",
-                        "script": "new content",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="script_include",
-            data=json.dumps({"name": "Override", "script": "old content"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert result.get("warnings") is not None
-        assert any("overridden" in w.lower() for w in result["warnings"])
-
-    @pytest.mark.asyncio()
-    async def test_blocked_in_prod(self, prod_settings: Settings, prod_auth_provider: BasicAuthProvider) -> None:
-        """Returns error when environment is production."""
-        tools = _register_and_get_tools(prod_settings, prod_auth_provider)
-
-        raw = await tools["artifact_create"](
-            artifact_type="script_include",
-            data=json.dumps({"name": "Test"}),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-        assert "production" in result["error"]["message"].lower()
-
-    @pytest.mark.asyncio()
-    async def test_invalid_json_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error when data is not valid JSON."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_create"](artifact_type="script_include", data="not valid json")
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-
-    @pytest.mark.asyncio()
-    async def test_unknown_artifact_type(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error for an unknown artifact type."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="nonexistent_type",
-            data=json.dumps({"name": "Test"}),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-        assert "unknown" in result["error"]["message"].lower()
-
-    @pytest.mark.asyncio()
-    async def test_non_dict_json_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error when data is a JSON array instead of object."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="script_include",
-            data=json.dumps(["not", "an", "object"]),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-        assert "object" in result["error"]["message"].lower()
-
-    @pytest.mark.asyncio()
-    async def test_invalid_key_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error when data contains an invalid field name."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="script_include",
-            data=json.dumps({"INVALID-KEY!": "value"}),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-
-
-# -- artifact_update -----------------------------------------------------------
-
-
-class TestArtifactUpdate:
-    """Tests for the artifact_update tool."""
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_updates_artifact_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Updates an artifact and returns the masked record."""
-        respx.patch(f"{BASE_URL}/api/now/table/sys_script_include/{SYS_ID_ART001}").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": SYS_ID_ART001,
-                        "name": "UpdatedScript",
-                        "active": "true",
-                        "password": "s3cret",  # NOSONAR
-                    }
-                },
-            )
+    async def test_apply_update(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """artifact_apply consumes an update-preview token and patches the record."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/{SYS_ID_ART001}").mock(
+            return_value=httpx.Response(200, json={"result": {"sys_id": SYS_ID_ART001, "name": "Old"}})
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_update"](
+        preview_raw = await tools["artifact_update_preview"](
             artifact_type="script_include",
             sys_id=SYS_ID_ART001,
-            changes=json.dumps({"active": "true"}),
+            changes=json.dumps({"name": "New"}),
         )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert result["data"]["table"] == "sys_script_include"
-        assert result["data"]["artifact_type"] == "script_include"
-        assert result["data"]["sys_id"] == SYS_ID_ART001
-        assert result["data"]["record"]["password"] == "***MASKED***"  # NOSONAR
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_updates_artifact_with_script_path(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """Reads script content from a local file when updating."""
-        script_file = tmp_path / "update_script.js"
-        script_file.write_text("var updated = true;", encoding="utf-8")
+        token = decode_response(preview_raw)["data"]["token"]
 
         route = respx.patch(f"{BASE_URL}/api/now/table/sys_script_include/{SYS_ID_ART001}").mock(
             return_value=httpx.Response(
                 200,
-                json={
-                    "result": {
-                        "sys_id": SYS_ID_ART001,
-                        "name": "FileUpdate",
-                        "script": "var updated = true;",
-                    }
-                },
+                json={"result": {"sys_id": SYS_ID_ART001, "name": "New"}},
             )
         )
 
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="script_include",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"name": "FileUpdate"}),
-            script_path=str(script_file),
-        )
+        raw = await tools["artifact_apply"](preview_token=token)
         result = decode_response(raw)
 
         assert result["status"] == "success"
+        assert result["data"]["action"] == "update"
         assert result["data"]["sys_id"] == SYS_ID_ART001
-
-        # Verify outbound request body contains the script content
         assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["script"] == "var updated = true;"
-        assert request_body["name"] == "FileUpdate"
 
     @pytest.mark.asyncio()
     @respx.mock
-    async def test_script_path_warns_on_override(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """Warns when script_path overrides an existing 'script' key in changes."""
-        script_file = tmp_path / "override_update.js"
-        script_file.write_text("new update content", encoding="utf-8")
-
-        respx.patch(f"{BASE_URL}/api/now/table/sys_script_include/{SYS_ID_ART001}").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "result": {
-                        "sys_id": SYS_ID_ART001,
-                        "script": "new update content",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_update"](
+    async def test_token_is_single_use(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """A preview token cannot be applied twice."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["artifact_create_preview"](
             artifact_type="script_include",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"script": "old content"}),
-            script_path=str(script_file),
+            data=json.dumps({"name": "Once"}),
         )
-        result = decode_response(raw)
+        token = decode_response(preview_raw)["data"]["token"]
 
-        assert result["status"] == "success"
-        assert result.get("warnings") is not None
-        assert any("overridden" in w.lower() for w in result["warnings"])
+        respx.post(f"{BASE_URL}/api/now/table/sys_script_include").mock(
+            return_value=httpx.Response(201, json={"result": {"sys_id": "n1", "name": "Once"}})
+        )
+
+        first = decode_response(await tools["artifact_apply"](preview_token=token))
+        assert first["status"] == "success"
+
+        second = decode_response(await tools["artifact_apply"](preview_token=token))
+        assert second["status"] == "error"
+        assert "invalid" in second["error"]["message"].lower() or "expired" in second["error"]["message"].lower()
 
     @pytest.mark.asyncio()
-    async def test_blocked_in_prod(self, prod_settings: Settings, prod_auth_provider: BasicAuthProvider) -> None:
-        """Returns error when environment is production."""
-        tools = _register_and_get_tools(prod_settings, prod_auth_provider)
-
-        raw = await tools["artifact_update"](
-            artifact_type="script_include",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"active": "false"}),
-        )
+    async def test_invalid_token_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        """An unknown token fails with a clear error envelope."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["artifact_apply"](preview_token="not-a-real-token")
         result = decode_response(raw)
+        assert result["status"] == "error"
 
+    @pytest.mark.asyncio()
+    async def test_write_gate_recheck_on_apply(
+        self, settings: Settings, auth_provider: BasicAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A successful preview still fails at apply time if prod mode flips on in between."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        preview_raw = await tools["artifact_create_preview"](
+            artifact_type="script_include",
+            data=json.dumps({"name": "Block"}),
+        )
+        token = decode_response(preview_raw)["data"]["token"]
+
+        # Flip the production gate between preview and apply - writes must stop.
+        monkeypatch.setattr(type(settings), "is_production", property(lambda _self: True))
+
+        raw = await tools["artifact_apply"](preview_token=token)
+        result = decode_response(raw)
         assert result["status"] == "error"
         assert "production" in result["error"]["message"].lower()
-
-    @pytest.mark.asyncio()
-    async def test_invalid_sys_id(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error for an invalid sys_id format."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="script_include",
-            sys_id="not-a-valid-hex-id",
-            changes=json.dumps({"active": "false"}),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-
-    @pytest.mark.asyncio()
-    async def test_unknown_artifact_type(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error for an unknown artifact type."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="nonexistent_type",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"name": "Test"}),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-        assert "unknown" in result["error"]["message"].lower()
-
-    @pytest.mark.asyncio()
-    async def test_non_dict_json_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error when changes is a JSON array instead of object."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="script_include",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps(["not", "an", "object"]),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-        assert "object" in result["error"]["message"].lower()
-
-    @pytest.mark.asyncio()
-    async def test_invalid_key_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Returns error when changes contains an invalid field name."""
-        tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="script_include",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"INVALID-KEY!": "value"}),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "error"
-
-
-# -- SCRIPT_FIELD_MAP ----------------------------------------------------------
-
-
-class TestScriptFieldMap:
-    """Tests for SCRIPT_FIELD_MAP per-artifact script field routing."""
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_ui_macro_writes_to_xml_field(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """script_path content for ui_macro is written to the 'xml' field."""
-        script_file = tmp_path / "macro.xml"
-        script_file.write_text("<j:jelly><p>Hello</p></j:jelly>", encoding="utf-8")
-
-        route = respx.post(f"{BASE_URL}/api/now/table/sys_ui_macro").mock(
-            return_value=httpx.Response(
-                201,
-                json={"result": {"sys_id": "macro001", "name": "TestMacro", "xml": "<j:jelly><p>Hello</p></j:jelly>"}},
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="ui_macro",
-            data=json.dumps({"name": "TestMacro"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["xml"] == "<j:jelly><p>Hello</p></j:jelly>"
-        assert "script" not in request_body
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_ui_page_writes_to_html_field(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """script_path content for ui_page is written to the 'html' field."""
-        script_file = tmp_path / "page.html"
-        script_file.write_text("<div>Hello</div>", encoding="utf-8")
-
-        route = respx.post(f"{BASE_URL}/api/now/table/sys_ui_page").mock(
-            return_value=httpx.Response(
-                201,
-                json={"result": {"sys_id": "page001", "name": "TestPage", "html": "<div>Hello</div>"}},
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="ui_page",
-            data=json.dumps({"name": "TestPage"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["html"] == "<div>Hello</div>"
-        assert "script" not in request_body
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_update_with_field_map(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """artifact_update also uses SCRIPT_FIELD_MAP for the correct field."""
-        script_file = tmp_path / "macro_update.xml"
-        script_file.write_text("<updated/>", encoding="utf-8")
-
-        route = respx.patch(f"{BASE_URL}/api/now/table/sys_ui_macro/{SYS_ID_ART001}").mock(
-            return_value=httpx.Response(
-                200,
-                json={"result": {"sys_id": SYS_ID_ART001, "xml": "<updated/>"}},
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="ui_macro",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"name": "UpdatedMacro"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["xml"] == "<updated/>"
-        assert "script" not in request_body
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_ui_policy_writes_to_script_true_field(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """script_path content for ui_policy is written to the 'script_true' field."""
-        script_file = tmp_path / "policy.js"
-        script_file.write_text("g_form.setVisible('field', true);", encoding="utf-8")
-
-        route = respx.post(f"{BASE_URL}/api/now/table/sys_ui_policy").mock(
-            return_value=httpx.Response(
-                201,
-                json={
-                    "result": {
-                        "sys_id": "pol001",
-                        "name": "TestPolicy",
-                        "script_true": "g_form.setVisible('field', true);",
-                    }
-                },
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="ui_policy",
-            data=json.dumps({"name": "TestPolicy"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["script_true"] == "g_form.setVisible('field', true);"
-        assert "script" not in request_body
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_widget_writes_to_client_script_field(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """script_path content for widget is written to the 'client_script' field."""
-        script_file = tmp_path / "widget.js"
-        script_file.write_text("function($scope) { $scope.data.ready = true; }", encoding="utf-8")
-
-        route = respx.post(f"{BASE_URL}/api/now/table/sp_widget").mock(
-            return_value=httpx.Response(
-                201,
-                json={"result": {"sys_id": "wid001", "name": "TestWidget"}},
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="widget",
-            data=json.dumps({"name": "TestWidget"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["client_script"] == "function($scope) { $scope.data.ready = true; }"
-        assert "script" not in request_body
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_scripted_rest_resource_writes_to_operation_script_field(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """script_path content for scripted_rest_resource is written to the 'operation_script' field."""
-        script_file = tmp_path / "rest_op.js"
-        script_file.write_text("(function process(request, response) {})(request, response);", encoding="utf-8")
-
-        route = respx.post(f"{BASE_URL}/api/now/table/sys_ws_operation").mock(
-            return_value=httpx.Response(
-                201,
-                json={"result": {"sys_id": "rest001", "name": "TestRestOp"}},
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_create"](
-            artifact_type="scripted_rest_resource",
-            data=json.dumps({"name": "TestRestOp"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["operation_script"] == "(function process(request, response) {})(request, response);"
-        assert "script" not in request_body
-
-    @pytest.mark.asyncio()
-    @respx.mock
-    async def test_notification_script_writes_to_advanced_condition_field(
-        self, script_settings: Settings, script_auth_provider: BasicAuthProvider, tmp_path: Any
-    ) -> None:
-        """script_path content for notification_script is written to the 'advanced_condition' field."""
-        script_file = tmp_path / "notif.js"
-        script_file.write_text("current.priority == 1", encoding="utf-8")
-
-        route = respx.patch(f"{BASE_URL}/api/now/table/sysevent_email_action/{SYS_ID_ART001}").mock(
-            return_value=httpx.Response(
-                200,
-                json={"result": {"sys_id": SYS_ID_ART001, "name": "TestNotif"}},
-            )
-        )
-
-        tools = _register_and_get_tools(script_settings, script_auth_provider)
-        raw = await tools["artifact_update"](
-            artifact_type="notification_script",
-            sys_id=SYS_ID_ART001,
-            changes=json.dumps({"name": "TestNotif"}),
-            script_path=str(script_file),
-        )
-        result = decode_response(raw)
-
-        assert result["status"] == "success"
-        assert route.called
-        request_body = json.loads(route.calls[0].request.content)
-        assert request_body["advanced_condition"] == "current.priority == 1"
-        assert "script" not in request_body
 
 
 # -- Tool registration ---------------------------------------------------------
@@ -838,11 +633,23 @@ class TestToolRegistration:
     """Tests for tool registration and TOOL_NAMES constant."""
 
     def test_tool_names_constant(self) -> None:
-        """TOOL_NAMES contains the expected tool names."""
-        assert TOOL_NAMES == ["artifact_create", "artifact_update"]
+        """TOOL_NAMES contains exactly the preview/apply trio - no direct-write names."""
+        assert TOOL_NAMES == [
+            "artifact_create_preview",
+            "artifact_update_preview",
+            "artifact_apply",
+        ]
 
     def test_all_tools_registered(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """All TOOL_NAMES are registered in the MCP tool map."""
         tools = _register_and_get_tools(settings, auth_provider)
         for name in TOOL_NAMES:
             assert name in tools, f"Tool '{name}' not registered"
+
+    def test_legacy_direct_write_tools_not_registered(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """The CRIT-1 direct-write tools must be gone from the registry."""
+        tools = _register_and_get_tools(settings, auth_provider)
+        assert "artifact_create" not in tools
+        assert "artifact_update" not in tools

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -134,7 +134,7 @@ class TestAttachmentReadTools:
     async def test_attachment_download_success_with_base64(
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
-        """Downloads binary content and returns a base64 payload."""
+        """Downloads binary content and returns a base64 payload when explicitly requested."""
         respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
             return_value=httpx.Response(200, json={"result": _metadata()})
         )
@@ -143,12 +143,59 @@ class TestAttachmentReadTools:
         )
 
         tools = _register_read_tools(settings, auth_provider)
-        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID)
+        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID, include_content=True)
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
         assert result["data"]["content_base64"] == base64.b64encode(b"hello").decode("ascii")
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_defaults_to_metadata_only(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """HIGH-7: attachment_download returns metadata only by default - no bytes transferred."""
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(200, json={"result": _metadata()})
+        )
+        download_route = respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"should-not-be-fetched")
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
+        assert "content_base64" not in result["data"]
+        assert not download_route.called
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_metadata_only_bypasses_size_cap(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Oversized attachments can still be inspected as metadata - only content transfer is capped."""
+        respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": _metadata(size_bytes=str(MAX_ATTACHMENT_BYTES + 1))},
+            )
+        )
+        download_route = respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"x")
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID)
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["size_bytes"] == MAX_ATTACHMENT_BYTES + 1
+        assert "content_base64" not in result["data"]
+        assert not download_route.called
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -171,6 +218,7 @@ class TestAttachmentReadTools:
             table_name="incident",
             table_sys_id=TABLE_SYS_ID,
             file_name="hello.txt",
+            include_content=True,
         )
         result = decode_response(raw)
 
@@ -181,6 +229,32 @@ class TestAttachmentReadTools:
         assert "ORDERBYsys_created_on" in query_route.calls.last.request.url.params["sysparm_query"]
         assert download_route.called
         assert not by_name_route.called
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_attachment_download_by_name_defaults_to_metadata_only(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """HIGH-7: attachment_download_by_name returns metadata only by default."""
+        respx.get(f"{BASE_URL}/api/now/table/sys_attachment").mock(
+            return_value=httpx.Response(200, json={"result": [_metadata()]}, headers={"X-Total-Count": "1"})
+        )
+        download_route = respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}/file").mock(
+            return_value=httpx.Response(200, content=b"should-not-be-fetched")
+        )
+
+        tools = _register_read_tools(settings, auth_provider)
+        raw = await tools["attachment_download_by_name"](
+            table_name="incident",
+            table_sys_id=TABLE_SYS_ID,
+            file_name="hello.txt",
+        )
+        result = decode_response(raw)
+
+        assert result["status"] == "success"
+        assert result["data"]["sys_id"] == ATTACHMENT_SYS_ID
+        assert "content_base64" not in result["data"]
+        assert not download_route.called
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -213,7 +287,7 @@ class TestAttachmentReadTools:
     @pytest.mark.asyncio()
     @respx.mock
     async def test_oversized_download_rejection(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """Rejects downloads larger than the MCP attachment transfer limit before fetch."""
+        """Rejects content downloads larger than the MCP attachment transfer limit before fetch."""
         respx.get(f"{BASE_URL}/api/now/attachment/{ATTACHMENT_SYS_ID}").mock(
             return_value=httpx.Response(
                 200,
@@ -225,7 +299,7 @@ class TestAttachmentReadTools:
         )
 
         tools = _register_read_tools(settings, auth_provider)
-        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID)
+        raw = await tools["attachment_download"](sys_id=ATTACHMENT_SYS_ID, include_content=True)
         result = decode_response(raw)
 
         assert result["status"] == "error"

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -526,7 +526,9 @@ class TestChangesReleaseNotes:
         self._mock_release_notes_requests("bc89942e2774d75ebcc7362c55807e09")
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_release_notes"](update_set_id="bc89942e2774d75ebcc7362c55807e09", format=format_value)
+        raw = await tools["changes_release_notes"](
+            update_set_id="bc89942e2774d75ebcc7362c55807e09", format=format_value
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -283,7 +283,7 @@ class TestChangesDiffArtifact:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_diff_artifact"](table="sys_script_include", sys_id="xyz")
+        raw = await tools["changes_diff_artifact"](table="sys_script_include", sys_id="xyz", include_script_body=True)
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -40,12 +40,12 @@ class TestChangesUpdatesetInspect:
     async def test_returns_grouped_summary(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns update set members grouped by table/type."""
         # Mock the update set record fetch
-        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/us001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/f7c5a9c7fa7010efe496857fbfc9d0d5").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "us001",
+                        "sys_id": "f7c5a9c7fa7010efe496857fbfc9d0d5",
                         "name": "My Update Set",
                         "state": "in progress",
                         "application": "Global",
@@ -60,28 +60,28 @@ class TestChangesUpdatesetInspect:
                 json={
                     "result": [
                         {
-                            "sys_id": "m1",
+                            "sys_id": "ae23b94ccaf714337e4ce5ba99ef3dc2",
                             "name": "sys_script_include_abc",
                             "type": "sys_script_include",
                             "action": "INSERT_OR_UPDATE",
                             "target_name": "MyUtil",
-                            "update_set": "us001",
+                            "update_set": "f7c5a9c7fa7010efe496857fbfc9d0d5",
                         },
                         {
-                            "sys_id": "m2",
+                            "sys_id": "32d332da761f44df7959e5887b6b94cb",
                             "name": "sys_script_def",
                             "type": "sys_script",
                             "action": "INSERT_OR_UPDATE",
                             "target_name": "BR: Validate incident",
-                            "update_set": "us001",
+                            "update_set": "f7c5a9c7fa7010efe496857fbfc9d0d5",
                         },
                         {
-                            "sys_id": "m3",
+                            "sys_id": "862a51f8b6294a4b0729a7c5c929bfd6",
                             "name": "sys_ui_policy_ghi",
                             "type": "sys_ui_policy",
                             "action": "INSERT_OR_UPDATE",
                             "target_name": "Hide fields when resolved",
-                            "update_set": "us001",
+                            "update_set": "f7c5a9c7fa7010efe496857fbfc9d0d5",
                         },
                     ]
                 },
@@ -90,12 +90,12 @@ class TestChangesUpdatesetInspect:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_updateset_inspect"](update_set_id="us001")
+        raw = await tools["changes_updateset_inspect"](update_set_id="f7c5a9c7fa7010efe496857fbfc9d0d5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
         data = result["data"]
-        assert data["update_set"]["sys_id"] == "us001"
+        assert data["update_set"]["sys_id"] == "f7c5a9c7fa7010efe496857fbfc9d0d5"
         assert data["total_members"] == 3
         # Should be grouped by type
         assert "groups" in data
@@ -105,12 +105,12 @@ class TestChangesUpdatesetInspect:
     @respx.mock
     async def test_flags_risk_indicators(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Flags risk when dangerous artifact types are present (ACLs, scripts)."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/us002").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/246378846af9222db26d7a2ab0462245").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "us002",
+                        "sys_id": "246378846af9222db26d7a2ab0462245",
                         "name": "Risky Changes",
                         "state": "in progress",
                     }
@@ -123,7 +123,7 @@ class TestChangesUpdatesetInspect:
                 json={
                     "result": [
                         {
-                            "sys_id": "m1",
+                            "sys_id": "ae23b94ccaf714337e4ce5ba99ef3dc2",
                             "name": "sys_security_acl_abc",
                             "type": "sys_security_acl",
                             "action": "INSERT_OR_UPDATE",
@@ -136,7 +136,7 @@ class TestChangesUpdatesetInspect:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_updateset_inspect"](update_set_id="us002")
+        raw = await tools["changes_updateset_inspect"](update_set_id="246378846af9222db26d7a2ab0462245")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -146,12 +146,12 @@ class TestChangesUpdatesetInspect:
     @respx.mock
     async def test_empty_update_set(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Handles update set with no members."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/us003").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/50ae2cd3c6fd16820c3fa5f064a93d53").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "us003",
+                        "sys_id": "50ae2cd3c6fd16820c3fa5f064a93d53",
                         "name": "Empty",
                         "state": "in progress",
                     }
@@ -167,7 +167,7 @@ class TestChangesUpdatesetInspect:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_updateset_inspect"](update_set_id="us003")
+        raw = await tools["changes_updateset_inspect"](update_set_id="50ae2cd3c6fd16820c3fa5f064a93d53")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -198,13 +198,13 @@ class TestChangesDiffArtifact:
                 json={
                     "result": [
                         {
-                            "sys_id": "v2",
+                            "sys_id": "a1047eab1035d58682a53557e0b2a75e",
                             "name": "sys_script_include_abc",
                             "payload": '<record><sys_script_include action="INSERT_OR_UPDATE"><script>function hello() { return "world"; }</script></sys_script_include></record>',
                             "sys_recorded_at": "2026-02-20 10:00:00",
                         },
                         {
-                            "sys_id": "v1",
+                            "sys_id": "5a6df720540c20d95d530d3fd6885511",
                             "name": "sys_script_include_abc",
                             "payload": '<record><sys_script_include action="INSERT_OR_UPDATE"><script>function hello() { return "hello"; }</script></sys_script_include></record>',
                             "sys_recorded_at": "2026-02-19 10:00:00",
@@ -265,13 +265,13 @@ class TestChangesDiffArtifact:
                 json={
                     "result": [
                         {
-                            "sys_id": "v2",
+                            "sys_id": "a1047eab1035d58682a53557e0b2a75e",
                             "name": "sys_script_include_xyz",
                             "payload": new_payload,
                             "sys_recorded_at": "2026-02-21 10:00:00",
                         },
                         {
-                            "sys_id": "v1",
+                            "sys_id": "5a6df720540c20d95d530d3fd6885511",
                             "name": "sys_script_include_xyz",
                             "payload": old_payload,
                             "sys_recorded_at": "2026-02-20 10:00:00",
@@ -307,13 +307,13 @@ class TestChangesDiffArtifact:
                 json={
                     "result": [
                         {
-                            "sys_id": "v2",
+                            "sys_id": "a1047eab1035d58682a53557e0b2a75e",
                             "name": "sys_script_include_abc",
                             "payload": "<new/>",
                             "sys_recorded_at": "2026-02-21 10:00:00",
                         },
                         {
-                            "sys_id": "v1",
+                            "sys_id": "5a6df720540c20d95d530d3fd6885511",
                             "name": "sys_script_include_abc",
                             "payload": "<old/>",
                             "sys_recorded_at": "2026-02-20 10:00:00",
@@ -354,13 +354,13 @@ class TestChangesDiffArtifact:
                 json={
                     "result": [
                         {
-                            "sys_id": "v2",
+                            "sys_id": "a1047eab1035d58682a53557e0b2a75e",
                             "name": "sys_script_include_abc^^def",
                             "payload": "<new/>",
                             "sys_recorded_at": "2026-02-21 10:00:00",
                         },
                         {
-                            "sys_id": "v1",
+                            "sys_id": "5a6df720540c20d95d530d3fd6885511",
                             "name": "sys_script_include_abc^^def",
                             "payload": "<old/>",
                             "sys_recorded_at": "2026-02-20 10:00:00",
@@ -402,22 +402,22 @@ class TestChangesLastTouched:
                 json={
                     "result": [
                         {
-                            "sys_id": "a1",
+                            "sys_id": "f29bc91bbdab169fc0c0a326965953d1",
                             "user": "admin",
                             "fieldname": "state",
                             "oldvalue": "1",
                             "newvalue": "2",
                             "sys_created_on": "2026-02-20 09:00:00",
-                            "documentkey": "inc001",
+                            "documentkey": "6d55028a7049dbf2f4275991d6fc81cf",
                         },
                         {
-                            "sys_id": "a2",
+                            "sys_id": "b9f85daa6f83cf02ce5c31913d1f64d3",
                             "user": "admin",
                             "fieldname": "assigned_to",
                             "oldvalue": "",
                             "newvalue": "John Doe",
                             "sys_created_on": "2026-02-20 08:30:00",
-                            "documentkey": "inc001",
+                            "documentkey": "6d55028a7049dbf2f4275991d6fc81cf",
                         },
                     ]
                 },
@@ -426,7 +426,7 @@ class TestChangesLastTouched:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_last_touched"](table="incident", sys_id="inc001")
+        raw = await tools["changes_last_touched"](table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -446,7 +446,7 @@ class TestChangesLastTouched:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_last_touched"](table="incident", sys_id="inc999")
+        raw = await tools["changes_last_touched"](table="incident", sys_id="2edef9aa2e99060fd11a80ae6eed85b5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -480,13 +480,13 @@ class TestChangesReleaseNotes:
                 json={
                     "result": [
                         {
-                            "sys_id": "m1",
+                            "sys_id": "ae23b94ccaf714337e4ce5ba99ef3dc2",
                             "type": "sys_script_include",
                             "action": "INSERT_OR_UPDATE",
                             "target_name": "IncidentUtils",
                         },
                         {
-                            "sys_id": "m2",
+                            "sys_id": "32d332da761f44df7959e5887b6b94cb",
                             "type": "sys_script",
                             "action": "INSERT_OR_UPDATE",
                             "target_name": "BR: Auto-assign",
@@ -501,10 +501,10 @@ class TestChangesReleaseNotes:
     @respx.mock
     async def test_generates_markdown_release_notes(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Generates Markdown release notes from update set."""
-        self._mock_release_notes_requests("us001")
+        self._mock_release_notes_requests("f7c5a9c7fa7010efe496857fbfc9d0d5")
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_release_notes"](update_set_id="us001")
+        raw = await tools["changes_release_notes"](update_set_id="f7c5a9c7fa7010efe496857fbfc9d0d5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -523,10 +523,10 @@ class TestChangesReleaseNotes:
         format_value: str,
     ) -> None:
         """Accepts markdown variants and preserves legacy fallback-to-markdown behavior."""
-        self._mock_release_notes_requests("us005")
+        self._mock_release_notes_requests("bc89942e2774d75ebcc7362c55807e09")
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_release_notes"](update_set_id="us005", format=format_value)
+        raw = await tools["changes_release_notes"](update_set_id="bc89942e2774d75ebcc7362c55807e09", format=format_value)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -537,12 +537,12 @@ class TestChangesReleaseNotes:
     @respx.mock
     async def test_handles_empty_update_set(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Generates notes even for empty update set."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/us004").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_update_set/1682126ebf3ed4a51478f0c4439c8da6").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "us004",
+                        "sys_id": "1682126ebf3ed4a51478f0c4439c8da6",
                         "name": "Empty Release",
                         "state": "in progress",
                     }
@@ -558,7 +558,7 @@ class TestChangesReleaseNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["changes_release_notes"](update_set_id="us004")
+        raw = await tools["changes_release_notes"](update_set_id="1682126ebf3ed4a51478f0c4439c8da6")
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1615,7 +1615,7 @@ class TestATFCloudRunner404:
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(NotFoundError, match="ATF Cloud Runner"):
-                await client.atf_run("test_sys_id_123")
+                await client.atf_run("a" * 32)
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -1630,7 +1630,7 @@ class TestATFCloudRunner404:
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(NotFoundError, match="ATF Cloud Runner"):
-                await client.atf_progress("snboq_id_123")
+                await client.atf_progress("b" * 32)
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -1645,4 +1645,141 @@ class TestATFCloudRunner404:
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(NotFoundError, match="ATF Cloud Runner"):
-                await client.atf_cancel("snboq_id_123")
+                await client.atf_cancel("c" * 32)
+
+
+class TestServiceCatalogSysIdValidation:
+    """Assert sc_* methods reject malformed sys_ids before issuing any HTTP.
+
+    The service_catalog endpoints interpolate sys_id values directly into URL
+    paths (e.g. /api/sn_sc/servicecatalog/items/{sys_id}/order_now). Without
+    ``validate_sys_id`` a caller could inject path segments, query strings,
+    or URL-encoded traversal sequences. Validation must happen before
+    ``_sc_url()`` builds the URL.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_sys_id",
+        [
+            "../../etc/passwd",
+            "%2e%2e%2f",
+            "a" * 31,
+            "a" * 33,
+            "a" * 16 + "/" + "a" * 15,
+            "a" * 32 + "/../other",
+            "a" * 32 + "?sysparm_fields=password",
+            "XYZ" * 11,
+            "",
+        ],
+    )
+    @pytest.mark.asyncio()
+    async def test_sc_get_catalog_rejects_malformed(
+        self,
+        settings: Settings,
+        auth_provider: BasicAuthProvider,
+        bad_sys_id: str,
+    ) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_get_catalog(bad_sys_id)
+
+    @pytest.mark.asyncio()
+    async def test_sc_get_catalog_categories_rejects_malformed(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_get_catalog_categories("a" * 32 + "/../other")
+
+    @pytest.mark.asyncio()
+    async def test_sc_get_category_rejects_malformed(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_get_category("../../etc/passwd")
+
+    @pytest.mark.asyncio()
+    async def test_sc_get_item_rejects_malformed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_get_item("%2e%2e%2f")
+
+    @pytest.mark.asyncio()
+    async def test_sc_get_item_variables_rejects_malformed(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_get_item_variables("a" * 31)
+
+    @pytest.mark.asyncio()
+    async def test_sc_order_now_rejects_malformed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_order_now("a" * 32 + "?sysparm_fields=password")
+
+    @pytest.mark.asyncio()
+    async def test_sc_add_to_cart_rejects_malformed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.sc_add_to_cart("XYZ" * 11)
+
+
+class TestATFSysIdValidation:
+    """Assert atf_* methods reject malformed sys_ids before issuing any HTTP.
+
+    ``snboqId`` is a ServiceNow queue-execution sys_id and must conform to
+    the 32-hex contract; accepting arbitrary strings would allow a caller
+    to smuggle arbitrary values into ATF runner query parameters or bodies.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_atf_run_rejects_malformed_test_id(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.atf_run("../../etc/passwd")
+
+    @pytest.mark.asyncio()
+    async def test_atf_run_rejects_malformed_suite_id(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.atf_run("a" * 32 + "/../other", is_suite=True)
+
+    @pytest.mark.asyncio()
+    async def test_atf_progress_rejects_malformed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.atf_progress("a" * 32 + "?admin=true")
+
+    @pytest.mark.asyncio()
+    async def test_atf_cancel_rejects_malformed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.atf_cancel("XYZ" * 11)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,6 +131,31 @@ class TestServiceNowClientGetRecord:
             with pytest.raises(AuthError):
                 await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
+    @pytest.mark.asyncio()
+    async def test_get_record_rejects_non_hex_sys_id(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """_table_url invokes validate_sys_id; non-hex sys_ids are rejected before any HTTP call.
+
+        This is the chokepoint that blocks path-traversal-style sys_id inputs
+        (e.g. '../foo', URL-encoded junk) from ever reaching the network.
+        """
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            # Path traversal attempt
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.get_record("incident", "../secrets/admin")
+            # URL-encoded junk
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.get_record("incident", "%2E%2E%2Fadmin")
+            # Uppercase hex (valid length, invalid casing)
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.get_record("incident", "A" * 32)
+            # 33-char hex (one over)
+            with pytest.raises(ValueError, match="Invalid sys_id"):
+                await client.get_record("incident", "a" * 33)
+
 
 class TestServiceNowClientQueryRecords:
     """Test query_records method."""
@@ -268,6 +293,133 @@ class TestServiceNowClientQueryRecords:
 
         assert route.calls.last is not None
         assert "sysparm_display_value" not in str(route.calls.last.request.url)
+
+
+class TestGetRecordsPrivileged:
+    """Test get_records_privileged - the allowlist-gated bypass for DENIED_TABLES.
+
+    This path is only meant for investigation modules that own the decision
+    to read a hardened table (e.g. acl_conflicts -> sys_security_acl). The
+    caller-declared allowlist is the gate: any table outside it - including
+    tables that are NOT on DENIED_TABLES - is rejected so mistakes fail closed.
+    """
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_allowed_table_returns_masked_records(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Allowed table returns records with sensitive fields masked."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.policy import MASK_VALUE
+
+        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "a" * 32,
+                            "name": "incident",
+                            "operation": "read",
+                            "password": "hunter2",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.get_records_privileged(
+                "sys_security_acl",
+                allowed_tables=frozenset({"sys_security_acl"}),
+                query="name=incident",
+                fields="sys_id,name,operation,password",
+                limit=10,
+            )
+
+        assert len(result["records"]) == 1
+        record = result["records"][0]
+        assert record["name"] == "incident"
+        assert record["password"] == MASK_VALUE
+
+    @pytest.mark.asyncio()
+    async def test_denied_table_outside_allowlist_raises(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """A DENIED_TABLES entry not in the allowlist is rejected."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import PolicyError
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            # sys_credentials is on DENIED_TABLES but not in the caller's allowlist.
+            with pytest.raises(PolicyError, match="not in the caller's"):
+                await client.get_records_privileged(
+                    "sys_credentials",
+                    allowed_tables=frozenset({"sys_security_acl"}),
+                    query="",
+                    limit=1,
+                )
+
+    @pytest.mark.asyncio()
+    async def test_non_denied_table_outside_allowlist_raises(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Even a benign (non-denied) table is rejected if not in the allowlist.
+
+        The allowlist is the gate - not DENIED_TABLES membership - so a typo
+        or accidental call path cannot silently succeed.
+        """
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import PolicyError
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(PolicyError, match="not in the caller's"):
+                await client.get_records_privileged(
+                    "incident",
+                    allowed_tables=frozenset({"sys_security_acl"}),
+                    query="",
+                    limit=1,
+                )
+
+    @pytest.mark.asyncio()
+    async def test_invalid_identifier_raises(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Malformed table names are rejected by validate_identifier via _table_url."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(ValueError, match="Invalid identifier"):
+                await client.get_records_privileged(
+                    "sys_security_acl; DROP TABLE users",
+                    allowed_tables=frozenset({"sys_security_acl; DROP TABLE users"}),
+                    query="",
+                    limit=1,
+                )
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_display_values_flag_propagates(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """display_values=True adds sysparm_display_value=true to the request."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            await client.get_records_privileged(
+                "sys_security_acl",
+                allowed_tables=frozenset({"sys_security_acl"}),
+                display_values=True,
+            )
+
+        assert route.calls.last is not None
+        assert "sysparm_display_value=true" in str(route.calls.last.request.url)
 
 
 class TestServiceNowClientAttachmentMethods:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -384,9 +384,7 @@ class TestGetRecordsPrivileged:
                 )
 
     @pytest.mark.asyncio()
-    async def test_invalid_identifier_raises(
-        self, settings: Settings, auth_provider: BasicAuthProvider
-    ) -> None:
+    async def test_invalid_identifier_raises(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Malformed table names are rejected by validate_identifier via _table_url."""
         from servicenow_mcp.client import ServiceNowClient
 
@@ -401,9 +399,7 @@ class TestGetRecordsPrivileged:
 
     @pytest.mark.asyncio()
     @respx.mock
-    async def test_display_values_flag_propagates(
-        self, settings: Settings, auth_provider: BasicAuthProvider
-    ) -> None:
+    async def test_display_values_flag_propagates(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """display_values=True adds sysparm_display_value=true to the request."""
         from servicenow_mcp.client import ServiceNowClient
 
@@ -745,7 +741,9 @@ class TestServiceNowClientDeleteRecord:
         """Deletes a record via DELETE."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.delete(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(return_value=httpx.Response(204))
+        respx.delete(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
+            return_value=httpx.Response(204)
+        )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             result = await client.delete_record("incident", "6367c48dd193d56ea7b0baad25b19455")
@@ -1159,7 +1157,10 @@ class TestServiceNowClientCMDB:
                 200,
                 json={
                     "result": {
-                        "attributes": {"sys_id": "73767563ce47fbef89395fe3a44f456a", "name": "365c544c62cbe6bb0b789bdb702b190e"},
+                        "attributes": {
+                            "sys_id": "73767563ce47fbef89395fe3a44f456a",
+                            "name": "365c544c62cbe6bb0b789bdb702b190e",
+                        },
                         "inbound_relations": [],
                         "outbound_relations": [],
                     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 """Tests for ServiceNow REST client."""
 
 from typing import Any
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -416,6 +417,145 @@ class TestGetRecordsPrivileged:
 
         assert route.calls.last is not None
         assert "sysparm_display_value=true" in str(route.calls.last.request.url)
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_limit_clamped_to_max_row_limit(self, auth_provider: BasicAuthProvider) -> None:
+        """Oversized caller limits are clamped by enforce_privileged_query_safety.
+
+        Privileged reads bypass DENIED_TABLES but MUST still honour cost-control
+        clamps. A caller passing ``limit=10000`` against a tenant configured for
+        ``max_row_limit=50`` should see the outbound request capped at 50 and
+        ``effective_limit`` in the return dict reflect the clamp.
+        """
+        from servicenow_mcp.client import ServiceNowClient
+
+        env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "s3cret",
+            "SERVICENOW_ENV": "dev",
+            "MCP_TOOL_PACKAGE": "full",
+            "MAX_ROW_LIMIT": "50",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            clamped_settings = Settings(_env_file=None)
+
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        async with ServiceNowClient(clamped_settings, auth_provider) as client:
+            result = await client.get_records_privileged(
+                "sys_security_acl",
+                allowed_tables=frozenset({"sys_security_acl"}),
+                limit=10000,
+            )
+
+        assert route.calls.last is not None
+        assert "sysparm_limit=50" in str(route.calls.last.request.url)
+        assert result["effective_limit"] == 50
+
+    @pytest.mark.asyncio()
+    async def test_large_table_without_date_filter_raises(self, auth_provider: BasicAuthProvider) -> None:
+        """Privileged reads against a large table without a date filter fail fast."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import QuerySafetyError
+
+        env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "s3cret",
+            "SERVICENOW_ENV": "dev",
+            "MCP_TOOL_PACKAGE": "full",
+            "LARGE_TABLE_NAMES_CSV": "sys_security_acl",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            large_settings = Settings(_env_file=None)
+
+        async with ServiceNowClient(large_settings, auth_provider) as client:
+            with pytest.raises(QuerySafetyError, match="date-bounded filter"):
+                await client.get_records_privileged(
+                    "sys_security_acl",
+                    allowed_tables=frozenset({"sys_security_acl"}),
+                    query="operation=read",
+                    limit=10,
+                )
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_large_table_with_date_filter_passes(self, auth_provider: BasicAuthProvider) -> None:
+        """A date-bounded query against a large table is permitted."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        env = {
+            "SERVICENOW_INSTANCE_URL": "https://test.service-now.com",
+            "SERVICENOW_USERNAME": "admin",
+            "SERVICENOW_PASSWORD": "s3cret",
+            "SERVICENOW_ENV": "dev",
+            "MCP_TOOL_PACKAGE": "full",
+            "LARGE_TABLE_NAMES_CSV": "sys_security_acl",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            large_settings = Settings(_env_file=None)
+
+        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        async with ServiceNowClient(large_settings, auth_provider) as client:
+            result = await client.get_records_privileged(
+                "sys_security_acl",
+                allowed_tables=frozenset({"sys_security_acl"}),
+                query="sys_created_on>=2024-01-01^operation=read",
+                limit=10,
+            )
+
+        assert result["count"] == 0
+        assert result["effective_limit"] == 10
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_display_values_masks_sensitive_fields(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Finding 7: display_values=True must not bypass sensitive-field masking.
+
+        Masking is applied to the parsed record regardless of whether the
+        response was rendered with display values; a password in the result
+        must always be replaced by ``MASK_VALUE``.
+        """
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.policy import MASK_VALUE
+
+        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "sys_id": "a" * 32,
+                            "name": "incident",
+                            "password": "hunter2",
+                            "secret_key": "topsecret",
+                        },
+                    ]
+                },
+                headers={"X-Total-Count": "1"},
+            )
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.get_records_privileged(
+                "sys_security_acl",
+                allowed_tables=frozenset({"sys_security_acl"}),
+                display_values=True,
+            )
+
+        record = result["records"][0]
+        assert record["password"] == MASK_VALUE
+        assert record["secret_key"] == MASK_VALUE
+        assert record["name"] == "incident"
 
 
 class TestServiceNowClientAttachmentMethods:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,13 +107,14 @@ class TestServiceNowClientGetRecord:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import NotFoundError
 
-        respx.get(f"{BASE_URL}/api/now/table/incident/missing").mock(
+        missing_sys_id = "00000000000000000000000000000000"
+        respx.get(f"{BASE_URL}/api/now/table/incident/{missing_sys_id}").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(NotFoundError):
-                await client.get_record("incident", "missing")
+                await client.get_record("incident", missing_sys_id)
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -664,7 +665,7 @@ class TestServiceNowClientGetEmail:
         """Fetches an email record by ID."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.get(f"{BASE_URL}/api/now/5a6df720540c20d95d530d3fd6885511/email/285b9ff22fbce171a68a2b88194bf4c9").mock(
+        respx.get(f"{BASE_URL}/api/now/v1/email/285b9ff22fbce171a68a2b88194bf4c9").mock(
             return_value=httpx.Response(
                 200,
                 json={
@@ -689,7 +690,7 @@ class TestServiceNowClientGetEmail:
         """Passes sysparm_fields parameter."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/5a6df720540c20d95d530d3fd6885511/email/285b9ff22fbce171a68a2b88194bf4c9").mock(
+        route = respx.get(f"{BASE_URL}/api/now/v1/email/285b9ff22fbce171a68a2b88194bf4c9").mock(
             return_value=httpx.Response(
                 200,
                 json={"result": {"sys_id": "285b9ff22fbce171a68a2b88194bf4c9"}},
@@ -738,13 +739,14 @@ class TestServiceNowClientGetImportSetRecord:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import NotFoundError
 
-        respx.get(f"{BASE_URL}/api/now/import/u_staging_table/missing").mock(
+        missing_sys_id = "00000000000000000000000000000000"
+        respx.get(f"{BASE_URL}/api/now/import/u_staging_table/{missing_sys_id}").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(NotFoundError):
-                await client.get_import_set_record("u_staging_table", "missing")
+                await client.get_import_set_record("u_staging_table", missing_sys_id)
 
 
 class TestServiceNowClientReportingAPIs:
@@ -1025,13 +1027,14 @@ class TestServiceNowClientCMDB:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import NotFoundError
 
-        respx.get(f"{BASE_URL}/api/now/cmdb/instance/cmdb_ci_linux_server/missing").mock(
+        missing_sys_id = "00000000000000000000000000000000"
+        respx.get(f"{BASE_URL}/api/now/cmdb/instance/cmdb_ci_linux_server/{missing_sys_id}").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(NotFoundError):
-                await client.cmdb_get_instance("cmdb_ci_linux_server", "missing")
+                await client.cmdb_get_instance("cmdb_ci_linux_server", missing_sys_id)
 
     @pytest.mark.asyncio()
     @respx.mock

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,17 +28,17 @@ class TestServiceNowClientGetRecord:
         """Fetches a single record by sys_id."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        route = respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "abc123", "number": "INC0001"}},
+                json={"result": {"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0001"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            record = await client.get_record("incident", "abc123")
+            record = await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
-        assert record == {"sys_id": "abc123", "number": "INC0001"}
+        assert record == {"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0001"}
         assert route.called
 
     @pytest.mark.asyncio()
@@ -47,15 +47,15 @@ class TestServiceNowClientGetRecord:
         """Respects field selection parameter."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        route = respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "abc123", "number": "INC0001"}},
+                json={"result": {"sys_id": "6367c48dd193d56ea7b0baad25b19455", "number": "INC0001"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            await client.get_record("incident", "abc123", fields=["sys_id", "number"])
+            await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455", fields=["sys_id", "number"])
 
         assert route.calls.last is not None
         assert "sysparm_fields" in str(route.calls.last.request.url)
@@ -66,15 +66,15 @@ class TestServiceNowClientGetRecord:
         """Passes display_value parameter."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        route = respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "abc123"}},
+                json={"result": {"sys_id": "6367c48dd193d56ea7b0baad25b19455"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            await client.get_record("incident", "abc123", display_values=True)
+            await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455", display_values=True)
 
         assert route.calls.last is not None
         assert "sysparm_display_value=true" in str(route.calls.last.request.url)
@@ -87,15 +87,15 @@ class TestServiceNowClientGetRecord:
         """Omits display_value param when display_values is False."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        route = respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "abc123"}},
+                json={"result": {"sys_id": "6367c48dd193d56ea7b0baad25b19455"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            await client.get_record("incident", "abc123", display_values=False)
+            await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455", display_values=False)
 
         assert route.calls.last is not None
         assert "sysparm_display_value" not in str(route.calls.last.request.url)
@@ -122,13 +122,13 @@ class TestServiceNowClientGetRecord:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import AuthError
 
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(401, json={"error": {"message": "Unauthorized"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(AuthError):
-                await client.get_record("incident", "abc123")
+                await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
 
 class TestServiceNowClientQueryRecords:
@@ -551,14 +551,14 @@ class TestServiceNowClientCreateRecord:
         respx.post(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=httpx.Response(
                 201,
-                json={"result": {"sys_id": "new123", "number": "INC0099"}},
+                json={"result": {"sys_id": "bdb8465ce041d94a0e490564f2162dcc", "number": "INC0099"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             record = await client.create_record("incident", {"short_description": "Test incident"})
 
-        assert record["sys_id"] == "new123"
+        assert record["sys_id"] == "bdb8465ce041d94a0e490564f2162dcc"
 
 
 class TestServiceNowClientUpdateRecord:
@@ -570,15 +570,15 @@ class TestServiceNowClientUpdateRecord:
         """Updates a record via PATCH."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.patch(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.patch(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "abc123", "state": "2"}},
+                json={"result": {"sys_id": "6367c48dd193d56ea7b0baad25b19455", "state": "2"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            record = await client.update_record("incident", "abc123", {"state": "2"})
+            record = await client.update_record("incident", "6367c48dd193d56ea7b0baad25b19455", {"state": "2"})
 
         assert record["state"] == "2"
 
@@ -592,10 +592,10 @@ class TestServiceNowClientDeleteRecord:
         """Deletes a record via DELETE."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.delete(f"{BASE_URL}/api/now/table/incident/abc123").mock(return_value=httpx.Response(204))
+        respx.delete(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(return_value=httpx.Response(204))
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.delete_record("incident", "abc123")
+            result = await client.delete_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
         assert result is True
 
@@ -610,13 +610,13 @@ class TestServiceNowClientErrorHandling:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import ForbiddenError
 
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(403, json={"error": {"message": "Forbidden"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(ForbiddenError):
-                await client.get_record("incident", "abc123")
+                await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -625,13 +625,13 @@ class TestServiceNowClientErrorHandling:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import ServerError
 
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(500, json={"error": {"message": "Internal"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(ServerError):
-                await client.get_record("incident", "abc123")
+                await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
 
 class TestServiceNowClientCorrelationId:
@@ -643,12 +643,12 @@ class TestServiceNowClientCorrelationId:
         """Every request includes an X-Correlation-ID header."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
-            return_value=httpx.Response(200, json={"result": {"sys_id": "abc123"}})
+        route = respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
+            return_value=httpx.Response(200, json={"result": {"sys_id": "6367c48dd193d56ea7b0baad25b19455"}})
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            await client.get_record("incident", "abc123")
+            await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
         assert route.calls.last is not None
         request_headers = dict(route.calls.last.request.headers)
@@ -664,12 +664,12 @@ class TestServiceNowClientGetEmail:
         """Fetches an email record by ID."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.get(f"{BASE_URL}/api/now/v1/email/email123").mock(
+        respx.get(f"{BASE_URL}/api/now/5a6df720540c20d95d530d3fd6885511/email/285b9ff22fbce171a68a2b88194bf4c9").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "email123",
+                        "sys_id": "285b9ff22fbce171a68a2b88194bf4c9",
                         "subject": "Test email",
                         "type": "send",
                     }
@@ -678,9 +678,9 @@ class TestServiceNowClientGetEmail:
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.get_email("email123")
+            result = await client.get_email("285b9ff22fbce171a68a2b88194bf4c9")
 
-        assert result["sys_id"] == "email123"
+        assert result["sys_id"] == "285b9ff22fbce171a68a2b88194bf4c9"
         assert result["subject"] == "Test email"
 
     @pytest.mark.asyncio()
@@ -689,15 +689,15 @@ class TestServiceNowClientGetEmail:
         """Passes sysparm_fields parameter."""
         from servicenow_mcp.client import ServiceNowClient
 
-        route = respx.get(f"{BASE_URL}/api/now/v1/email/email123").mock(
+        route = respx.get(f"{BASE_URL}/api/now/5a6df720540c20d95d530d3fd6885511/email/285b9ff22fbce171a68a2b88194bf4c9").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "email123"}},
+                json={"result": {"sys_id": "285b9ff22fbce171a68a2b88194bf4c9"}},
             )
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            await client.get_email("email123", fields=["sys_id", "subject"])
+            await client.get_email("285b9ff22fbce171a68a2b88194bf4c9", fields=["sys_id", "subject"])
 
         assert route.calls.last is not None
         assert "sysparm_fields" in str(route.calls.last.request.url)
@@ -712,12 +712,12 @@ class TestServiceNowClientGetImportSetRecord:
         """Retrieves an import set record."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.get(f"{BASE_URL}/api/now/import/u_staging_table/rec123").mock(
+        respx.get(f"{BASE_URL}/api/now/import/u_staging_table/aa97905375e489695050579dce8b0ab2").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "rec123",
+                        "sys_id": "aa97905375e489695050579dce8b0ab2",
                         "import_set": "IMP001",
                         "status": "inserted",
                     }
@@ -726,9 +726,9 @@ class TestServiceNowClientGetImportSetRecord:
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.get_import_set_record("u_staging_table", "rec123")
+            result = await client.get_import_set_record("u_staging_table", "aa97905375e489695050579dce8b0ab2")
 
-        assert result["sys_id"] == "rec123"
+        assert result["sys_id"] == "aa97905375e489695050579dce8b0ab2"
         assert result["status"] == "inserted"
 
     @pytest.mark.asyncio()
@@ -761,8 +761,8 @@ class TestServiceNowClientReportingAPIs:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "rpt1", "title": "Incident Report"},
-                        {"sys_id": "rpt2", "title": "Change Report"},
+                        {"sys_id": "7ed1b3474f1c2b181abf7930a484c423", "title": "Incident Report"},
+                        {"sys_id": "bb6d7f12edfd300254797a296ee73d31", "title": "Change Report"},
                     ]
                 },
             )
@@ -952,8 +952,8 @@ class TestServiceNowClientCMDB:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "ci1", "name": "server01"},
-                        {"sys_id": "ci2", "name": "server02"},
+                        {"sys_id": "d5f759f849bd82f4d43947407ffce511", "name": "365c544c62cbe6bb0b789bdb702b190e"},
+                        {"sys_id": "6f7aa3d044bfc90517430647fcbddac7", "name": "a9b964002520dfa399588247c37460c8"},
                     ]
                 },
                 headers={"X-Total-Count": "2"},
@@ -983,7 +983,7 @@ class TestServiceNowClientCMDB:
         async with ServiceNowClient(settings, auth_provider) as client:
             await client.cmdb_query(
                 "cmdb_ci_linux_server",
-                query="name=server01",
+                query="name=365c544c62cbe6bb0b789bdb702b190e",
                 limit=10,
                 offset=5,
             )
@@ -1000,12 +1000,12 @@ class TestServiceNowClientCMDB:
         """Retrieves a CMDB CI with relationships."""
         from servicenow_mcp.client import ServiceNowClient
 
-        respx.get(f"{BASE_URL}/api/now/cmdb/instance/cmdb_ci_linux_server/ci123").mock(
+        respx.get(f"{BASE_URL}/api/now/cmdb/instance/cmdb_ci_linux_server/73767563ce47fbef89395fe3a44f456a").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "attributes": {"sys_id": "ci123", "name": "server01"},
+                        "attributes": {"sys_id": "73767563ce47fbef89395fe3a44f456a", "name": "365c544c62cbe6bb0b789bdb702b190e"},
                         "inbound_relations": [],
                         "outbound_relations": [],
                     }
@@ -1014,9 +1014,9 @@ class TestServiceNowClientCMDB:
         )
 
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.cmdb_get_instance("cmdb_ci_linux_server", "ci123")
+            result = await client.cmdb_get_instance("cmdb_ci_linux_server", "73767563ce47fbef89395fe3a44f456a")
 
-        assert result["attributes"]["sys_id"] == "ci123"
+        assert result["attributes"]["sys_id"] == "73767563ce47fbef89395fe3a44f456a"
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -1112,7 +1112,7 @@ class TestClientNotInitialized:
 
         client = ServiceNowClient(settings, auth_provider)
         with pytest.raises(RuntimeError, match="Client not initialized"):
-            await client.get_record("incident", "abc123")
+            await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
     @pytest.mark.asyncio()
     async def test_query_records_without_context_manager(
@@ -1136,7 +1136,7 @@ class TestMissingResultKey:
         from servicenow_mcp.client import ServiceNowClient
         from servicenow_mcp.errors import ServerError
 
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
                 json={"error": "something went wrong"},
@@ -1145,7 +1145,7 @@ class TestMissingResultKey:
 
         async with ServiceNowClient(settings, auth_provider) as client:
             with pytest.raises(ServerError, match="missing 'result' key"):
-                await client.get_record("incident", "abc123")
+                await client.get_record("incident", "6367c48dd193d56ea7b0baad25b19455")
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -1201,7 +1201,7 @@ class TestInvalidTotalCount:
         respx.get(f"{BASE_URL}/api/now/cmdb/instance/cmdb_ci_linux_server").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": "ci1"}]},
+                json={"result": [{"sys_id": "d5f759f849bd82f4d43947407ffce511"}]},
                 headers={"X-Total-Count": "not_a_number"},
             )
         )
@@ -1238,7 +1238,7 @@ class TestUrlBuilderValidation:
 
         client = ServiceNowClient(settings, auth_provider)
         with pytest.raises(ValueError, match="Invalid identifier"):
-            client._import_set_url("../etc/passwd", "abc123")
+            client._import_set_url("../etc/passwd", "6367c48dd193d56ea7b0baad25b19455")
 
     def test_cmdb_instance_url_rejects_invalid_name(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """_cmdb_instance_url raises ValueError for invalid class name."""

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -534,7 +534,9 @@ class TestDebugFieldMutationStory:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_field_mutation_story"](table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf", field="state")
+        raw = await tools["debug_field_mutation_story"](
+            table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf", field="state"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -552,7 +554,9 @@ class TestDebugFieldMutationStory:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_field_mutation_story"](table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf", field="state")
+        raw = await tools["debug_field_mutation_story"](
+            table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf", field="state"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -46,14 +46,14 @@ class TestDebugTrace:
                 json={
                     "result": [
                         {
-                            "sys_id": "a1",
+                            "sys_id": "f29bc91bbdab169fc0c0a326965953d1",
                             "user": "admin",
                             "fieldname": "state",
                             "oldvalue": "1",
                             "newvalue": "2",
                             "sys_created_on": "2026-02-20 09:00:00",
                             "tablename": "incident",
-                            "documentkey": "inc001",
+                            "documentkey": "6d55028a7049dbf2f4275991d6fc81cf",
                         },
                     ]
                 },
@@ -67,7 +67,7 @@ class TestDebugTrace:
                 json={
                     "result": [
                         {
-                            "sys_id": "l1",
+                            "sys_id": "39a89dd158c8e9747943b00f84be79fc",
                             "message": "BR: Auto-assign triggered",
                             "source": "sys_script",
                             "level": "0",
@@ -85,7 +85,7 @@ class TestDebugTrace:
                 json={
                     "result": [
                         {
-                            "sys_id": "j1",
+                            "sys_id": "67921242516c48ac712807f98c98ee13",
                             "element": "comments",
                             "value": "Working on this issue",
                             "sys_created_on": "2026-02-20 09:01:00",
@@ -98,7 +98,7 @@ class TestDebugTrace:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_trace"](record_sys_id="inc001", table="incident", minutes=60)
+        raw = await tools["debug_trace"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf", table="incident", minutes=60)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -122,7 +122,7 @@ class TestDebugTrace:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_trace"](record_sys_id="inc999", table="incident")
+        raw = await tools["debug_trace"](record_sys_id="2edef9aa2e99060fd11a80ae6eed85b5", table="incident")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -143,7 +143,7 @@ class TestDebugTrace:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_trace"](record_sys_id="inc001", table="incident", minutes=30)
+        raw = await tools["debug_trace"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf", table="incident", minutes=30)
         result = decode_response(raw)
         assert result["status"] == "success"
 
@@ -184,12 +184,12 @@ class TestDebugFlowExecution:
     async def test_returns_flow_steps(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns flow execution steps from sys_flow_context and sys_flow_log."""
         # Mock flow context
-        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ctx001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/18dbe9bd70e88bd7d141d13c8a46e7d7").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx001",
+                        "sys_id": "18dbe9bd70e88bd7d141d13c8a46e7d7",
                         "name": "Auto-assign flow",
                         "state": "Completed",
                         "started": "2026-02-20 08:00:00",
@@ -205,15 +205,15 @@ class TestDebugFlowExecution:
                 json={
                     "result": [
                         {
-                            "sys_id": "fl1",
+                            "sys_id": "f8e82113421aa92b5fdb30a353b6e82c",
                             "step_label": "Lookup Record",
                             "state": "Completed",
                             "sys_created_on": "2026-02-20 08:00:01",
-                            "output_data": '{"record": "inc001"}',
+                            "output_data": '{"record": "6d55028a7049dbf2f4275991d6fc81cf"}',
                             "error_message": "",
                         },
                         {
-                            "sys_id": "fl2",
+                            "sys_id": "228c49472381812a668368a02dc4e3e0",
                             "step_label": "Update Record",
                             "state": "Completed",
                             "sys_created_on": "2026-02-20 08:00:03",
@@ -227,7 +227,7 @@ class TestDebugFlowExecution:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_flow_execution"](context_id="ctx001")
+        raw = await tools["debug_flow_execution"](context_id="18dbe9bd70e88bd7d141d13c8a46e7d7")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -238,12 +238,12 @@ class TestDebugFlowExecution:
     @respx.mock
     async def test_handles_flow_with_errors(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns error info when flow steps have errors."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ctx002").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ffff7ed3a8c7ffe871d910c0eb40322e").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx002",
+                        "sys_id": "ffff7ed3a8c7ffe871d910c0eb40322e",
                         "name": "Failed flow",
                         "state": "Error",
                     }
@@ -256,7 +256,7 @@ class TestDebugFlowExecution:
                 json={
                     "result": [
                         {
-                            "sys_id": "fl1",
+                            "sys_id": "f8e82113421aa92b5fdb30a353b6e82c",
                             "step_label": "Script Step",
                             "state": "Error",
                             "sys_created_on": "2026-02-20 08:00:01",
@@ -270,7 +270,7 @@ class TestDebugFlowExecution:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_flow_execution"](context_id="ctx002")
+        raw = await tools["debug_flow_execution"](context_id="ffff7ed3a8c7ffe871d910c0eb40322e")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -290,7 +290,7 @@ class TestDebugEmailTrace:
                 json={
                     "result": [
                         {
-                            "sys_id": "e1",
+                            "sys_id": "84896d3e067884621c0f54334b8d8409",
                             "type": "received",
                             "subject": "RE: INC0001",
                             "recipients": "admin@example.com",
@@ -299,7 +299,7 @@ class TestDebugEmailTrace:
                             "body_text": "Thanks for the update",
                         },
                         {
-                            "sys_id": "e2",
+                            "sys_id": "dc1885915a8902bc29de6d834477a26d",
                             "type": "send",
                             "subject": "INC0001 created",
                             "recipients": "user@example.com",
@@ -314,7 +314,7 @@ class TestDebugEmailTrace:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_email_trace"](record_sys_id="inc001")
+        raw = await tools["debug_email_trace"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -329,7 +329,7 @@ class TestDebugEmailTrace:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_email_trace"](record_sys_id="inc999")
+        raw = await tools["debug_email_trace"](record_sys_id="2edef9aa2e99060fd11a80ae6eed85b5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -349,7 +349,7 @@ class TestDebugIntegrationHealth:
                 json={
                     "result": [
                         {
-                            "sys_id": "ecc1",
+                            "sys_id": "c104970cbb6160c996f3cf0d5e7c1955",
                             "name": "SOAP",
                             "queue": "input",
                             "state": "error",
@@ -380,7 +380,7 @@ class TestDebugIntegrationHealth:
                 json={
                     "result": [
                         {
-                            "sys_id": "rt1",
+                            "sys_id": "50782307d71bd69a8c3a269bf7346646",
                             "rest_message": "ServiceNow API",
                             "http_method": "POST",
                             "http_status": "500",
@@ -423,12 +423,12 @@ class TestDebugImportsetRun:
     async def test_returns_import_set_results(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns import set run results."""
         # Mock import set header
-        respx.get(f"{BASE_URL}/api/now/table/sys_import_set/imp001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_import_set/3c8ef400f0d355f096cee5204dbd2819").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "imp001",
+                        "sys_id": "3c8ef400f0d355f096cee5204dbd2819",
                         "table_name": "u_staging",
                         "state": "loaded",
                         "mode": "asynchronous",
@@ -444,13 +444,13 @@ class TestDebugImportsetRun:
                 json={
                     "result": [
                         {
-                            "sys_id": "r1",
+                            "sys_id": "5573e39b6600496d40f493d00ec76584",
                             "sys_import_state": "inserted",
-                            "sys_target_sys_id": "t1",
+                            "sys_target_sys_id": "e5353879bd69bfddcb465dad176ff52d",
                             "sys_import_state_comment": "",
                         },
                         {
-                            "sys_id": "r2",
+                            "sys_id": "a50126cc2d6c726de0ca203c3b659f65",
                             "sys_import_state": "error",
                             "sys_target_sys_id": "",
                             "sys_import_state_comment": "Transform error: field mapping failed",
@@ -462,11 +462,11 @@ class TestDebugImportsetRun:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_importset_run"](import_set_sys_id="imp001")
+        raw = await tools["debug_importset_run"](import_set_sys_id="3c8ef400f0d355f096cee5204dbd2819")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["import_set"]["sys_id"] == "imp001"
+        assert result["data"]["import_set"]["sys_id"] == "3c8ef400f0d355f096cee5204dbd2819"
         assert result["data"]["summary"]["total"] == 2
         assert result["data"]["summary"]["inserted"] == 1
         assert result["data"]["summary"]["error"] == 1
@@ -475,12 +475,12 @@ class TestDebugImportsetRun:
     @respx.mock
     async def test_handles_empty_import_set(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Handles import set with no rows."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_import_set/imp002").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_import_set/dfff4e2300bbee9303bb3413aa5d6933").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "imp002",
+                        "sys_id": "dfff4e2300bbee9303bb3413aa5d6933",
                         "table_name": "u_staging",
                         "state": "loaded",
                     }
@@ -492,7 +492,7 @@ class TestDebugImportsetRun:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_importset_run"](import_set_sys_id="imp002")
+        raw = await tools["debug_importset_run"](import_set_sys_id="dfff4e2300bbee9303bb3413aa5d6933")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -512,7 +512,7 @@ class TestDebugFieldMutationStory:
                 json={
                     "result": [
                         {
-                            "sys_id": "a1",
+                            "sys_id": "f29bc91bbdab169fc0c0a326965953d1",
                             "user": "admin",
                             "fieldname": "state",
                             "oldvalue": "1",
@@ -520,7 +520,7 @@ class TestDebugFieldMutationStory:
                             "sys_created_on": "2026-02-19 10:00:00",
                         },
                         {
-                            "sys_id": "a2",
+                            "sys_id": "b9f85daa6f83cf02ce5c31913d1f64d3",
                             "user": "jdoe",
                             "fieldname": "state",
                             "oldvalue": "2",
@@ -534,7 +534,7 @@ class TestDebugFieldMutationStory:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_field_mutation_story"](table="incident", sys_id="inc001", field="state")
+        raw = await tools["debug_field_mutation_story"](table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf", field="state")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -552,7 +552,7 @@ class TestDebugFieldMutationStory:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["debug_field_mutation_story"](table="incident", sys_id="inc001", field="state")
+        raw = await tools["debug_field_mutation_story"](table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf", field="state")
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,8 +4,7 @@ import inspect
 import uuid
 from typing import Any
 
-from toon_format import decode as toon_decode
-
+from servicenow_mcp._vendor.toon_format import decode as toon_decode
 from servicenow_mcp.decorators import tool_handler
 from servicenow_mcp.errors import ForbiddenError
 from servicenow_mcp.utils import format_response

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -276,7 +276,9 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b")
+        raw = await tools["docs_artifact_summary"](
+            artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -294,7 +296,9 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="35a1af58a3b00bde3d8af97f82562ac2")
+        raw = await tools["docs_artifact_summary"](
+            artifact_type="business_rule", sys_id="35a1af58a3b00bde3d8af97f82562ac2"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -305,7 +309,9 @@ class TestDocsArtifactSummary:
     ) -> None:
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="bogus_type", sys_id="6367c48dd193d56ea7b0baad25b19455")
+        raw = await tools["docs_artifact_summary"](
+            artifact_type="bogus_type", sys_id="6367c48dd193d56ea7b0baad25b19455"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -336,7 +342,9 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="2edaa2dc068427312415c976a18155dd")
+        raw = await tools["docs_artifact_summary"](
+            artifact_type="business_rule", sys_id="2edaa2dc068427312415c976a18155dd"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -371,7 +379,9 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81", include_script_body=True)
+        raw = await tools["docs_artifact_summary"](
+            artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81", include_script_body=True
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -410,7 +420,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -438,7 +450,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="3d89a2d60f9752f52469325512b23c1e")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="3d89a2d60f9752f52469325512b23c1e"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -464,7 +478,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="1bf9bbae004e659911b334ee1b5bc4b6")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="1bf9bbae004e659911b334ee1b5bc4b6"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -503,7 +519,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="61bf664b40fbd88d122defa600c69f14")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="61bf664b40fbd88d122defa600c69f14"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -529,7 +547,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="83839a9c296d5abac37d82d3b4840022")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="83839a9c296d5abac37d82d3b4840022"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -555,7 +575,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="e70b73e9294b3ae08fa13456ec932bdd")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="e70b73e9294b3ae08fa13456ec932bdd"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -581,7 +603,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="c00bbddf942d596518d4ccdad89a4bdc")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="c00bbddf942d596518d4ccdad89a4bdc"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -607,7 +631,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="302dfaa738c5008f7359702d3a68d9bb")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="302dfaa738c5008f7359702d3a68d9bb"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -634,7 +660,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="3190599a75cb88b0c8873d2695a1eaa2")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="3190599a75cb88b0c8873d2695a1eaa2"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -662,7 +690,9 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81")
+        raw = await tools["docs_test_scenarios"](
+            artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -140,7 +140,7 @@ class TestDocsLogicMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "br_del",
+                            "sys_id": "61bf664b40fbd88d122defa600c69f14",
                             "name": "On delete",
                             "when": "before",
                             "action_insert": "false",
@@ -149,7 +149,7 @@ class TestDocsLogicMap:
                             "active": "true",
                         },
                         {
-                            "sys_id": "br_all",
+                            "sys_id": "3d94aec2ee47e55f945e280c4f258d94",
                             "name": "On all",
                             "when": "before",
                             "action_insert": "false",
@@ -316,12 +316,12 @@ class TestDocsArtifactSummary:
     @respx.mock
     async def test_code_search_failure_is_silent(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Code search exception is caught silently; referenced_by is empty."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_search_fail").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/2edaa2dc068427312415c976a18155dd").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_search_fail",
+                        "sys_id": "2edaa2dc068427312415c976a18155dd",
                         "name": "SearchFail BR",
                         "script": "var gr = new GlideRecord('task'); gr.query();",
                         "collection": "incident",
@@ -336,7 +336,7 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="br_search_fail")
+        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="2edaa2dc068427312415c976a18155dd")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -347,12 +347,12 @@ class TestDocsArtifactSummary:
     @respx.mock
     async def test_masks_sensitive_fields(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Sensitive fields in the artifact record are masked in the response."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_sensitive").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/a4735c7a88ec47eec3fba55319b9df81").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_sensitive",
+                        "sys_id": "a4735c7a88ec47eec3fba55319b9df81",
                         "name": "Sensitive BR",
                         "script": "gs.log('hello');",
                         "collection": "incident",
@@ -371,7 +371,7 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="br_sensitive")
+        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81", include_script_body=True)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -488,12 +488,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_delete_operation(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects delete operation check in script."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_del").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/61bf664b40fbd88d122defa600c69f14").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_del",
+                        "sys_id": "61bf664b40fbd88d122defa600c69f14",
                         "name": "Delete handler",
                         "script": "if (current.operation() == 'delete') { gs.log('deleted'); }",
                         "collection": "incident",
@@ -503,7 +503,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_del")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="61bf664b40fbd88d122defa600c69f14")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -514,12 +514,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_is_new_record(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects isNewRecord() check in script."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_new").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/83839a9c296d5abac37d82d3b4840022").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_new",
+                        "sys_id": "83839a9c296d5abac37d82d3b4840022",
                         "name": "New record handler",
                         "script": "if (current.isNewRecord()) { current.state = 1; }",
                         "collection": "incident",
@@ -529,7 +529,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_new")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="83839a9c296d5abac37d82d3b4840022")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -540,12 +540,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_role_check(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects gs.hasRole() check in script."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_role").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/e70b73e9294b3ae08fa13456ec932bdd").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_role",
+                        "sys_id": "e70b73e9294b3ae08fa13456ec932bdd",
                         "name": "Role gated",
                         "script": "if (gs.hasRole('admin')) { current.state = 2; }",
                         "collection": "incident",
@@ -555,7 +555,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_role")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="e70b73e9294b3ae08fa13456ec932bdd")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -566,12 +566,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_abort_action(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects setAbortAction(true) in script."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_abort").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/c00bbddf942d596518d4ccdad89a4bdc").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_abort",
+                        "sys_id": "c00bbddf942d596518d4ccdad89a4bdc",
                         "name": "Abort handler",
                         "script": "if (current.priority == 1) { current.setAbortAction(true); }",
                         "collection": "incident",
@@ -581,7 +581,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_abort")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="c00bbddf942d596518d4ccdad89a4bdc")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -592,12 +592,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_gliderecord_dependency(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects GlideRecord table dependencies in script."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_gr").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/302dfaa738c5008f7359702d3a68d9bb").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_gr",
+                        "sys_id": "302dfaa738c5008f7359702d3a68d9bb",
                         "name": "GR lookup",
                         "script": "var gr = new GlideRecord('sys_user'); gr.get(current.assigned_to);",
                         "collection": "incident",
@@ -607,7 +607,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_gr")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="302dfaa738c5008f7359702d3a68d9bb")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -619,12 +619,12 @@ class TestDocsTestScenarios:
     async def test_no_patterns_returns_generic(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Script with no detectable patterns returns generic fallback scenario."""
         # Use a non-empty script that matches none of the detection patterns
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_plain").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/3190599a75cb88b0c8873d2695a1eaa2").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_plain",
+                        "sys_id": "3190599a75cb88b0c8873d2695a1eaa2",
                         "name": "Plain BR",
                         "script": "gs.log('hello world');",
                         "collection": "incident",
@@ -634,7 +634,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_plain")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="3190599a75cb88b0c8873d2695a1eaa2")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -646,12 +646,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_masks_sensitive_fields_in_record(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Sensitive fields in the artifact record are masked before generating scenarios."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_sensitive").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/a4735c7a88ec47eec3fba55319b9df81").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_sensitive",
+                        "sys_id": "a4735c7a88ec47eec3fba55319b9df81",
                         "name": "Sensitive BR",
                         "script": "if (current.priority == 1) { current.state = 2; }",
                         "collection": "incident",
@@ -662,7 +662,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br_sensitive")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -695,12 +695,12 @@ class TestDocsReviewNotes:
     @respx.mock
     async def test_empty_script_no_findings(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Empty script returns empty findings list."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_empty").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/5be222eb14c6f8214c606ca364c61ff2").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_empty",
+                        "sys_id": "5be222eb14c6f8214c606ca364c61ff2",
                         "name": "Empty BR",
                         "script": "   ",
                         "collection": "incident",
@@ -710,7 +710,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br_empty")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="5be222eb14c6f8214c606ca364c61ff2")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -722,12 +722,12 @@ class TestDocsReviewNotes:
     async def test_detects_current_update(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects current.update() anti-pattern in script."""
         script = "current.state = 2;\ncurrent.update();"
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_cupd").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/d833ee4ab99720915651478f5fef8e68").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_cupd",
+                        "sys_id": "d833ee4ab99720915651478f5fef8e68",
                         "name": "Current update BR",
                         "script": script,
                         "collection": "incident",
@@ -737,7 +737,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br_cupd")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="d833ee4ab99720915651478f5fef8e68")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -837,12 +837,12 @@ class TestDocsReviewNotes:
     @respx.mock
     async def test_masks_sensitive_fields_in_record(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Sensitive fields in the artifact record are masked before scanning."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br_sensitive").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/a4735c7a88ec47eec3fba55319b9df81").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br_sensitive",
+                        "sys_id": "a4735c7a88ec47eec3fba55319b9df81",
                         "name": "Sensitive BR",
                         "script": "current.state = 2;",
                         "collection": "incident",
@@ -854,7 +854,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br_sensitive")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="a4735c7a88ec47eec3fba55319b9df81")
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -48,7 +48,7 @@ class TestDocsLogicMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "br1",
+                            "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                             "name": "Set defaults",
                             "when": "before",
                             "action_insert": "true",
@@ -57,7 +57,7 @@ class TestDocsLogicMap:
                             "active": "true",
                         },
                         {
-                            "sys_id": "br2",
+                            "sys_id": "45caf3e7f1e7ce17456aec79ce1ab853",
                             "name": "Send notification",
                             "when": "after",
                             "action_insert": "false",
@@ -77,7 +77,7 @@ class TestDocsLogicMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "cs1",
+                            "sys_id": "f9ce352c1d3e957f5b6330307d618b98",
                             "name": "Validate priority",
                             "type": "onChange",
                             "active": "true",
@@ -201,7 +201,7 @@ class TestDocsLogicMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "uip1",
+                            "sys_id": "a1151e6d2642a62fbecdab41e26d6bb2",
                             "short_description": "Make field read-only",
                             "active": "true",
                         },
@@ -216,7 +216,7 @@ class TestDocsLogicMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "uia1",
+                            "sys_id": "d8ebd7fd78247f151e5b789805832857",
                             "name": "Close Incident",
                             "action_name": "close",
                             "active": "true",
@@ -253,12 +253,12 @@ class TestDocsArtifactSummary:
     ) -> None:
         """Returns artifact summary with referenced tables and referenced_by."""
         # Get the artifact
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/5f94cbf2a18c848c38da0c789d5da01b").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br001",
+                        "sys_id": "5f94cbf2a18c848c38da0c789d5da01b",
                         "name": "Update CI",
                         "script": "var gr = new GlideRecord('cmdb_ci'); gr.addQuery('name', current.ci); gr.query();",
                         "collection": "incident",
@@ -276,7 +276,7 @@ class TestDocsArtifactSummary:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="br001")
+        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -289,12 +289,12 @@ class TestDocsArtifactSummary:
     @respx.mock
     async def test_not_found_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns error for non-existent artifact."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/bad_id").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/35a1af58a3b00bde3d8af97f82562ac2").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="bad_id")
+        raw = await tools["docs_artifact_summary"](artifact_type="business_rule", sys_id="35a1af58a3b00bde3d8af97f82562ac2")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -305,7 +305,7 @@ class TestDocsArtifactSummary:
     ) -> None:
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_artifact_summary"](artifact_type="bogus_type", sys_id="abc123")
+        raw = await tools["docs_artifact_summary"](artifact_type="bogus_type", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -395,12 +395,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_condition_branches(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects if/else conditions and suggests test scenarios."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/5f94cbf2a18c848c38da0c789d5da01b").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br001",
+                        "sys_id": "5f94cbf2a18c848c38da0c789d5da01b",
                         "name": "Priority handler",
                         "script": "if (current.priority == 1) { current.state = 2; } else { current.state = 1; }",
                         "collection": "incident",
@@ -410,7 +410,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br001")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -423,12 +423,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_detects_insert_vs_update(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects insert/update operation checks."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br002").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/3d89a2d60f9752f52469325512b23c1e").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br002",
+                        "sys_id": "3d89a2d60f9752f52469325512b23c1e",
                         "name": "Operation handler",
                         "script": "if (current.operation() == 'insert') { gs.log('new'); } else if (current.operation() == 'update') { gs.log('update'); }",
                         "collection": "incident",
@@ -438,7 +438,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br002")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="3d89a2d60f9752f52469325512b23c1e")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -449,12 +449,12 @@ class TestDocsTestScenarios:
     @respx.mock
     async def test_empty_script_returns_generic(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Empty script returns generic suggestions."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br003").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/1bf9bbae004e659911b334ee1b5bc4b6").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br003",
+                        "sys_id": "1bf9bbae004e659911b334ee1b5bc4b6",
                         "name": "Empty BR",
                         "script": "",
                         "collection": "incident",
@@ -464,7 +464,7 @@ class TestDocsTestScenarios:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="br003")
+        raw = await tools["docs_test_scenarios"](artifact_type="business_rule", sys_id="1bf9bbae004e659911b334ee1b5bc4b6")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -477,7 +477,7 @@ class TestDocsTestScenarios:
     ) -> None:
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_test_scenarios"](artifact_type="bogus_type", sys_id="abc123")
+        raw = await tools["docs_test_scenarios"](artifact_type="bogus_type", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -684,7 +684,7 @@ class TestDocsReviewNotes:
     ) -> None:
         """Unknown artifact_type returns an error with valid types listed."""
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="bogus_type", sys_id="abc123")
+        raw = await tools["docs_review_notes"](artifact_type="bogus_type", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -756,12 +756,12 @@ class TestDocsReviewNotes:
             "  inner.get(gr.assigned_to);\n"
             "}"
         )
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/5f94cbf2a18c848c38da0c789d5da01b").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br001",
+                        "sys_id": "5f94cbf2a18c848c38da0c789d5da01b",
                         "name": "Bad BR",
                         "script": script,
                         "collection": "incident",
@@ -771,7 +771,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br001")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="5f94cbf2a18c848c38da0c789d5da01b")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -785,12 +785,12 @@ class TestDocsReviewNotes:
     async def test_detects_hardcoded_sysid(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Detects hardcoded 32-char hex sys_ids in script."""
         script = "var user = gs.getUser('6816f79cc0a8016401c5a33be04be441');"
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br002").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/3d89a2d60f9752f52469325512b23c1e").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br002",
+                        "sys_id": "3d89a2d60f9752f52469325512b23c1e",
                         "name": "Hardcoded BR",
                         "script": script,
                         "collection": "incident",
@@ -800,7 +800,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br002")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="3d89a2d60f9752f52469325512b23c1e")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -812,12 +812,12 @@ class TestDocsReviewNotes:
     async def test_clean_script_no_findings(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Clean script returns no findings."""
         script = "current.state = 2;"
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br003").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/1bf9bbae004e659911b334ee1b5bc4b6").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br003",
+                        "sys_id": "1bf9bbae004e659911b334ee1b5bc4b6",
                         "name": "Clean BR",
                         "script": script,
                         "collection": "incident",
@@ -827,7 +827,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br003")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="1bf9bbae004e659911b334ee1b5bc4b6")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -866,12 +866,12 @@ class TestDocsReviewNotes:
     async def test_loop_truncated_at_eof(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Loop condition at EOF with no body is silently skipped."""
         script = "var gr = new GlideRecord('task');\ngr.query();\nwhile (gr.next())   "
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br002").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/3d89a2d60f9752f52469325512b23c1e").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br002",
+                        "sys_id": "3d89a2d60f9752f52469325512b23c1e",
                         "name": "Truncated BR",
                         "script": script,
                         "collection": "incident",
@@ -881,7 +881,7 @@ class TestDocsReviewNotes:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="br002")
+        raw = await tools["docs_review_notes"](artifact_type="business_rule", sys_id="3d89a2d60f9752f52469325512b23c1e")
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_flow_designer.py
+++ b/tests/test_flow_designer.py
@@ -388,7 +388,9 @@ class TestFlowMap:
     @respx.mock
     async def test_flow_map_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Uses latest_snapshot when child records are linked to the newest snapshot."""
-        self._mock_parent_flow_lookup("8eecae1b3a5230387ff5f06a91b9fbe9", latest_snapshot="b6069c7ab2fac9d79864075defa6176c")
+        self._mock_parent_flow_lookup(
+            "8eecae1b3a5230387ff5f06a91b9fbe9", latest_snapshot="b6069c7ab2fac9d79864075defa6176c"
+        )
         action_route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(
                 200,
@@ -450,7 +452,9 @@ class TestFlowMap:
     @respx.mock
     async def test_flow_map_only_actions(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Falls back to master_snapshot when latest_snapshot is missing."""
-        self._mock_parent_flow_lookup("06bed3558e7fd1e9359964cedb4dc271", master_snapshot="9b250a88678953224d007032837d3d92")
+        self._mock_parent_flow_lookup(
+            "06bed3558e7fd1e9359964cedb4dc271", master_snapshot="9b250a88678953224d007032837d3d92"
+        )
         action_route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(
                 200,
@@ -487,7 +491,9 @@ class TestFlowMap:
     @respx.mock
     async def test_flow_map_only_logic(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Flow with logic blocks but no actions."""
-        self._mock_parent_flow_lookup("f05a9e989019b2cd934dc2ba0c31a1d2", latest_snapshot="9095d45621112c8881812276e734f504")
+        self._mock_parent_flow_lookup(
+            "f05a9e989019b2cd934dc2ba0c31a1d2", latest_snapshot="9095d45621112c8881812276e734f504"
+        )
         respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
@@ -577,7 +583,9 @@ class TestFlowActionDetail:
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/636f282a5dd34466ab9e91c1706b1998").mock(side_effect=_instance_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/636f282a5dd34466ab9e91c1706b1998").mock(
+            side_effect=_instance_side_effect
+        )
         respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/8f60c39c7a0b23a9865bf30e8363153f").mock(
             return_value=httpx.Response(
                 200,
@@ -638,7 +646,9 @@ class TestFlowActionDetail:
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/bff4b2197387890d8565ff7bba7374fe").mock(side_effect=_nodef_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/bff4b2197387890d8565ff7bba7374fe").mock(
+            side_effect=_nodef_side_effect
+        )
 
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["flow_action_detail"](action_instance_sys_id="bff4b2197387890d8565ff7bba7374fe")
@@ -814,7 +824,11 @@ class TestFlowExecutionList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_list"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9", source_record="6d55028a7049dbf2f4275991d6fc81cf", state="COMPLETE")
+        raw = await tools["flow_execution_list"](
+            flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9",
+            source_record="6d55028a7049dbf2f4275991d6fc81cf",
+            state="COMPLETE",
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1086,7 +1100,11 @@ class TestFlowSnapshotList:
 class TestWorkflowMigrationAnalysis:
     """Tests for the workflow_migration_analysis tool."""
 
-    def _mock_version(self, sys_id: str = "e35fec24db6d035c7a6fa33e76847858", name: str = "Incident WF 5a6df720540c20d95d530d3fd6885511") -> None:
+    def _mock_version(
+        self,
+        sys_id: str = "e35fec24db6d035c7a6fa33e76847858",
+        name: str = "Incident WF 5a6df720540c20d95d530d3fd6885511",
+    ) -> None:
         """Mock a wf_workflow_version GET."""
         respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/{sys_id}").mock(
             return_value=httpx.Response(
@@ -1813,7 +1831,10 @@ class TestFlowDesignerDictReferenceFields:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """flow_action_detail handles action_type returned as a dict reference."""
-        dict_action_type = {"display_value": "13619c05f5ecfe7907f8a0677a47a1d2", "link": "https://test.service-now.com/api/..."}
+        dict_action_type = {
+            "display_value": "13619c05f5ecfe7907f8a0677a47a1d2",
+            "link": "https://test.service-now.com/api/...",
+        }
 
         respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/ee62d9d23f50afc16c59cd7bf652888b").mock(
             side_effect=[
@@ -1868,7 +1889,13 @@ class TestFlowDesignerDictReferenceFields:
         respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/ed05ba708c14a19d2afe245830c0f1e5").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "ed05ba708c14a19d2afe245830c0f1e5", "name": "Migration WF", "table": "incident"}},
+                json={
+                    "result": {
+                        "sys_id": "ed05ba708c14a19d2afe245830c0f1e5",
+                        "name": "Migration WF",
+                        "table": "incident",
+                    }
+                },
             )
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
@@ -1916,9 +1943,15 @@ class TestFlowDesignerDictReferenceFields:
                     "result": [
                         {
                             "sys_id": "a5d23ceaba84465f5cebeb9a4c0c4836",
-                            "from": {"display_value": "f8a6be5668c8de0f81a1b30a4cf8face", "link": "https://test.service-now.com/api/..."},
+                            "from": {
+                                "display_value": "f8a6be5668c8de0f81a1b30a4cf8face",
+                                "link": "https://test.service-now.com/api/...",
+                            },
                             "from.name": "Start",
-                            "to": {"display_value": "27ebb39863c212df73df6e9ce50b58a4", "link": "https://test.service-now.com/api/..."},
+                            "to": {
+                                "display_value": "27ebb39863c212df73df6e9ce50b58a4",
+                                "link": "https://test.service-now.com/api/...",
+                            },
                             "to.name": "End",
                             "condition": "",
                         }
@@ -1936,7 +1969,10 @@ class TestFlowDesignerDictReferenceFields:
                             "sys_id": "var_dict",
                             "variable": "script",
                             "value": "gs.log('test');",
-                            "document_key": {"display_value": "f8a6be5668c8de0f81a1b30a4cf8face", "link": "https://test.service-now.com/api/..."},
+                            "document_key": {
+                                "display_value": "f8a6be5668c8de0f81a1b30a4cf8face",
+                                "link": "https://test.service-now.com/api/...",
+                            },
                         }
                     ]
                 },

--- a/tests/test_flow_designer.py
+++ b/tests/test_flow_designer.py
@@ -631,21 +631,21 @@ class TestFlowActionDetail:
                 200,
                 json={
                     "result": {
-                        "sys_id": "ai_nodef",
+                        "sys_id": "bff4b2197387890d8565ff7bba7374fe",
                         "name": "Custom Instance",
                         "action_type": "",
                     }
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/ai_nodef").mock(side_effect=_nodef_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/bff4b2197387890d8565ff7bba7374fe").mock(side_effect=_nodef_side_effect)
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_action_detail"](action_instance_sys_id="ai_nodef")
+        raw = await tools["flow_action_detail"](action_instance_sys_id="bff4b2197387890d8565ff7bba7374fe")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["instance"]["sys_id"] == "ai_nodef"
+        assert result["data"]["instance"]["sys_id"] == "bff4b2197387890d8565ff7bba7374fe"
         assert result["data"]["type_definition"] is None
         assert result["data"]["steps"] == []
 
@@ -660,7 +660,7 @@ class TestFlowActionDetail:
                     200,
                     json={
                         "result": {
-                            "sys_id": "ai_nosteps",
+                            "sys_id": "048920ff3a5c5fbe81afd4f5ffd8b0f4",
                             "name": "Lookup Record",
                             "action_type": "Lookup Record",
                         }
@@ -670,22 +670,22 @@ class TestFlowActionDetail:
                 200,
                 json={
                     "result": {
-                        "sys_id": "ai_nosteps",
+                        "sys_id": "048920ff3a5c5fbe81afd4f5ffd8b0f4",
                         "name": "Lookup Record",
-                        "action_type": "atd_nosteps",
+                        "action_type": "21487c9e1a7c18c2b8f94fe2da220cae",
                     }
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/ai_nosteps").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/048920ff3a5c5fbe81afd4f5ffd8b0f4").mock(
             side_effect=_instance_side_effect
         )
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/atd_nosteps").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/21487c9e1a7c18c2b8f94fe2da220cae").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "atd_nosteps",
+                        "sys_id": "21487c9e1a7c18c2b8f94fe2da220cae",
                         "name": "Lookup Record",
                         "description": "Looks up a record",
                     }
@@ -697,7 +697,7 @@ class TestFlowActionDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_action_detail"](action_instance_sys_id="ai_nosteps")
+        raw = await tools["flow_action_detail"](action_instance_sys_id="048920ff3a5c5fbe81afd4f5ffd8b0f4")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -934,12 +934,12 @@ class TestFlowExecutionDetail:
     @respx.mock
     async def test_flow_execution_detail_no_logs(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Context exists but no log entries."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ctx_nologs").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ddbc98fc6f659935756886374856a903").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx_nologs",
+                        "sys_id": "ddbc98fc6f659935756886374856a903",
                         "name": "Empty Execution",
                         "state": "IN_PROGRESS",
                         "started": "2026-02-20 10:00:00",
@@ -953,11 +953,11 @@ class TestFlowExecutionDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_detail"](context_id="ctx_nologs")
+        raw = await tools["flow_execution_detail"](context_id="ddbc98fc6f659935756886374856a903")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["context"]["sys_id"] == "ctx_nologs"
+        assert result["data"]["context"]["sys_id"] == "ddbc98fc6f659935756886374856a903"
         assert result["data"]["log_count"] == 0
         assert result["data"]["logs"] == []
 
@@ -965,7 +965,7 @@ class TestFlowExecutionDetail:
     @respx.mock
     async def test_flow_execution_detail_not_found(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Context 404 returns error."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ctx_404").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/8aa2a5f2515585b27a0b1e3a9db73823").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Record not found"}})
         )
         respx.get(f"{BASE_URL}/api/now/table/sys_flow_log").mock(
@@ -973,7 +973,7 @@ class TestFlowExecutionDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_detail"](context_id="ctx_404")
+        raw = await tools["flow_execution_detail"](context_id="8aa2a5f2515585b27a0b1e3a9db73823")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -1813,16 +1813,16 @@ class TestFlowDesignerDictReferenceFields:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """flow_action_detail handles action_type returned as a dict reference."""
-        dict_action_type = {"display_value": "action_type_001", "link": "https://test.service-now.com/api/..."}
+        dict_action_type = {"display_value": "13619c05f5ecfe7907f8a0677a47a1d2", "link": "https://test.service-now.com/api/..."}
 
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/ai_dict_test").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/ee62d9d23f50afc16c59cd7bf652888b").mock(
             side_effect=[
                 # First call: raw (display_values=False) - returns dict reference
                 httpx.Response(
                     200,
                     json={
                         "result": {
-                            "sys_id": "ai_dict_test",
+                            "sys_id": "ee62d9d23f50afc16c59cd7bf652888b",
                             "name": "Send Email",
                             "action_type": dict_action_type,
                         }
@@ -1833,7 +1833,7 @@ class TestFlowDesignerDictReferenceFields:
                     200,
                     json={
                         "result": {
-                            "sys_id": "ai_dict_test",
+                            "sys_id": "ee62d9d23f50afc16c59cd7bf652888b",
                             "name": "Send Email",
                             "action_type": "Send Email Action",
                         }
@@ -1841,10 +1841,10 @@ class TestFlowDesignerDictReferenceFields:
                 ),
             ]
         )
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/action_type_001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/13619c05f5ecfe7907f8a0677a47a1d2").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "action_type_001", "name": "Send Email Type"}},
+                json={"result": {"sys_id": "13619c05f5ecfe7907f8a0677a47a1d2", "name": "Send Email Type"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/table/sys_hub_step_instance").mock(
@@ -1852,7 +1852,7 @@ class TestFlowDesignerDictReferenceFields:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_action_detail"](action_instance_sys_id="ai_dict_test")
+        raw = await tools["flow_action_detail"](action_instance_sys_id="ee62d9d23f50afc16c59cd7bf652888b")
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_flow_designer.py
+++ b/tests/test_flow_designer.py
@@ -80,7 +80,7 @@ class TestFlowList:
                 json={
                     "result": [
                         {
-                            "sys_id": "flow001",
+                            "sys_id": "8eecae1b3a5230387ff5f06a91b9fbe9",
                             "name": "Auto Assignment Flow",
                             "status": "published",
                             "type": "flow",
@@ -249,12 +249,12 @@ class TestFlowGet:
     @respx.mock
     async def test_flow_get_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns flow record with its variables."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow/flow001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow/8eecae1b3a5230387ff5f06a91b9fbe9").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "flow001",
+                        "sys_id": "8eecae1b3a5230387ff5f06a91b9fbe9",
                         "name": "Auto Assignment Flow",
                         "status": "published",
                         "type": "flow",
@@ -270,14 +270,14 @@ class TestFlowGet:
                 json={
                     "result": [
                         {
-                            "sys_id": "var001",
+                            "sys_id": "47a920e21ce3b82c733a27e71b6e24b7",
                             "name": "assignment_group",
                             "type": "reference",
                             "mandatory": "true",
                             "default_value": "",
                         },
                         {
-                            "sys_id": "var002",
+                            "sys_id": "f26728a87efd1d5a8256284c435cc0c4",
                             "name": "priority",
                             "type": "integer",
                             "mandatory": "false",
@@ -290,7 +290,7 @@ class TestFlowGet:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_get"](flow_sys_id="flow001")
+        raw = await tools["flow_get"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -330,7 +330,7 @@ class TestFlowGet:
     @respx.mock
     async def test_flow_get_not_found(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """404 response returns error."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow/notfound").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow/a83d4bf9070ae6eb080b4cc7b2703e17").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Record not found"}})
         )
         # Variable query may or may not fire depending on gather; mock it to avoid ConnectionError
@@ -339,7 +339,7 @@ class TestFlowGet:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_get"](flow_sys_id="notfound")
+        raw = await tools["flow_get"](flow_sys_id="a83d4bf9070ae6eb080b4cc7b2703e17")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -388,24 +388,24 @@ class TestFlowMap:
     @respx.mock
     async def test_flow_map_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Uses latest_snapshot when child records are linked to the newest snapshot."""
-        self._mock_parent_flow_lookup("flow001", latest_snapshot="snap_latest")
+        self._mock_parent_flow_lookup("8eecae1b3a5230387ff5f06a91b9fbe9", latest_snapshot="snap_latest")
         action_route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": [
                         {
-                            "sys_id": "ai001",
+                            "sys_id": "636f282a5dd34466ab9e91c1706b1998",
                             "name": "Create Task",
-                            "action_type": "at001",
+                            "action_type": "de31c068fa3d1adb0687dc4d7bbf0648",
                             "order": "1",
                             "position": "0",
                             "sys_created_on": "2026-01-15 08:00:00",
                         },
                         {
-                            "sys_id": "ai002",
+                            "sys_id": "9903d5f9dbdac520c4e23b8550661763",
                             "name": "Send Email",
-                            "action_type": "at002",
+                            "action_type": "c0d996b6aee4ec53e6b3e2f86a64dd3e",
                             "order": "2",
                             "position": "1",
                             "sys_created_on": "2026-01-15 08:01:00",
@@ -421,7 +421,7 @@ class TestFlowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "fl001",
+                            "sys_id": "390c28e84854396993c1dcc315dfe48c",
                             "name": "If Priority 1",
                             "type": "if",
                             "order": "1",
@@ -435,7 +435,7 @@ class TestFlowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_map"](flow_sys_id="flow001")
+        raw = await tools["flow_map"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -457,9 +457,9 @@ class TestFlowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "ai010",
+                            "sys_id": "3ff4a88b3dd61ff2b18f015f0ad2e484",
                             "name": "Update Record",
-                            "action_type": "at010",
+                            "action_type": "7f15696e98f35a0906ca2804a9a177aa",
                             "order": "1",
                             "position": "0",
                             "sys_created_on": "2026-01-20 09:00:00",
@@ -497,7 +497,7 @@ class TestFlowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "fl010",
+                            "sys_id": "8a912c42d911682d7f9b9625d3cb2246",
                             "name": "For Each Record",
                             "type": "for_each",
                             "order": "1",
@@ -560,7 +560,7 @@ class TestFlowActionDetail:
                     200,
                     json={
                         "result": {
-                            "sys_id": "ai001",
+                            "sys_id": "636f282a5dd34466ab9e91c1706b1998",
                             "name": "Create Task",
                             "action_type": "Create Record",
                         }
@@ -570,20 +570,20 @@ class TestFlowActionDetail:
                 200,
                 json={
                     "result": {
-                        "sys_id": "ai001",
+                        "sys_id": "636f282a5dd34466ab9e91c1706b1998",
                         "name": "Create Task",
-                        "action_type": "atd001",
+                        "action_type": "8f60c39c7a0b23a9865bf30e8363153f",
                     }
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/ai001").mock(side_effect=_instance_side_effect)
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/atd001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance/636f282a5dd34466ab9e91c1706b1998").mock(side_effect=_instance_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_definition/8f60c39c7a0b23a9865bf30e8363153f").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "atd001",
+                        "sys_id": "8f60c39c7a0b23a9865bf30e8363153f",
                         "name": "Create Record",
                         "description": "Creates a new record",
                         "access": "public",
@@ -597,7 +597,7 @@ class TestFlowActionDetail:
                 json={
                     "result": [
                         {
-                            "sys_id": "step001",
+                            "sys_id": "d07a54fe040684bbd267d6e61a2e11e0",
                             "name": "Set Fields",
                             "step_type": "set_values",
                             "order": "1",
@@ -610,11 +610,11 @@ class TestFlowActionDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_action_detail"](action_instance_sys_id="ai001")
+        raw = await tools["flow_action_detail"](action_instance_sys_id="636f282a5dd34466ab9e91c1706b1998")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["instance"]["sys_id"] == "ai001"
+        assert result["data"]["instance"]["sys_id"] == "636f282a5dd34466ab9e91c1706b1998"
         assert result["data"]["type_definition"]["name"] == "Create Record"
         assert len(result["data"]["steps"]) == 1
         assert result["data"]["steps"][0]["name"] == "Set Fields"
@@ -723,10 +723,10 @@ class TestFlowExecutionList:
                 json={
                     "result": [
                         {
-                            "sys_id": "ctx001",
+                            "sys_id": "18dbe9bd70e88bd7d141d13c8a46e7d7",
                             "name": "Exec 1",
-                            "flow": "flow001",
-                            "source_record": "inc001",
+                            "flow": "8eecae1b3a5230387ff5f06a91b9fbe9",
+                            "source_record": "6d55028a7049dbf2f4275991d6fc81cf",
                             "source_table": "incident",
                             "state": "COMPLETE",
                             "started": "2026-02-20 09:00:00",
@@ -740,7 +740,7 @@ class TestFlowExecutionList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_list"](flow_sys_id="flow001")
+        raw = await tools["flow_execution_list"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -757,10 +757,10 @@ class TestFlowExecutionList:
                 json={
                     "result": [
                         {
-                            "sys_id": "ctx002",
+                            "sys_id": "ffff7ed3a8c7ffe871d910c0eb40322e",
                             "name": "Exec 2",
-                            "flow": "flow002",
-                            "source_record": "inc999",
+                            "flow": "fdf7325b5fa9fb3a675311af2efbe71c",
+                            "source_record": "2edef9aa2e99060fd11a80ae6eed85b5",
                             "source_table": "incident",
                             "state": "IN_PROGRESS",
                             "started": "2026-02-20 10:00:00",
@@ -774,7 +774,7 @@ class TestFlowExecutionList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_list"](source_record="inc999")
+        raw = await tools["flow_execution_list"](source_record="2edef9aa2e99060fd11a80ae6eed85b5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -782,7 +782,7 @@ class TestFlowExecutionList:
         assert exec_route.calls.last is not None
         last_request = exec_route.calls.last.request
         qs = parse_qs(urlparse(str(last_request.url)).query)
-        assert "source_record=inc999" in qs["sysparm_query"][0]
+        assert "source_record=2edef9aa2e99060fd11a80ae6eed85b5" in qs["sysparm_query"][0]
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -793,7 +793,7 @@ class TestFlowExecutionList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_list"](flow_sys_id="flow001", state="ERROR")
+        raw = await tools["flow_execution_list"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9", state="ERROR")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -814,7 +814,7 @@ class TestFlowExecutionList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_list"](flow_sys_id="flow001", source_record="inc001", state="COMPLETE")
+        raw = await tools["flow_execution_list"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9", source_record="6d55028a7049dbf2f4275991d6fc81cf", state="COMPLETE")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -822,8 +822,8 @@ class TestFlowExecutionList:
         last_request = exec_route.calls.last.request
         qs = parse_qs(urlparse(str(last_request.url)).query)
         query_str = qs["sysparm_query"][0]
-        assert "flow=flow001" in query_str
-        assert "source_record=inc001" in query_str
+        assert "flow=8eecae1b3a5230387ff5f06a91b9fbe9" in query_str
+        assert "source_record=6d55028a7049dbf2f4275991d6fc81cf" in query_str
         assert "state=COMPLETE" in query_str
 
     @pytest.mark.asyncio()
@@ -867,19 +867,19 @@ class TestFlowExecutionDetail:
     @respx.mock
     async def test_flow_execution_detail_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns context record and ordered log entries."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/ctx001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_flow_context/18dbe9bd70e88bd7d141d13c8a46e7d7").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx001",
+                        "sys_id": "18dbe9bd70e88bd7d141d13c8a46e7d7",
                         "name": "Auto Assignment Execution",
                         "state": "COMPLETE",
                         "started": "2026-02-20 09:00:00",
                         "ended": "2026-02-20 09:00:05",
-                        "flow": "flow001",
+                        "flow": "8eecae1b3a5230387ff5f06a91b9fbe9",
                         "source_table": "incident",
-                        "source_record": "inc001",
+                        "source_record": "6d55028a7049dbf2f4275991d6fc81cf",
                     }
                 },
             )
@@ -890,7 +890,7 @@ class TestFlowExecutionDetail:
                 json={
                     "result": [
                         {
-                            "sys_id": "log001",
+                            "sys_id": "c7437b6f8d9c00ea14eab197e745aacd",
                             "action": "Create Task",
                             "operation": "execute",
                             "level": "info",
@@ -902,7 +902,7 @@ class TestFlowExecutionDetail:
                             "duration": "0:00:01",
                         },
                         {
-                            "sys_id": "log002",
+                            "sys_id": "d2b4eb18597b547b72c70b31bf26b49e",
                             "action": "Send Email",
                             "operation": "execute",
                             "level": "info",
@@ -920,7 +920,7 @@ class TestFlowExecutionDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_detail"](context_id="ctx001")
+        raw = await tools["flow_execution_detail"](context_id="18dbe9bd70e88bd7d141d13c8a46e7d7")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -999,18 +999,18 @@ class TestFlowSnapshotList:
                 json={
                     "result": [
                         {
-                            "sys_id": "snap001",
+                            "sys_id": "7ee71fe03706c9bcb43380fbe0d2d71e",
                             "name": "Version 2.0",
-                            "parent_flow": "flow001",
+                            "parent_flow": "8eecae1b3a5230387ff5f06a91b9fbe9",
                             "version": "2.0",
                             "status": "published",
                             "sys_created_on": "2026-02-20 10:00:00",
                             "sys_updated_on": "2026-02-20 10:00:00",
                         },
                         {
-                            "sys_id": "snap002",
+                            "sys_id": "f6181240cc65ea9f4a1391d16567586c",
                             "name": "Version 1.0",
-                            "parent_flow": "flow001",
+                            "parent_flow": "8eecae1b3a5230387ff5f06a91b9fbe9",
                             "version": "1.0",
                             "status": "published",
                             "sys_created_on": "2026-01-15 08:00:00",
@@ -1023,7 +1023,7 @@ class TestFlowSnapshotList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_snapshot_list"](flow_sys_id="flow001")
+        raw = await tools["flow_snapshot_list"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1054,7 +1054,7 @@ class TestFlowSnapshotList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_snapshot_list"](flow_sys_id="flow001")
+        raw = await tools["flow_snapshot_list"](flow_sys_id="8eecae1b3a5230387ff5f06a91b9fbe9")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1071,7 +1071,7 @@ class TestFlowSnapshotList:
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_snapshot_list"](flow_sys_id="abc123", limit=5)
+        raw = await tools["flow_snapshot_list"](flow_sys_id="6367c48dd193d56ea7b0baad25b19455", limit=5)
         result = decode_response(raw)
         assert result["status"] == "success"
         req = respx.calls[0].request
@@ -1086,7 +1086,7 @@ class TestFlowSnapshotList:
 class TestWorkflowMigrationAnalysis:
     """Tests for the workflow_migration_analysis tool."""
 
-    def _mock_version(self, sys_id: str = "wfv001", name: str = "Incident WF v1") -> None:
+    def _mock_version(self, sys_id: str = "e35fec24db6d035c7a6fa33e76847858", name: str = "Incident WF 5a6df720540c20d95d530d3fd6885511") -> None:
         """Mock a wf_workflow_version GET."""
         respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/{sys_id}").mock(
             return_value=httpx.Response(
@@ -1142,7 +1142,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Begin",
                     "activity_definition": "def_begin",
                     "activity_definition.name": "Begin",
@@ -1153,7 +1153,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act002",
+                    "sys_id": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "name": "Run Script",
                     "activity_definition": "def_rs",
                     "activity_definition.name": "Run Script",
@@ -1164,7 +1164,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act003",
+                    "sys_id": "2ece7051da817573c5081f76dd089a30",
                     "name": "End",
                     "activity_definition": "def_end",
                     "activity_definition.name": "End",
@@ -1179,18 +1179,18 @@ class TestWorkflowMigrationAnalysis:
         self._mock_transitions(
             [
                 {
-                    "sys_id": "tr001",
-                    "from": "act001",
+                    "sys_id": "82b655b7980ce1431a5665bd5e3fc4fb",
+                    "from": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "from.name": "Begin",
-                    "to": "act002",
+                    "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "to.name": "Run Script",
                     "condition": "",
                 },
                 {
-                    "sys_id": "tr002",
-                    "from": "act002",
+                    "sys_id": "5b2d0cf104fe83a192898b0e1874244f",
+                    "from": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "from.name": "Run Script",
-                    "to": "act003",
+                    "to": "2ece7051da817573c5081f76dd089a30",
                     "to.name": "End",
                     "condition": "",
                 },
@@ -1199,7 +1199,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables([])
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1227,7 +1227,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Begin",
                     "activity_definition": "def_begin",
                     "activity_definition.name": "Begin",
@@ -1238,7 +1238,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act002",
+                    "sys_id": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "name": "Approval",
                     "activity_definition": "def_approval",
                     "activity_definition.name": "Approval - User",
@@ -1249,7 +1249,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act003",
+                    "sys_id": "2ece7051da817573c5081f76dd089a30",
                     "name": "Set Values",
                     "activity_definition": "def_sv",
                     "activity_definition.name": "Set Values",
@@ -1264,26 +1264,26 @@ class TestWorkflowMigrationAnalysis:
         self._mock_transitions(
             [
                 {
-                    "sys_id": "tr001",
-                    "from": "act001",
+                    "sys_id": "82b655b7980ce1431a5665bd5e3fc4fb",
+                    "from": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "from.name": "Begin",
-                    "to": "act002",
+                    "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "to.name": "Approval",
                     "condition": "",
                 },
                 {
-                    "sys_id": "tr002",
-                    "from": "act002",
+                    "sys_id": "5b2d0cf104fe83a192898b0e1874244f",
+                    "from": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "from.name": "Approval",
-                    "to": "act003",
+                    "to": "2ece7051da817573c5081f76dd089a30",
                     "to.name": "Set Values",
                     "condition": "",
                 },
                 {
-                    "sys_id": "tr003",
-                    "from": "act003",
+                    "sys_id": "fdb792aa92ea3fcdd5ae0cacec93485b",
+                    "from": "2ece7051da817573c5081f76dd089a30",
                     "from.name": "Set Values",
-                    "to": "act002",
+                    "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "to.name": "Approval",
                     "condition": "rejected",
                 },
@@ -1292,7 +1292,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables([])
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1314,7 +1314,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Run Script",
                     "activity_definition": "def_rs",
                     "activity_definition.name": "Run Script",
@@ -1332,16 +1332,16 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables(
             [
                 {
-                    "sys_id": "sv001",
+                    "sys_id": "eaa2e11f5972c0fd8e423f1c6234180d",
                     "variable": "script",
                     "value": script_body,
-                    "document_key": "act001",
+                    "document_key": "a37b4556fc38ce6b2a3fd1521b1291bc",
                 },
             ]
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1370,7 +1370,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Notification Body",
                     "activity_definition": "def_notif",
                     "activity_definition.name": "Notification",
@@ -1386,16 +1386,16 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables(
             [
                 {
-                    "sys_id": "sv001",
+                    "sys_id": "eaa2e11f5972c0fd8e423f1c6234180d",
                     "variable": "message_template",
                     "value": "Hello team,\nPlease review this request.\nThanks.",
-                    "document_key": "act001",
+                    "document_key": "a37b4556fc38ce6b2a3fd1521b1291bc",
                 },
             ]
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1416,7 +1416,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Notification Body",
                     "activity_definition": "def_notif",
                     "activity_definition.name": "Notification",
@@ -1432,16 +1432,16 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables(
             [
                 {
-                    "sys_id": "sv001",
+                    "sys_id": "eaa2e11f5972c0fd8e423f1c6234180d",
                     "variable": "message_template",
                     "value": "If the requester asks for help, return this article to the customer.",
-                    "document_key": "act001",
+                    "document_key": "a37b4556fc38ce6b2a3fd1521b1291bc",
                 },
             ]
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1461,7 +1461,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Begin",
                     "activity_definition": "def_begin",
                     "activity_definition.name": "Begin",
@@ -1472,7 +1472,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act002",
+                    "sys_id": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "name": "Approval Step",
                     "activity_definition": "def_approval",
                     "activity_definition.name": "Approval - User",
@@ -1483,7 +1483,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act003",
+                    "sys_id": "2ece7051da817573c5081f76dd089a30",
                     "name": "Notify User",
                     "activity_definition": "def_notif",
                     "activity_definition.name": "Notification",
@@ -1499,7 +1499,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables([])
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1518,7 +1518,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Custom Widget",
                     "activity_definition": "def_custom",
                     "activity_definition.name": "Custom Widget Type",
@@ -1534,7 +1534,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables([])
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1562,7 +1562,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Begin",
                     "activity_definition": "def_begin",
                     "activity_definition.name": "Begin",
@@ -1573,7 +1573,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act002",
+                    "sys_id": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "name": "Rollback Step",
                     "activity_definition": "def_rb",
                     "activity_definition.name": "Rollback To",
@@ -1584,7 +1584,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act003",
+                    "sys_id": "2ece7051da817573c5081f76dd089a30",
                     "name": "Approval",
                     "activity_definition": "def_approval",
                     "activity_definition.name": "Approval - User",
@@ -1599,26 +1599,26 @@ class TestWorkflowMigrationAnalysis:
         self._mock_transitions(
             [
                 {
-                    "sys_id": "tr001",
-                    "from": "act001",
+                    "sys_id": "82b655b7980ce1431a5665bd5e3fc4fb",
+                    "from": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "from.name": "Begin",
-                    "to": "act002",
+                    "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "to.name": "Rollback Step",
                     "condition": "",
                 },
                 {
-                    "sys_id": "tr002",
-                    "from": "act002",
+                    "sys_id": "5b2d0cf104fe83a192898b0e1874244f",
+                    "from": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "from.name": "Rollback Step",
-                    "to": "act003",
+                    "to": "2ece7051da817573c5081f76dd089a30",
                     "to.name": "Approval",
                     "condition": "",
                 },
                 {
-                    "sys_id": "tr003",
-                    "from": "act003",
+                    "sys_id": "fdb792aa92ea3fcdd5ae0cacec93485b",
+                    "from": "2ece7051da817573c5081f76dd089a30",
                     "from.name": "Approval",
-                    "to": "act002",
+                    "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "to.name": "Rollback Step",
                     "condition": "rejected",
                 },
@@ -1627,7 +1627,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables([])
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1649,7 +1649,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Known Activity",
                     "activity_definition": "def_if",
                     "activity_definition.name": "If",
@@ -1660,7 +1660,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act002",
+                    "sys_id": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "name": "Mystery Activity",
                     "activity_definition": "def_mystery",
                     "activity_definition.name": "Mystery Type",
@@ -1676,18 +1676,18 @@ class TestWorkflowMigrationAnalysis:
         self._mock_transitions(
             [
                 {
-                    "sys_id": "tr001",
-                    "from": "act001",
+                    "sys_id": "82b655b7980ce1431a5665bd5e3fc4fb",
+                    "from": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "from.name": "Known Activity",
-                    "to": "act002",
+                    "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "to.name": "Mystery Activity",
                     "condition": "",
                 },
                 {
-                    "sys_id": "tr002",
-                    "from": "act002",
+                    "sys_id": "5b2d0cf104fe83a192898b0e1874244f",
+                    "from": "6ae7ca85d4792cabe5bafd3b8d148725",
                     "from.name": "Mystery Activity",
-                    "to": "act001",
+                    "to": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "to.name": "Known Activity",
                     "condition": "",
                 },
@@ -1696,16 +1696,16 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables(
             [
                 {
-                    "sys_id": "sv001",
+                    "sys_id": "eaa2e11f5972c0fd8e423f1c6234180d",
                     "variable": "script",
                     "value": script_body,
-                    "document_key": "act001",
+                    "document_key": "a37b4556fc38ce6b2a3fd1521b1291bc",
                 },
             ]
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1736,7 +1736,7 @@ class TestWorkflowMigrationAnalysis:
         # No activities means no sys_variable_value query is made
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1788,7 +1788,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_variables([])
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1915,7 +1915,7 @@ class TestFlowDesignerDictReferenceFields:
                 json={
                     "result": [
                         {
-                            "sys_id": "trans001",
+                            "sys_id": "a5d23ceaba84465f5cebeb9a4c0c4836",
                             "from": {"display_value": "act_a", "link": "https://test.service-now.com/api/..."},
                             "from.name": "Start",
                             "to": {"display_value": "act_b", "link": "https://test.service-now.com/api/..."},

--- a/tests/test_flow_designer.py
+++ b/tests/test_flow_designer.py
@@ -302,12 +302,12 @@ class TestFlowGet:
     @respx.mock
     async def test_flow_get_with_no_variables(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Flow exists but has no variables."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow/flow_novar").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow/68fccdc772b24d949d4ec0381cb858eb").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "flow_novar",
+                        "sys_id": "68fccdc772b24d949d4ec0381cb858eb",
                         "name": "Simple Flow",
                         "status": "published",
                     }
@@ -319,11 +319,11 @@ class TestFlowGet:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_get"](flow_sys_id="flow_novar")
+        raw = await tools["flow_get"](flow_sys_id="68fccdc772b24d949d4ec0381cb858eb")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["flow"]["sys_id"] == "flow_novar"
+        assert result["data"]["flow"]["sys_id"] == "68fccdc772b24d949d4ec0381cb858eb"
         assert result["data"]["variables"] == []
 
     @pytest.mark.asyncio()
@@ -388,7 +388,7 @@ class TestFlowMap:
     @respx.mock
     async def test_flow_map_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Uses latest_snapshot when child records are linked to the newest snapshot."""
-        self._mock_parent_flow_lookup("8eecae1b3a5230387ff5f06a91b9fbe9", latest_snapshot="snap_latest")
+        self._mock_parent_flow_lookup("8eecae1b3a5230387ff5f06a91b9fbe9", latest_snapshot="b6069c7ab2fac9d79864075defa6176c")
         action_route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(
                 200,
@@ -443,14 +443,14 @@ class TestFlowMap:
         assert len(result["data"]["logic_blocks"]) == 1
         assert result["data"]["actions"][0]["name"] == "Create Task"
         assert result["data"]["logic_blocks"][0]["name"] == "If Priority 1"
-        assert self._get_query_target(action_route) == "snap_latest"
-        assert self._get_query_target(logic_route) == "snap_latest"
+        assert self._get_query_target(action_route) == "b6069c7ab2fac9d79864075defa6176c"
+        assert self._get_query_target(logic_route) == "b6069c7ab2fac9d79864075defa6176c"
 
     @pytest.mark.asyncio()
     @respx.mock
     async def test_flow_map_only_actions(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Falls back to master_snapshot when latest_snapshot is missing."""
-        self._mock_parent_flow_lookup("flow_acts", master_snapshot="snap_master")
+        self._mock_parent_flow_lookup("06bed3558e7fd1e9359964cedb4dc271", master_snapshot="9b250a88678953224d007032837d3d92")
         action_route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(
                 200,
@@ -474,20 +474,20 @@ class TestFlowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_map"](flow_sys_id="flow_acts")
+        raw = await tools["flow_map"](flow_sys_id="06bed3558e7fd1e9359964cedb4dc271")
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert len(result["data"]["actions"]) == 1
         assert result["data"]["logic_blocks"] == []
-        assert self._get_query_target(action_route) == "snap_master"
-        assert self._get_query_target(logic_route) == "snap_master"
+        assert self._get_query_target(action_route) == "9b250a88678953224d007032837d3d92"
+        assert self._get_query_target(logic_route) == "9b250a88678953224d007032837d3d92"
 
     @pytest.mark.asyncio()
     @respx.mock
     async def test_flow_map_only_logic(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Flow with logic blocks but no actions."""
-        self._mock_parent_flow_lookup("flow_logic", latest_snapshot="snap_logic")
+        self._mock_parent_flow_lookup("f05a9e989019b2cd934dc2ba0c31a1d2", latest_snapshot="9095d45621112c8881812276e734f504")
         respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
@@ -511,7 +511,7 @@ class TestFlowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_map"](flow_sys_id="flow_logic")
+        raw = await tools["flow_map"](flow_sys_id="f05a9e989019b2cd934dc2ba0c31a1d2")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -522,7 +522,7 @@ class TestFlowMap:
     @respx.mock
     async def test_flow_map_empty(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Falls back to the original flow sys_id when no snapshot references exist."""
-        self._mock_parent_flow_lookup("flow_empty")
+        self._mock_parent_flow_lookup("188a7d874a4b60bd7ef309c6f8872ba7")
         action_route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_instance").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
@@ -531,14 +531,14 @@ class TestFlowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_map"](flow_sys_id="flow_empty")
+        raw = await tools["flow_map"](flow_sys_id="188a7d874a4b60bd7ef309c6f8872ba7")
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert result["data"]["actions"] == []
         assert result["data"]["logic_blocks"] == []
-        assert self._get_query_target(action_route) == "flow_empty"
-        assert self._get_query_target(logic_route) == "flow_empty"
+        assert self._get_query_target(action_route) == "188a7d874a4b60bd7ef309c6f8872ba7"
+        assert self._get_query_target(logic_route) == "188a7d874a4b60bd7ef309c6f8872ba7"
 
 
 # ---------------------------------------------------------------------------
@@ -848,7 +848,7 @@ class TestFlowExecutionList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_execution_list"](flow_sys_id="flow_none")
+        raw = await tools["flow_execution_list"](flow_sys_id="6d90efaf0787be213a9f58202ec86f89")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1039,7 +1039,7 @@ class TestFlowSnapshotList:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["flow_snapshot_list"](flow_sys_id="flow_none")
+        raw = await tools["flow_snapshot_list"](flow_sys_id="6d90efaf0787be213a9f58202ec86f89")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1761,7 +1761,7 @@ class TestWorkflowMigrationAnalysis:
         self._mock_activities(
             [
                 {
-                    "sys_id": "act_rb",
+                    "sys_id": "fdc79c389c219498815dbde80a740ac4",
                     "name": "Rollback Step",
                     "activity_definition": "def_rb",
                     "activity_definition.name": "Rollback To",
@@ -1772,7 +1772,7 @@ class TestWorkflowMigrationAnalysis:
                     "notes": "",
                 },
                 {
-                    "sys_id": "act_tb",
+                    "sys_id": "bd3952ef766e436ed570bc8af337e0ab",
                     "name": "Turnback Step",
                     "activity_definition": "def_tb",
                     "activity_definition.name": "Turnback To",
@@ -1865,10 +1865,10 @@ class TestFlowDesignerDictReferenceFields:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """workflow_migration_analysis handles from, to, document_key, and definition name as dicts."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_dict_mig").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/ed05ba708c14a19d2afe245830c0f1e5").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "wfv_dict_mig", "name": "Migration WF", "table": "incident"}},
+                json={"result": {"sys_id": "ed05ba708c14a19d2afe245830c0f1e5", "name": "Migration WF", "table": "incident"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
@@ -1877,7 +1877,7 @@ class TestFlowDesignerDictReferenceFields:
                 json={
                     "result": [
                         {
-                            "sys_id": "act_a",
+                            "sys_id": "f8a6be5668c8de0f81a1b30a4cf8face",
                             "name": "Start",
                             "activity_definition": "def_begin",
                             "activity_definition.name": {
@@ -1891,7 +1891,7 @@ class TestFlowDesignerDictReferenceFields:
                             "notes": "",
                         },
                         {
-                            "sys_id": "act_b",
+                            "sys_id": "27ebb39863c212df73df6e9ce50b58a4",
                             "name": "End",
                             "activity_definition": "def_end",
                             "activity_definition.name": {
@@ -1916,9 +1916,9 @@ class TestFlowDesignerDictReferenceFields:
                     "result": [
                         {
                             "sys_id": "a5d23ceaba84465f5cebeb9a4c0c4836",
-                            "from": {"display_value": "act_a", "link": "https://test.service-now.com/api/..."},
+                            "from": {"display_value": "f8a6be5668c8de0f81a1b30a4cf8face", "link": "https://test.service-now.com/api/..."},
                             "from.name": "Start",
-                            "to": {"display_value": "act_b", "link": "https://test.service-now.com/api/..."},
+                            "to": {"display_value": "27ebb39863c212df73df6e9ce50b58a4", "link": "https://test.service-now.com/api/..."},
                             "to.name": "End",
                             "condition": "",
                         }
@@ -1936,7 +1936,7 @@ class TestFlowDesignerDictReferenceFields:
                             "sys_id": "var_dict",
                             "variable": "script",
                             "value": "gs.log('test');",
-                            "document_key": {"display_value": "act_a", "link": "https://test.service-now.com/api/..."},
+                            "document_key": {"display_value": "f8a6be5668c8de0f81a1b30a4cf8face", "link": "https://test.service-now.com/api/..."},
                         }
                     ]
                 },
@@ -1945,7 +1945,7 @@ class TestFlowDesignerDictReferenceFields:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="wfv_dict_mig")
+        raw = await tools["workflow_migration_analysis"](workflow_version_sys_id="ed05ba708c14a19d2afe245830c0f1e5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1955,8 +1955,8 @@ class TestFlowDesignerDictReferenceFields:
         # Activity mapping should resolve dict reference fields to strings
         mapping = data["activity_mapping"]
         assert len(mapping) == 2
-        assert mapping[0]["activity_sys_id"] == "act_a"
-        assert mapping[1]["activity_sys_id"] == "act_b"
+        assert mapping[0]["activity_sys_id"] == "f8a6be5668c8de0f81a1b30a4cf8face"
+        assert mapping[1]["activity_sys_id"] == "27ebb39863c212df73df6e9ce50b58a4"
         # Definition names should be resolved from dicts
         assert mapping[0]["legacy_type"] == "Begin"
         assert mapping[1]["legacy_type"] == "End"

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -1085,19 +1085,26 @@ class TestExplainAclConflicts:
     @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_acl_record(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
-        """explain() returns context for an ACL conflict finding."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl/9b332a2446a6dbc9d0d8da69a4397e33").mock(
+        """explain() returns context for an ACL conflict finding.
+
+        ``sys_security_acl`` is denied for tool callers, so the investigation
+        uses ``get_records_privileged`` which queries the list endpoint with a
+        ``sys_id`` filter rather than fetching by path.
+        """
+        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "result": {
-                        "sys_id": "9b332a2446a6dbc9d0d8da69a4397e33",
-                        "name": "incident.*.read",
-                        "operation": "read",
-                        "condition": "active=true",
-                        "script": "",
-                        "active": "true",
-                    }
+                    "result": [
+                        {
+                            "sys_id": "9b332a2446a6dbc9d0d8da69a4397e33",
+                            "name": "incident.*.read",
+                            "operation": "read",
+                            "condition": "active=true",
+                            "script": "",
+                            "active": "true",
+                        }
+                    ]
                 },
             )
         )

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -49,7 +49,7 @@ class TestInvestigateRun:
                 json={
                     "result": [
                         {
-                            "sys_id": "fc001",
+                            "sys_id": "b45e2ae965e607a079b6677d64ba7c83",
                             "name": "Approval Flow",
                             "state": "IN_PROGRESS",
                             "sys_created_on": "2026-01-01 00:00:00",
@@ -108,12 +108,12 @@ class TestInvestigateRun:
     ) -> None:
         """investigate_explain returns contextual explanation for a finding."""
         # Mock fetching the flow_context record
-        respx.get(f"{BASE_URL}/api/now/table/flow_context/fc001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/flow_context/b45e2ae965e607a079b6677d64ba7c83").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "fc001",
+                        "sys_id": "b45e2ae965e607a079b6677d64ba7c83",
                         "name": "Approval Flow",
                         "state": "IN_PROGRESS",
                         "sys_created_on": "2026-01-01 00:00:00",
@@ -125,7 +125,7 @@ class TestInvestigateRun:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="stale_automations",
-            element_id="flow_context:fc001",
+            element_id="flow_context:b45e2ae965e607a079b6677d64ba7c83",
         )
         result = decode_response(raw)
 
@@ -150,7 +150,7 @@ class TestStaleAutomations:
                 json={
                     "result": [
                         {
-                            "sys_id": "fc001",
+                            "sys_id": "b45e2ae965e607a079b6677d64ba7c83",
                             "name": "Stuck Flow",
                             "state": "IN_PROGRESS",
                             "sys_created_on": "2026-01-01 00:00:00",
@@ -240,7 +240,7 @@ class TestDeprecatedApis:
         def _code_search_side_effect(request: httpx.Request) -> httpx.Response:
             """Return a match only when the query contains 'Packages.'."""
             hits = (
-                [{"sys_id": "script001", "className": "sys_script_include", "name": "OldHelper"}]
+                [{"sys_id": "f080e34a96799d32cdc642f724be7e8c", "className": "sys_script_include", "name": "OldHelper"}]
                 if "Packages." in str(request.url)
                 else []
             )
@@ -301,9 +301,9 @@ class TestTableHealth:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "br1", "name": "BR One", "when": "before"},
-                        {"sys_id": "br2", "name": "BR Two", "when": "after"},
-                        {"sys_id": "br3", "name": "BR Three", "when": "async"},
+                        {"sys_id": "8baeabad365de895ab58ec0d6dd2c1e2", "name": "BR One", "when": "before"},
+                        {"sys_id": "45caf3e7f1e7ce17456aec79ce1ab853", "name": "BR Two", "when": "after"},
+                        {"sys_id": "e2b8e6746ec1c186d1bc96993ce34da6", "name": "BR Three", "when": "async"},
                     ]
                 },
                 headers={"X-Total-Count": "3"},
@@ -313,7 +313,7 @@ class TestTableHealth:
         respx.get(f"{BASE_URL}/api/now/table/sys_script_client").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": "cs1", "name": "CS One"}]},
+                json={"result": [{"sys_id": "f9ce352c1d3e957f5b6330307d618b98", "name": "CS One"}]},
                 headers={"X-Total-Count": "1"},
             )
         )
@@ -326,8 +326,8 @@ class TestTableHealth:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "acl1", "name": "incident.*.read"},
-                        {"sys_id": "acl2", "name": "incident.*.write"},
+                        {"sys_id": "a22a175514b88956ca45212cf48e1287", "name": "incident.*.read"},
+                        {"sys_id": "919246ee55548f64fe2c4ca2715ec446", "name": "incident.*.write"},
                     ]
                 },
                 headers={"X-Total-Count": "2"},
@@ -416,7 +416,7 @@ class TestAclConflicts:
                 json={
                     "result": [
                         {
-                            "sys_id": "acl1",
+                            "sys_id": "a22a175514b88956ca45212cf48e1287",
                             "name": "incident.*.read",
                             "operation": "read",
                             "condition": "active=true",
@@ -424,7 +424,7 @@ class TestAclConflicts:
                             "active": "true",
                         },
                         {
-                            "sys_id": "acl2",
+                            "sys_id": "919246ee55548f64fe2c4ca2715ec446",
                             "name": "incident.*.read",
                             "operation": "read",
                             "condition": "priority=1",
@@ -457,7 +457,7 @@ class TestAclConflicts:
                 json={
                     "result": [
                         {
-                            "sys_id": "acl1",
+                            "sys_id": "a22a175514b88956ca45212cf48e1287",
                             "name": "incident.*.read",
                             "operation": "read",
                             "condition": "",
@@ -465,7 +465,7 @@ class TestAclConflicts:
                             "active": "true",
                         },
                         {
-                            "sys_id": "acl2",
+                            "sys_id": "919246ee55548f64fe2c4ca2715ec446",
                             "name": "incident.*.write",
                             "operation": "write",
                             "condition": "",
@@ -502,21 +502,21 @@ class TestErrorAnalysis:
                 json={
                     "result": [
                         {
-                            "sys_id": "log1",
+                            "sys_id": "f4f1b5fb935f19c3ed564c873a77041e",
                             "message": "Error evaluating script",
                             "source": "sys_script.My BR",
                             "level": "0",
                             "sys_created_on": "2026-02-20 10:00:00",
                         },
                         {
-                            "sys_id": "log2",
+                            "sys_id": "8272fbd4ea89b69b3ccf4f94a9578f95",
                             "message": "Error evaluating script again",
                             "source": "sys_script.My BR",
                             "level": "0",
                             "sys_created_on": "2026-02-20 10:05:00",
                         },
                         {
-                            "sys_id": "log3",
+                            "sys_id": "740e4fa6e316646b192a2ddc68a44060",
                             "message": "Null pointer",
                             "source": "sys_script_include.Helper",
                             "level": "0",
@@ -585,7 +585,7 @@ class TestSlowTransactions:
                 json={
                     "result": [
                         {
-                            "sys_id": "qp001",
+                            "sys_id": "eae5779340d58657f7ef93b78f5e1f1d",
                             "name": "incident - complex query",
                             "count": "450",
                             "sys_created_on": "2026-02-20 08:00:00",
@@ -760,12 +760,12 @@ class TestExplainStaleAutomations:
     @respx.mock
     async def test_explain_flow_context(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a stuck flow_context record."""
-        respx.get(f"{BASE_URL}/api/now/table/flow_context/fc001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/flow_context/b45e2ae965e607a079b6677d64ba7c83").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "fc001",
+                        "sys_id": "b45e2ae965e607a079b6677d64ba7c83",
                         "name": "Approval Flow",
                         "state": "IN_PROGRESS",
                         "sys_created_on": "2026-01-01 00:00:00",
@@ -777,7 +777,7 @@ class TestExplainStaleAutomations:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="stale_automations",
-            element_id="flow_context:fc001",
+            element_id="flow_context:b45e2ae965e607a079b6677d64ba7c83",
         )
         result = decode_response(raw)
 
@@ -785,18 +785,18 @@ class TestExplainStaleAutomations:
         assert "explanation" in result["data"]
         assert "element" in result["data"]
         assert "Approval Flow" in result["data"]["explanation"]
-        assert result["data"]["record"]["sys_id"] == "fc001"
+        assert result["data"]["record"]["sys_id"] == "b45e2ae965e607a079b6677d64ba7c83"
 
     @pytest.mark.asyncio()
     @respx.mock
     async def test_explain_sys_script(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a disabled business rule."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/5f94cbf2a18c848c38da0c789d5da01b").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br001",
+                        "sys_id": "5f94cbf2a18c848c38da0c789d5da01b",
                         "name": "Old BR",
                         "active": "false",
                         "collection": "incident",
@@ -808,7 +808,7 @@ class TestExplainStaleAutomations:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="stale_automations",
-            element_id="sys_script:br001",
+            element_id="sys_script:5f94cbf2a18c848c38da0c789d5da01b",
         )
         result = decode_response(raw)
 
@@ -820,12 +820,12 @@ class TestExplainStaleAutomations:
     @respx.mock
     async def test_explain_sys_script_include(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a disabled script include."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/si001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/0fb49cae66242ebeb4673f0b5daca08d").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "si001",
+                        "sys_id": "0fb49cae66242ebeb4673f0b5daca08d",
                         "name": "LegacyHelper",
                         "active": "false",
                         "api_name": "global.LegacyHelper",
@@ -837,7 +837,7 @@ class TestExplainStaleAutomations:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="stale_automations",
-            element_id="sys_script_include:si001",
+            element_id="sys_script_include:0fb49cae66242ebeb4673f0b5daca08d",
         )
         result = decode_response(raw)
 
@@ -849,12 +849,12 @@ class TestExplainStaleAutomations:
     @respx.mock
     async def test_explain_sysauto_script(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a stale scheduled job."""
-        respx.get(f"{BASE_URL}/api/now/table/sysauto_script/sj001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sysauto_script/05bcd64a30c30d6dbc77c74c1fa0818c").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "sj001",
+                        "sys_id": "05bcd64a30c30d6dbc77c74c1fa0818c",
                         "name": "Nightly Cleanup",
                         "last_run": "2025-06-01 00:00:00",
                         "run_type": "daily",
@@ -866,7 +866,7 @@ class TestExplainStaleAutomations:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="stale_automations",
-            element_id="sysauto_script:sj001",
+            element_id="sysauto_script:05bcd64a30c30d6dbc77c74c1fa0818c",
         )
         result = decode_response(raw)
 
@@ -882,12 +882,12 @@ class TestExplainDeprecatedApis:
     @respx.mock
     async def test_explain_deprecated_script(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a script using deprecated APIs."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/script001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script_include/f080e34a96799d32cdc642f724be7e8c").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "script001",
+                        "sys_id": "f080e34a96799d32cdc642f724be7e8c",
                         "name": "OldHelper",
                         "api_name": "global.OldHelper",
                         "script": "var x = Packages.com.example.Test;",
@@ -899,14 +899,14 @@ class TestExplainDeprecatedApis:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="deprecated_apis",
-            element_id="sys_script_include:script001",
+            element_id="sys_script_include:f080e34a96799d32cdc642f724be7e8c",
         )
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert "deprecated" in result["data"]["explanation"].lower()
         assert "OldHelper" in result["data"]["explanation"]
-        assert result["data"]["element"] == "sys_script_include:script001"
+        assert result["data"]["element"] == "sys_script_include:f080e34a96799d32cdc642f724be7e8c"
 
 
 class TestExplainErrorAnalysis:
@@ -916,12 +916,12 @@ class TestExplainErrorAnalysis:
     @respx.mock
     async def test_explain_syslog_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a syslog error entry."""
-        respx.get(f"{BASE_URL}/api/now/table/syslog/log001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/syslog/c7437b6f8d9c00ea14eab197e745aacd").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "log001",
+                        "sys_id": "c7437b6f8d9c00ea14eab197e745aacd",
                         "message": "Error evaluating script",
                         "source": "sys_script.My BR",
                         "level": "0",
@@ -934,14 +934,14 @@ class TestExplainErrorAnalysis:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="error_analysis",
-            element_id="syslog:log001",
+            element_id="syslog:c7437b6f8d9c00ea14eab197e745aacd",
         )
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert "sys_script.My BR" in result["data"]["explanation"]
         assert "Error evaluating script" in result["data"]["explanation"]
-        assert result["data"]["element"] == "syslog:log001"
+        assert result["data"]["element"] == "syslog:c7437b6f8d9c00ea14eab197e745aacd"
 
 
 class TestExplainSlowTransactions:
@@ -951,12 +951,12 @@ class TestExplainSlowTransactions:
     @respx.mock
     async def test_explain_query_pattern(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for a slow query pattern."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_query_pattern/qp001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_query_pattern/eae5779340d58657f7ef93b78f5e1f1d").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "qp001",
+                        "sys_id": "eae5779340d58657f7ef93b78f5e1f1d",
                         "name": "incident - complex query",
                         "count": "450",
                         "sys_created_on": "2026-02-20 08:00:00",
@@ -968,7 +968,7 @@ class TestExplainSlowTransactions:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="slow_transactions",
-            element_id="sys_query_pattern:qp001",
+            element_id="sys_query_pattern:eae5779340d58657f7ef93b78f5e1f1d",
         )
         result = decode_response(raw)
 
@@ -976,7 +976,7 @@ class TestExplainSlowTransactions:
         assert "sys_query_pattern" in result["data"]["explanation"]
         assert "incident - complex query" in result["data"]["explanation"]
         assert "450" in result["data"]["explanation"]
-        assert result["data"]["element"] == "sys_query_pattern:qp001"
+        assert result["data"]["element"] == "sys_query_pattern:eae5779340d58657f7ef93b78f5e1f1d"
 
 
 class TestExplainPerformanceBottlenecks:
@@ -986,12 +986,12 @@ class TestExplainPerformanceBottlenecks:
     @respx.mock
     async def test_explain_table_with_colon(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() with table:sys_id returns record context."""
-        respx.get(f"{BASE_URL}/api/now/table/sysauto_script/sj001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sysauto_script/05bcd64a30c30d6dbc77c74c1fa0818c").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "sj001",
+                        "sys_id": "05bcd64a30c30d6dbc77c74c1fa0818c",
                         "name": "Heavy Job",
                         "run_type": "daily",
                     }
@@ -1002,14 +1002,14 @@ class TestExplainPerformanceBottlenecks:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="performance_bottlenecks",
-            element_id="sysauto_script:sj001",
+            element_id="sysauto_script:05bcd64a30c30d6dbc77c74c1fa0818c",
         )
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert "Heavy Job" in result["data"]["explanation"]
         assert "bottleneck" in result["data"]["explanation"].lower()
-        assert result["data"]["record"]["sys_id"] == "sj001"
+        assert result["data"]["record"]["sys_id"] == "05bcd64a30c30d6dbc77c74c1fa0818c"
 
     @pytest.mark.asyncio()
     async def test_explain_invalid_table_identifier(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
@@ -1017,7 +1017,7 @@ class TestExplainPerformanceBottlenecks:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="performance_bottlenecks",
-            element_id="../evil_table:sj001",
+            element_id="../evil_table:05bcd64a30c30d6dbc77c74c1fa0818c",
         )
         result = decode_response(raw)
 
@@ -1030,7 +1030,7 @@ class TestExplainPerformanceBottlenecks:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="performance_bottlenecks",
-            element_id="sys_user_token:sj001",
+            element_id="sys_user_token:05bcd64a30c30d6dbc77c74c1fa0818c",
         )
         result = decode_response(raw)
 
@@ -1086,12 +1086,12 @@ class TestExplainAclConflicts:
     @respx.mock
     async def test_explain_acl_record(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """explain() returns context for an ACL conflict finding."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl/acl001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_security_acl/9b332a2446a6dbc9d0d8da69a4397e33").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "acl001",
+                        "sys_id": "9b332a2446a6dbc9d0d8da69a4397e33",
                         "name": "incident.*.read",
                         "operation": "read",
                         "condition": "active=true",
@@ -1105,7 +1105,7 @@ class TestExplainAclConflicts:
         tools = _register_and_get_tools(settings, auth_provider)
         raw = await tools["investigate_explain"](
             investigation="acl_conflicts",
-            element_id="acl001",
+            element_id="9b332a2446a6dbc9d0d8da69a4397e33",
         )
         result = decode_response(raw)
 
@@ -1116,7 +1116,7 @@ class TestExplainAclConflicts:
             "conflicting" in result["data"]["explanation"].lower()
             or "consolidated" in result["data"]["explanation"].lower()
         )
-        assert result["data"]["record"]["sys_id"] == "acl001"
+        assert result["data"]["record"]["sys_id"] == "9b332a2446a6dbc9d0d8da69a4397e33"
 
 
 class TestExplainTableHealth:
@@ -1545,7 +1545,7 @@ class TestPerformanceBottlenecksCoverage:
                 json={
                     "result": [
                         {
-                            "sys_id": "flow1",
+                            "sys_id": "633fdbe8d66e59b2804697cd8982e215",
                             "name": "Running Flow",
                             "state": "IN_PROGRESS",
                             "sys_created_on": "2026-02-20 08:00:00",
@@ -1595,7 +1595,7 @@ class TestStaleAutomationsCoverage:
                 json={
                     "result": [
                         {
-                            "sys_id": "br001",
+                            "sys_id": "5f94cbf2a18c848c38da0c789d5da01b",
                             "name": "Disabled BR",
                             "collection": "incident",
                             "sys_updated_on": "2026-01-01 00:00:00",
@@ -1612,7 +1612,7 @@ class TestStaleAutomationsCoverage:
                 json={
                     "result": [
                         {
-                            "sys_id": "si001",
+                            "sys_id": "0fb49cae66242ebeb4673f0b5daca08d",
                             "name": "OldHelper",
                             "api_name": "global.OldHelper",
                             "sys_updated_on": "2026-01-01 00:00:00",
@@ -1629,7 +1629,7 @@ class TestStaleAutomationsCoverage:
                 json={
                     "result": [
                         {
-                            "sys_id": "sj001",
+                            "sys_id": "05bcd64a30c30d6dbc77c74c1fa0818c",
                             "name": "Stale Job",
                             "run_type": "daily",
                             "last_run": "2025-01-01 00:00:00",
@@ -1929,7 +1929,7 @@ class TestTableHealthCoverage:
                 json={
                     "result": [
                         {
-                            "sys_id": "log1",
+                            "sys_id": "f4f1b5fb935f19c3ed564c873a77041e",
                             "message": "Error",
                             "source": "incident",
                             "sys_created_on": "2026-02-20 10:00:00",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -211,7 +211,7 @@ class TestMetaGetArtifact:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["meta_get_artifact"](artifact_type="business_rule", sys_id="8baeabad365de895ab58ec0d6dd2c1e2")
+        raw = await tools["meta_get_artifact"](artifact_type="business_rule", sys_id="8baeabad365de895ab58ec0d6dd2c1e2", include_script_body=True)
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -211,7 +211,9 @@ class TestMetaGetArtifact:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["meta_get_artifact"](artifact_type="business_rule", sys_id="8baeabad365de895ab58ec0d6dd2c1e2", include_script_body=True)
+        raw = await tools["meta_get_artifact"](
+            artifact_type="business_rule", sys_id="8baeabad365de895ab58ec0d6dd2c1e2", include_script_body=True
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -520,7 +522,11 @@ class TestMetadataHelpers:
         cs_result: dict[str, Any] = {
             "search_results": [
                 {"className": "sys_script", "sys_id": "allowed1", "name": "Allowed BR"},
-                {"className": "sys_user_has_password", "sys_id": "40cf839e914805ac5cccdc87f01a5876", "name": "Denied Record"},
+                {
+                    "className": "sys_user_has_password",
+                    "sys_id": "40cf839e914805ac5cccdc87f01a5876",
+                    "name": "Denied Record",
+                },
             ],
         }
 
@@ -545,7 +551,13 @@ class TestMetadataHelpers:
         ) -> dict[str, Any]:
             if table == "sys_script":
                 return {
-                    "records": [{"sys_id": "3ff45714ea4c3069586dde97f40b9527", "name": "Found BR", "sys_class_name": "sys_script"}],
+                    "records": [
+                        {
+                            "sys_id": "3ff45714ea4c3069586dde97f40b9527",
+                            "name": "Found BR",
+                            "sys_class_name": "sys_script",
+                        }
+                    ],
                     "count": 1,
                 }
             raise RuntimeError(f"HTTP error for table {table}")
@@ -564,7 +576,9 @@ class TestMetadataHelpers:
         mock_client = AsyncMock()
         mock_client.query_records = AsyncMock(
             return_value={
-                "records": [{"sys_id": "3ff45714ea4c3069586dde97f40b9527", "name": "Found", "sys_class_name": "sys_script"}],
+                "records": [
+                    {"sys_id": "3ff45714ea4c3069586dde97f40b9527", "name": "Found", "sys_class_name": "sys_script"}
+                ],
                 "count": 1,
             }
         )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -125,7 +125,7 @@ class TestMetaListArtifacts:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "collection=incident^active=true"})
+        token = query_store.create({"query": "collection=incident^active=true", "table": "sys_script"})
         raw = await tools["meta_list_artifacts"](artifact_type="business_rule", query_token=token)
         result = decode_response(raw)
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -75,13 +75,13 @@ class TestMetaListArtifacts:
                 json={
                     "result": [
                         {
-                            "sys_id": "br1",
+                            "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                             "name": "Set Priority",
                             "collection": "incident",
                             "active": "true",
                         },
                         {
-                            "sys_id": "br2",
+                            "sys_id": "45caf3e7f1e7ce17456aec79ce1ab853",
                             "name": "Auto Close",
                             "collection": "incident",
                             "active": "false",
@@ -113,7 +113,7 @@ class TestMetaListArtifacts:
                 json={
                     "result": [
                         {
-                            "sys_id": "br1",
+                            "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                             "name": "Set Priority",
                             "collection": "incident",
                             "active": "true",
@@ -194,12 +194,12 @@ class TestMetaGetArtifact:
     @respx.mock
     async def test_returns_full_artifact(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns full artifact details including script body."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_script/br1").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_script/8baeabad365de895ab58ec0d6dd2c1e2").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "br1",
+                        "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                         "name": "Set Priority",
                         "collection": "incident",
                         "script": "current.priority = 1;",
@@ -211,11 +211,11 @@ class TestMetaGetArtifact:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["meta_get_artifact"](artifact_type="business_rule", sys_id="br1")
+        raw = await tools["meta_get_artifact"](artifact_type="business_rule", sys_id="8baeabad365de895ab58ec0d6dd2c1e2")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["sys_id"] == "br1"
+        assert result["data"]["sys_id"] == "8baeabad365de895ab58ec0d6dd2c1e2"
         assert result["data"]["script"] == "current.priority = 1;"
 
     @pytest.mark.asyncio()
@@ -251,7 +251,7 @@ class TestMetaFindReferences:
                             {
                                 "className": "sys_script",
                                 "name": "Set Priority",
-                                "sys_id": "br1",
+                                "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                                 "field_name": "script",
                                 "matches": [{"context": "var gr = new GlideRecord()"}],
                             }
@@ -287,7 +287,7 @@ class TestMetaFindReferences:
                         json={
                             "result": [
                                 {
-                                    "sys_id": "br1",
+                                    "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                                     "name": "Set Priority",
                                     "sys_class_name": "sys_script",
                                 }
@@ -428,7 +428,7 @@ class TestMetaWhatWrites:
                 json={
                     "result": [
                         {
-                            "sys_id": "br1",
+                            "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                             "name": "Set Priority",
                             "collection": "incident",
                             "when": "before",
@@ -461,7 +461,7 @@ class TestMetaWhatWrites:
                 json={
                     "result": [
                         {
-                            "sys_id": "br1",
+                            "sys_id": "8baeabad365de895ab58ec0d6dd2c1e2",
                             "name": "Set Priority",
                             "collection": "incident",
                             "when": "before",
@@ -469,7 +469,7 @@ class TestMetaWhatWrites:
                             "active": "true",
                         },
                         {
-                            "sys_id": "br2",
+                            "sys_id": "45caf3e7f1e7ce17456aec79ce1ab853",
                             "name": "Log State",
                             "collection": "incident",
                             "when": "after",
@@ -520,7 +520,7 @@ class TestMetadataHelpers:
         cs_result: dict[str, Any] = {
             "search_results": [
                 {"className": "sys_script", "sys_id": "allowed1", "name": "Allowed BR"},
-                {"className": "sys_user_has_password", "sys_id": "denied1", "name": "Denied Record"},
+                {"className": "sys_user_has_password", "sys_id": "40cf839e914805ac5cccdc87f01a5876", "name": "Denied Record"},
             ],
         }
 
@@ -545,7 +545,7 @@ class TestMetadataHelpers:
         ) -> dict[str, Any]:
             if table == "sys_script":
                 return {
-                    "records": [{"sys_id": "rec1", "name": "Found BR", "sys_class_name": "sys_script"}],
+                    "records": [{"sys_id": "3ff45714ea4c3069586dde97f40b9527", "name": "Found BR", "sys_class_name": "sys_script"}],
                     "count": 1,
                 }
             raise RuntimeError(f"HTTP error for table {table}")
@@ -556,7 +556,7 @@ class TestMetadataHelpers:
 
         assert len(matches) == 1
         assert matches[0]["table"] == "sys_script"
-        assert matches[0]["sys_id"] == "rec1"
+        assert matches[0]["sys_id"] == "3ff45714ea4c3069586dde97f40b9527"
 
     @pytest.mark.asyncio()
     async def test_search_via_table_scan_skips_denied_tables_via_policy(self) -> None:
@@ -564,7 +564,7 @@ class TestMetadataHelpers:
         mock_client = AsyncMock()
         mock_client.query_records = AsyncMock(
             return_value={
-                "records": [{"sys_id": "rec1", "name": "Found", "sys_class_name": "sys_script"}],
+                "records": [{"sys_id": "3ff45714ea4c3069586dde97f40b9527", "name": "Found", "sys_class_name": "sys_script"}],
                 "count": 1,
             }
         )

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -46,6 +46,44 @@ class TestDenyList:
         with pytest.raises(PolicyError, match="denied"):
             check_table_access("Oauth_Credential")
 
+    @pytest.mark.parametrize(
+        "table",
+        [
+            # Baseline denied tables
+            "sys_user_has_password",
+            "oauth_credential",
+            "oauth_entity",
+            "sys_certificate",
+            "sys_ssh_key",
+            "sys_credentials",
+            "discovery_credentials",
+            "sys_user_token",
+            # Phase 4 additions - broadened to cover identity, configuration,
+            # ACL, auth, data-source, workflow-variable, scripted-email, and
+            # MID agent tables that can disclose secrets or sensitive posture.
+            "sys_user",
+            "sys_properties",
+            "sys_security_acl",
+            "sys_auth_profile",
+            "sys_data_source",
+            "sys_variable_value",
+            "sys_script_email",
+            "ecc_agent",
+            "ecc_queue",
+        ],
+    )
+    def test_every_denied_table_is_gated(self, table: str) -> None:
+        """Each DENIED_TABLES entry is present and rejected by check_table_access.
+
+        This is the single source of truth for the deny list - any future
+        removal must be an explicit decision, not a silent regression.
+        """
+        from servicenow_mcp.policy import DENIED_TABLES, check_table_access
+
+        assert table in DENIED_TABLES
+        with pytest.raises(PolicyError, match="denied"):
+            check_table_access(table)
+
 
 class TestSensitiveFieldMasking:
     """Test sensitive field masking."""

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -311,7 +311,14 @@ class TestRelReferencesTo:
         respx.get(f"{BASE_URL}/api/now/table/task").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": "d95216b77e0cd834ca43caef2322e8fd", "assigned_to": "95c946bf622ef93b0a211cd0fd028dfd"}]},
+                json={
+                    "result": [
+                        {
+                            "sys_id": "d95216b77e0cd834ca43caef2322e8fd",
+                            "assigned_to": "95c946bf622ef93b0a211cd0fd028dfd",
+                        }
+                    ]
+                },
                 headers={"X-Total-Count": "1"},
             )
         )
@@ -381,7 +388,11 @@ class TestRelReferencesTo:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": "bcb08020a40eeb713ee390dded876799", "caller_id": "b3daa77b4c04a9551b8781d03191fe09"}]},
+                json={
+                    "result": [
+                        {"sys_id": "bcb08020a40eeb713ee390dded876799", "caller_id": "b3daa77b4c04a9551b8781d03191fe09"}
+                    ]
+                },
                 headers={"X-Total-Count": "1"},
             )
         )

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -69,7 +69,7 @@ class TestRecordGet:
     @respx.mock
     async def test_masks_sensitive_fields(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Sensitive fields like password are masked in the response."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_user/b3daa77b4c04a9551b8781d03191fe09").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/b3daa77b4c04a9551b8781d03191fe09").mock(
             return_value=httpx.Response(
                 200,
                 json={
@@ -84,7 +84,7 @@ class TestRecordGet:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["record_get"](table="sys_user", sys_id="b3daa77b4c04a9551b8781d03191fe09")
+        raw = await tools["record_get"](table="incident", sys_id="b3daa77b4c04a9551b8781d03191fe09")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -152,7 +152,8 @@ class TestRecordErrorPropagation:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """NotFoundError (404) from client is caught and returned in error envelope."""
-        respx.get(f"{BASE_URL}/api/now/table/incident/missing").mock(
+        missing_sys_id = "00000000000000000000000000000000"
+        respx.get(f"{BASE_URL}/api/now/table/incident/{missing_sys_id}").mock(
             return_value=httpx.Response(
                 404,
                 json={"error": {"message": "Record not found"}},
@@ -160,7 +161,7 @@ class TestRecordErrorPropagation:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["record_get"](table="incident", sys_id="missing")
+        raw = await tools["record_get"](table="incident", sys_id=missing_sys_id)
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -253,12 +254,14 @@ class TestRelReferencesTo:
         """Paginated sys_dictionary fetches collect fields across all pages."""
         page_size = 1000
 
-        # Build two pages: first page has exactly page_size entries, second has 2
+        # Build two pages: first page has exactly page_size entries, second has 2.
+        # Using cmn_department as the target because sys_user is a denied table
+        # (MED-1 Phase 4) and rel_references_to performs check_table_access.
         page1_fields = [
             {
                 "name": f"table_p1_{i}",
                 "element": "ref_field",
-                "reference": "sys_user",
+                "reference": "cmn_department",
                 "column_label": f"Ref {i}",
             }
             for i in range(page_size)
@@ -267,13 +270,13 @@ class TestRelReferencesTo:
             {
                 "name": "task",
                 "element": "assigned_to",
-                "reference": "sys_user",
+                "reference": "cmn_department",
                 "column_label": "Assigned to",
             },
             {
                 "name": "task",
                 "element": "opened_by",
-                "reference": "sys_user",
+                "reference": "cmn_department",
                 "column_label": "Opened by",
             },
         ]
@@ -314,7 +317,7 @@ class TestRelReferencesTo:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_to"](table="sys_user", sys_id="95c946bf622ef93b0a211cd0fd028dfd")
+        raw = await tools["rel_references_to"](table="cmn_department", sys_id="95c946bf622ef93b0a211cd0fd028dfd")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -344,28 +347,28 @@ class TestRelReferencesTo:
                         {
                             "name": denied,
                             "element": "user",
-                            "reference": "sys_user",
+                            "reference": "cmn_department",
                             "column_label": "User",
                         },
                         # var__m_ internal entry - should be skipped
                         {
                             "name": "var__m_some_table",
                             "element": "ref",
-                            "reference": "sys_user",
+                            "reference": "cmn_department",
                             "column_label": "Ref",
                         },
                         # sys_variable_value entry - should be skipped
                         {
                             "name": "sys_variable_value",
                             "element": "ref",
-                            "reference": "sys_user",
+                            "reference": "cmn_department",
                             "column_label": "Ref",
                         },
                         # Valid entry - should be processed
                         {
                             "name": "incident",
                             "element": "caller_id",
-                            "reference": "sys_user",
+                            "reference": "cmn_department",
                             "column_label": "Caller",
                         },
                     ]
@@ -384,7 +387,7 @@ class TestRelReferencesTo:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_to"](table="sys_user", sys_id="b3daa77b4c04a9551b8781d03191fe09")
+        raw = await tools["rel_references_to"](table="cmn_department", sys_id="b3daa77b4c04a9551b8781d03191fe09")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -487,7 +490,7 @@ class TestRelReferencesFrom:
             # First call: lookup incident -> returns super_class pointing to task
             httpx.Response(
                 200,
-                json={"result": [{"super_class": {"value": "task_sys_id", "link": ""}}]},
+                json={"result": [{"super_class": {"value": "11111111111111111111111111111111", "link": ""}}]},
                 headers={"X-Total-Count": "1"},
             ),
             # Third call: lookup task -> no super_class
@@ -498,8 +501,8 @@ class TestRelReferencesFrom:
             ),
         ]
 
-        # Mock: resolve task_sys_id -> "task"
-        respx.get(f"{BASE_URL}/api/now/table/sys_db_object/task_sys_id").mock(
+        # Mock: resolve task super_class sys_id -> "task"
+        respx.get(f"{BASE_URL}/api/now/table/sys_db_object/11111111111111111111111111111111").mock(
             return_value=httpx.Response(
                 200,
                 json={"result": {"name": "task"}},

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -44,12 +44,12 @@ class TestRecordGet:
     @respx.mock
     async def test_returns_single_record(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Fetches and returns a single record by sys_id."""
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
                         "number": "INC0001",
                         "state": "1",
                     }
@@ -58,33 +58,33 @@ class TestRecordGet:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["record_get"](table="incident", sys_id="abc123")
+        raw = await tools["record_get"](table="incident", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["sys_id"] == "abc123"
+        assert result["data"]["sys_id"] == "6367c48dd193d56ea7b0baad25b19455"
         assert result["data"]["number"] == "INC0001"
 
     @pytest.mark.asyncio()
     @respx.mock
     async def test_masks_sensitive_fields(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Sensitive fields like password are masked in the response."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_user/user1").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_user/b3daa77b4c04a9551b8781d03191fe09").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "user1",
+                        "sys_id": "b3daa77b4c04a9551b8781d03191fe09",
                         "user_name": "admin",
                         "password": "supersecret",  # NOSONAR
-                        "api_key": "key123",  # NOSONAR
+                        "api_key": "e48c47f1431afd3bb030deea266b4309",  # NOSONAR
                     }
                 },
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["record_get"](table="sys_user", sys_id="user1")
+        raw = await tools["record_get"](table="sys_user", sys_id="b3daa77b4c04a9551b8781d03191fe09")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -131,7 +131,7 @@ class TestRecordErrorPropagation:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """AuthError (401) from client is caught and returned in error envelope."""
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 401,
                 json={"error": {"message": "User not authenticated"}},
@@ -139,7 +139,7 @@ class TestRecordErrorPropagation:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["record_get"](table="incident", sys_id="abc123")
+        raw = await tools["record_get"](table="incident", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -200,7 +200,7 @@ class TestRelReferencesTo:
                 200,
                 json={
                     "result": [
-                        {"sys_id": "sla1", "task": "abc123"},
+                        {"sys_id": "2fac834f6cba66ff7e1e8cf01c247103", "task": "6367c48dd193d56ea7b0baad25b19455"},
                     ]
                 },
                 headers={"X-Total-Count": "1"},
@@ -208,12 +208,12 @@ class TestRelReferencesTo:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_to"](table="incident", sys_id="abc123")
+        raw = await tools["rel_references_to"](table="incident", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "success"
         assert result["data"]["target"]["table"] == "incident"
-        assert result["data"]["target"]["sys_id"] == "abc123"
+        assert result["data"]["target"]["sys_id"] == "6367c48dd193d56ea7b0baad25b19455"
         assert len(result["data"]["incoming_references"]) == 1
         assert result["data"]["incoming_references"][0]["table"] == "task_sla"
 
@@ -230,7 +230,7 @@ class TestRelReferencesTo:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_to"](table="incident", sys_id="abc123")
+        raw = await tools["rel_references_to"](table="incident", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -308,13 +308,13 @@ class TestRelReferencesTo:
         respx.get(f"{BASE_URL}/api/now/table/task").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": "task1", "assigned_to": "user123"}]},
+                json={"result": [{"sys_id": "d95216b77e0cd834ca43caef2322e8fd", "assigned_to": "95c946bf622ef93b0a211cd0fd028dfd"}]},
                 headers={"X-Total-Count": "1"},
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_to"](table="sys_user", sys_id="user123")
+        raw = await tools["rel_references_to"](table="sys_user", sys_id="95c946bf622ef93b0a211cd0fd028dfd")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -378,13 +378,13 @@ class TestRelReferencesTo:
         respx.get(f"{BASE_URL}/api/now/table/incident").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": [{"sys_id": "inc1", "caller_id": "user1"}]},
+                json={"result": [{"sys_id": "bcb08020a40eeb713ee390dded876799", "caller_id": "b3daa77b4c04a9551b8781d03191fe09"}]},
                 headers={"X-Total-Count": "1"},
             )
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_to"](table="sys_user", sys_id="user1")
+        raw = await tools["rel_references_to"](table="sys_user", sys_id="b3daa77b4c04a9551b8781d03191fe09")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -406,14 +406,14 @@ class TestRelReferencesFrom:
     async def test_finds_outgoing_references(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Finds what a record references via its reference fields."""
         # Mock: get the record itself
-        respx.get(f"{BASE_URL}/api/now/table/incident/abc123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6367c48dd193d56ea7b0baad25b19455").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "abc123",
-                        "caller_id": "user1",
-                        "assignment_group": "group1",
+                        "sys_id": "6367c48dd193d56ea7b0baad25b19455",
+                        "caller_id": "b3daa77b4c04a9551b8781d03191fe09",
+                        "assignment_group": "be4f69bf25177a377d20437445e49a13",
                         "state": "1",
                     }
                 },
@@ -450,7 +450,7 @@ class TestRelReferencesFrom:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_from"](table="incident", sys_id="abc123")
+        raw = await tools["rel_references_from"](table="incident", sys_id="6367c48dd193d56ea7b0baad25b19455")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -466,15 +466,15 @@ class TestRelReferencesFrom:
     async def test_finds_inherited_reference_fields(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Inherited reference fields from parent tables are included."""
         # Mock: get the incident record -- has fields from both incident and task
-        respx.get(f"{BASE_URL}/api/now/table/incident/inc001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/incident/6d55028a7049dbf2f4275991d6fc81cf").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "inc001",
-                        "caller_id": "user1",
-                        "assigned_to": "user2",
-                        "opened_by": "user3",
+                        "sys_id": "6d55028a7049dbf2f4275991d6fc81cf",
+                        "caller_id": "b3daa77b4c04a9551b8781d03191fe09",
+                        "assigned_to": "a1881c06eec96db9901c7bbfe41c42a3",
+                        "opened_by": "0b7f849446d3383546d15a4809660844",
                         "state": "1",
                     }
                 },
@@ -536,7 +536,7 @@ class TestRelReferencesFrom:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_from"](table="incident", sys_id="inc001")
+        raw = await tools["rel_references_from"](table="incident", sys_id="6d55028a7049dbf2f4275991d6fc81cf")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -553,13 +553,13 @@ class TestRelReferencesFrom:
     async def test_hierarchy_stops_at_root(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Hierarchy walk terminates when there is no super_class."""
         # Mock: get the record
-        respx.get(f"{BASE_URL}/api/now/table/task/t1").mock(
+        respx.get(f"{BASE_URL}/api/now/table/task/e5353879bd69bfddcb465dad176ff52d").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "t1",
-                        "assigned_to": "user1",
+                        "sys_id": "e5353879bd69bfddcb465dad176ff52d",
+                        "assigned_to": "b3daa77b4c04a9551b8781d03191fe09",
                     }
                 },
             )
@@ -590,7 +590,7 @@ class TestRelReferencesFrom:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_from"](table="task", sys_id="t1")
+        raw = await tools["rel_references_from"](table="task", sys_id="e5353879bd69bfddcb465dad176ff52d")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -604,10 +604,10 @@ class TestRelReferencesFrom:
     @respx.mock
     async def test_handles_no_reference_fields(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns empty outgoing_references when record has no reference fields."""
-        respx.get(f"{BASE_URL}/api/now/table/cmdb_ci/ci1").mock(
+        respx.get(f"{BASE_URL}/api/now/table/cmdb_ci/d5f759f849bd82f4d43947407ffce511").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "ci1", "name": "Server01"}},
+                json={"result": {"sys_id": "d5f759f849bd82f4d43947407ffce511", "name": "Server01"}},
             )
         )
         # Mock: hierarchy -- cmdb_ci has no parent
@@ -627,7 +627,7 @@ class TestRelReferencesFrom:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["rel_references_from"](table="cmdb_ci", sys_id="ci1")
+        raw = await tools["rel_references_from"](table="cmdb_ci", sys_id="d5f759f849bd82f4d43947407ffce511")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -706,7 +706,7 @@ class TestRelReferencesToBoundedConcurrency:
             TrackingSemaphore,
         ):
             tools = _register_and_get_tools(settings, auth_provider)
-            raw = await tools["rel_references_to"](table="incident", sys_id="abc123")
+            raw = await tools["rel_references_to"](table="incident", sys_id="6367c48dd193d56ea7b0baad25b19455")
             result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -80,9 +80,9 @@ class TestSetupSentry:
         call_kwargs = mock_init.call_args[1]
         assert call_kwargs["dsn"] == "https://key@sentry.io/123"
         assert call_kwargs["environment"] == "staging"
-        assert call_kwargs["send_default_pii"] is True
+        assert call_kwargs["send_default_pii"] is False
         assert call_kwargs["integrations"] == []
-        assert call_kwargs["traces_sample_rate"] == pytest.approx(1.0)
+        assert call_kwargs["traces_sample_rate"] == pytest.approx(0.05)
         assert call_kwargs["profiles_sample_rate"] is None
 
     def test_falls_back_to_servicenow_env(self) -> None:
@@ -377,7 +377,7 @@ class TestSetSentryContextIntegration:
             )
 
     async def test_tool_handler_sets_tool_context(self) -> None:
-        """tool_handler sets tool context with name, correlation_id, and args."""
+        """tool_handler sets tool context with name, correlation_id, and arg_keys (keys only, no values, to avoid PII leakage)."""
         from servicenow_mcp.decorators import tool_handler
 
         @tool_handler
@@ -392,7 +392,8 @@ class TestSetSentryContextIntegration:
             context_data = call_args[0][1]
             assert context_data["name"] == "my_tool"
             assert "correlation_id" in context_data
-            assert context_data["args"] == {"table": "incident"}
+            assert context_data["arg_keys"] == ["table"]
+            assert "args" not in context_data
 
     def test_raise_for_status_sets_http_context(self) -> None:
         """_raise_for_status sets HTTP context before raising."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,9 +5,25 @@ from types import ModuleType
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from toon_format import decode as toon_decode
 
 from tests.helpers import get_tool_functions, get_tool_names
+
+
+@pytest.fixture(autouse=True)
+def _reset_dangerous_bypass_lock() -> None:
+    """Reset the one-shot dangerous-bypass sentinel between tests.
+
+    ``set_dangerous_bypass`` is bootstrap-only by design (see policy.py).
+    Each test here calls ``create_mcp_server()`` which invokes the setter,
+    so we reset the module-level lock/state before each test to simulate
+    a fresh process.
+    """
+    from servicenow_mcp import policy
+
+    policy._bypass_locked = False
+    policy._dangerous_bypass_enabled = False
 
 
 class TestCreateMcpServer:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,8 +6,8 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from toon_format import decode as toon_decode
 
+from servicenow_mcp._vendor.toon_format import decode as toon_decode
 from tests.helpers import get_tool_functions, get_tool_names
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -165,14 +165,14 @@ class TestQueryTokenStore:
     def test_create_returns_token_string(self) -> None:
         """create() returns a UUID-style string token."""
         store = QueryTokenStore(ttl_seconds=300)
-        token = store.create({"query": "active=true"})
+        token = store.create({"query": "active=true", "table": "incident"})
         assert isinstance(token, str)
         assert len(token) > 0
 
     def test_get_returns_stored_payload(self) -> None:
         """get() returns the payload stored for a valid token."""
         store = QueryTokenStore(ttl_seconds=300)
-        payload = {"query": "active=true"}
+        payload = {"query": "active=true", "table": "incident"}
         token = store.create(payload)
         result = store.get(token)
         assert result is not None
@@ -192,7 +192,7 @@ class TestQueryTokenStore:
             side_effect=lambda: fake_time,
         ):
             store = QueryTokenStore(ttl_seconds=60)
-            token = store.create({"query": "active=true"})
+            token = store.create({"query": "active=true", "table": "incident"})
 
         # Advance time past TTL
         with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time + 61):
@@ -203,7 +203,7 @@ class TestQueryTokenStore:
     def test_get_is_reusable_within_ttl(self) -> None:
         """get() succeeds multiple times for the same token (non-destructive)."""
         store = QueryTokenStore(ttl_seconds=300)
-        token = store.create({"query": "active=true"})
+        token = store.create({"query": "active=true", "table": "incident"})
 
         result1 = store.get(token)
         result2 = store.get(token)
@@ -224,7 +224,7 @@ class TestQueryTokenStore:
             side_effect=lambda: fake_time,
         ):
             store = QueryTokenStore(ttl_seconds=60)
-            token = store.create({"query": "active=true"})
+            token = store.create({"query": "active=true", "table": "incident"})
 
         # Advance time but stay within TTL
         with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time + 59):
@@ -241,7 +241,7 @@ class TestQueryTokenStore:
             side_effect=lambda: fake_time,
         ):
             store = QueryTokenStore(ttl_seconds=60)
-            token = store.create({"query": "active=true"})
+            token = store.create({"query": "active=true", "table": "incident"})
 
         # Advance time to exactly TTL -- _is_expired uses >, so 60 == 60 is NOT expired
         with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time + 60):
@@ -252,24 +252,24 @@ class TestQueryTokenStore:
     def test_store_max_size(self) -> None:
         """create() raises RuntimeError when max_size is reached and no entries are expired."""
         store = QueryTokenStore(ttl_seconds=300, max_size=3)
-        store.create({"query": "active=true"})
-        store.create({"query": "state=1"})
-        store.create({"query": "priority=1"})
+        store.create({"query": "active=true", "table": "incident"})
+        store.create({"query": "state=1", "table": "incident"})
+        store.create({"query": "priority=1", "table": "incident"})
 
         with pytest.raises(RuntimeError, match="store is full"):
-            store.create({"query": "impact=1"})
+            store.create({"query": "impact=1", "table": "incident"})
 
     def test_sweep_expired_on_create(self) -> None:
         """create() sweeps expired entries first, allowing new tokens when space is freed."""
         fake_time = 1000.0
         with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time):
             store = QueryTokenStore(ttl_seconds=60, max_size=2)
-            store.create({"query": "active=true"})
-            store.create({"query": "state=1"})
+            store.create({"query": "active=true", "table": "incident"})
+            store.create({"query": "state=1", "table": "incident"})
 
         # Advance time past TTL -- expired entries should be swept on next create()
         with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time + 61):
-            token = store.create({"query": "priority=1"})
+            token = store.create({"query": "priority=1", "table": "incident"})
             result = store.get(token)
 
         assert result is not None
@@ -280,9 +280,9 @@ class TestQueryTokenStore:
         fake_time = 1000.0
         with patch("servicenow_mcp.state.time.monotonic", return_value=fake_time):
             store = QueryTokenStore(ttl_seconds=60, max_size=10)
-            store.create({"query": "active=true"})
-            store.create({"query": "state=1"})
-            store.create({"query": "priority=1"})
+            store.create({"query": "active=true", "table": "incident"})
+            store.create({"query": "state=1", "table": "incident"})
+            store.create({"query": "priority=1", "table": "incident"})
 
         assert len(store) == 3
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -425,7 +425,9 @@ class TestBuildQuery:
     async def test_simple_equals(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Build a simple equals query."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "active=true"
@@ -476,7 +478,9 @@ class TestBuildQuery:
     async def test_is_empty_no_value_needed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Unary operators like is_empty don't need a value."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "is_empty", "field": "assigned_to"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "is_empty", "field": "assigned_to"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "assigned_toISEMPTY"
@@ -488,7 +492,9 @@ class TestBuildQuery:
     async def test_invalid_operator_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Unknown operator returns an error response."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "INVALID", "field": "active", "value": "true"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "INVALID", "field": "active", "value": "true"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "Unknown operator" in result["error"]["message"]
@@ -712,7 +718,8 @@ class TestBuildQuery:
         """Time operator without value key returns error (line 96)."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "hours_ago", "field": "sys_created_on"}]',
+            table="incident",
+            conditions='[{"operator": "hours_ago", "field": "sys_created_on"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "error"
@@ -730,7 +737,9 @@ class TestBuildQuery:
             "servicenow_mcp.tools.table.ServiceNowQuery",
             side_effect=RuntimeError("boom"),
         ):
-            raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+            raw = await tools["build_query"](
+                table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]'
+            )
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "boom" in result["error"]["message"]
@@ -748,7 +757,9 @@ class TestBuildQuery:
         register_tools(mcp, settings, auth_provider)
         tools = get_tool_functions(mcp)
 
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]'
+        )
         result = decode_response(raw)
         token = result["data"]["query_token"]
 
@@ -773,7 +784,9 @@ class TestBuildQuery:
     async def test_not_like(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test not_like string operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "not_like", "field": "name", "value": "test"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "not_like", "field": "name", "value": "test"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "nameNOT LIKEtest"
@@ -791,7 +804,9 @@ class TestBuildQuery:
     async def test_empty_string(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test empty_string unary operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "empty_string", "field": "description"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "empty_string", "field": "description"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "descriptionEMPTYSTRING"
@@ -810,7 +825,8 @@ class TestBuildQuery:
         """Test gt_field comparison operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "gt_field", "field": "sys_updated_on", "other_field": "sys_created_on"}]'
+            table="incident",
+            conditions='[{"operator": "gt_field", "field": "sys_updated_on", "other_field": "sys_created_on"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -855,7 +871,8 @@ class TestBuildQuery:
         """Test between range operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "between", "field": "sys_created_on", "start": "2026-01-01", "end": "2026-12-31"}]'
+            table="incident",
+            conditions='[{"operator": "between", "field": "sys_created_on", "start": "2026-01-01", "end": "2026-12-31"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -876,7 +893,8 @@ class TestBuildQuery:
         """Test datepart operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "datepart", "field": "sys_created_on", "part": "dayofweek", "dp_operator": "=", "dp_value": "1"}]'
+            table="incident",
+            conditions='[{"operator": "datepart", "field": "sys_created_on", "part": "dayofweek", "dp_operator": "=", "dp_value": "1"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -886,7 +904,9 @@ class TestBuildQuery:
     async def test_datepart_missing_part(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """datepart without required params returns error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "datepart", "field": "sys_created_on"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "datepart", "field": "sys_created_on"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "error"
 
@@ -906,7 +926,8 @@ class TestBuildQuery:
         """Test relative_gt date operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "relative_gt", "field": "sys_created_on", "value": "@year@ago@1"}]'
+            table="incident",
+            conditions='[{"operator": "relative_gt", "field": "sys_created_on", "value": "@year@ago@1"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -917,7 +938,8 @@ class TestBuildQuery:
         """Test more_than date operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "more_than", "field": "sys_updated_on", "value": "@hour@ago@3"}]'
+            table="incident",
+            conditions='[{"operator": "more_than", "field": "sys_updated_on", "value": "@hour@ago@3"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -927,7 +949,9 @@ class TestBuildQuery:
     async def test_changes_from(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test changes_from change detection operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "changes_from", "field": "priority", "value": "3"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "changes_from", "field": "priority", "value": "3"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "priorityCHANGESFROM3"
@@ -936,7 +960,9 @@ class TestBuildQuery:
     async def test_changes_to(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test changes_to change detection operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](table="incident", conditions='[{"operator": "changes_to", "field": "state", "value": "6"}]')
+        raw = await tools["build_query"](
+            table="incident", conditions='[{"operator": "changes_to", "field": "state", "value": "6"}]'
+        )
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "stateCHANGESTO6"
@@ -946,7 +972,8 @@ class TestBuildQuery:
         """Test dynamic reference operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "dynamic", "field": "cmdb_ci", "value": "javascript:getCIFilter()"}]'
+            table="incident",
+            conditions='[{"operator": "dynamic", "field": "cmdb_ci", "value": "javascript:getCIFilter()"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -1026,7 +1053,8 @@ class TestBuildQuery:
         """Time operator with non-integer value returns structured error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": "hours_ago", "field": "sys_created_on", "value": "abc"}]',
+            table="incident",
+            conditions='[{"operator": "hours_ago", "field": "sys_created_on", "value": "abc"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "error"
@@ -1039,7 +1067,8 @@ class TestBuildQuery:
         """Non-string operator value returns type error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            table="incident", conditions='[{"operator": 123, "field": "state"}]',
+            table="incident",
+            conditions='[{"operator": 123, "field": "state"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "error"

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -169,7 +169,7 @@ class TestTableQuery:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "incident"})
         raw = await tools["table_query"](table="incident", query_token=token)
         result = decode_response(raw)
 
@@ -190,7 +190,7 @@ class TestTableQuery:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "incident"})
         # Default max_row_limit is 100, request 500
         raw = await tools["table_query"](table="incident", query_token=token, limit=500)
         result = decode_response(raw)
@@ -208,7 +208,7 @@ class TestTableQuery:
         # Add syslog to large tables for this test
         settings.large_table_names_csv = "syslog,sys_audit"
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "level=error"})
+        token = query_store.create({"query": "level=error", "table": "syslog"})
         raw = await tools["table_query"](table="syslog", query_token=token)
         result = decode_response(raw)
 
@@ -220,7 +220,7 @@ class TestTableQuery:
         """Denied table returns error."""
         denied = next(iter(DENIED_TABLES))
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": denied})
         raw = await tools["table_query"](table=denied, query_token=token)
         result = decode_response(raw)
 
@@ -248,7 +248,7 @@ class TestTableQuery:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "incident"})
         raw = await tools["table_query"](table="incident", query_token=token, display_values=True)
         result = decode_response(raw)
 
@@ -279,7 +279,7 @@ class TestTableAggregate:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "incident"})
         raw = await tools["table_aggregate"](table="incident", query_token=token)
         result = decode_response(raw)
 
@@ -291,7 +291,7 @@ class TestTableAggregate:
         """Denied table returns error."""
         denied = next(iter(DENIED_TABLES))
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": denied})
         raw = await tools["table_aggregate"](table=denied, query_token=token)
         result = decode_response(raw)
 
@@ -344,7 +344,7 @@ class TestTableErrorPropagation:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "incident"})
         raw = await tools["table_query"](table="incident", query_token=token)
         result = decode_response(raw)
 
@@ -369,7 +369,7 @@ class TestTableErrorPropagation:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "incident"})
         raw = await tools["table_aggregate"](table="incident", query_token=token)
         result = decode_response(raw)
 
@@ -425,7 +425,7 @@ class TestBuildQuery:
     async def test_simple_equals(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Build a simple equals query."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "active=true"
@@ -438,7 +438,7 @@ class TestBuildQuery:
         """Build a query with hours_ago time filter."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "hours_ago", "field": "sys_created_on", "value": 24}]'
+            table="incident", conditions='[{"operator": "hours_ago", "field": "sys_created_on", "value": 24}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -462,7 +462,7 @@ class TestBuildQuery:
                 {"operator": "like", "field": "source", "value": "incident"},
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == (
@@ -476,7 +476,7 @@ class TestBuildQuery:
     async def test_is_empty_no_value_needed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Unary operators like is_empty don't need a value."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "is_empty", "field": "assigned_to"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "is_empty", "field": "assigned_to"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "assigned_toISEMPTY"
@@ -488,7 +488,7 @@ class TestBuildQuery:
     async def test_invalid_operator_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Unknown operator returns an error response."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "INVALID", "field": "active", "value": "true"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "INVALID", "field": "active", "value": "true"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "Unknown operator" in result["error"]["message"]
@@ -497,7 +497,7 @@ class TestBuildQuery:
     async def test_invalid_json_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Malformed JSON returns an error response."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions="not valid json")
+        raw = await tools["build_query"](table="incident", conditions="not valid json")
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "Invalid JSON" in result["error"]["message"]
@@ -506,7 +506,7 @@ class TestBuildQuery:
     async def test_missing_field_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Missing required 'field' key returns an error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "equals", "value": "true"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "value": "true"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "requires a 'field'" in result["error"]["message"]
@@ -517,7 +517,7 @@ class TestBuildQuery:
     ) -> None:
         """Binary operators require a value."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "equals", "field": "active"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "requires a 'value'" in result["error"]["message"]
@@ -526,7 +526,7 @@ class TestBuildQuery:
     async def test_not_array_returns_error(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Non-array JSON returns an error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='{"operator": "equals"}')
+        raw = await tools["build_query"](table="incident", conditions='{"operator": "equals"}')
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "must be a JSON array" in result["error"]["message"]
@@ -535,7 +535,7 @@ class TestBuildQuery:
     async def test_empty_array_returns_empty_query(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Empty array returns empty query string."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions="[]")
+        raw = await tools["build_query"](table="incident", conditions="[]")
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == ""
@@ -546,7 +546,7 @@ class TestBuildQuery:
         """Test days_ago time filter."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "days_ago", "field": "sys_created_on", "value": 30}]'
+            table="incident", conditions='[{"operator": "days_ago", "field": "sys_created_on", "value": 30}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -558,7 +558,7 @@ class TestBuildQuery:
         """Test starts_with string operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "starts_with", "field": "name", "value": "incident"}]'
+            table="incident", conditions='[{"operator": "starts_with", "field": "name", "value": "incident"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -575,7 +575,7 @@ class TestBuildQuery:
                 {"operator": "or_equals", "field": "state", "value": "2"},
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "state=1^ORstate=2"
@@ -595,7 +595,7 @@ class TestBuildQuery:
                 },
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "nameSTARTSWITHINC^ORnameSTARTSWITHREQ"
@@ -614,7 +614,7 @@ class TestBuildQuery:
                 },
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "stateIN1,2,3"
@@ -633,7 +633,7 @@ class TestBuildQuery:
                 },
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "priorityNOT IN4,5"
@@ -648,7 +648,7 @@ class TestBuildQuery:
                 {"operator": "in_list", "field": "state", "value": "1"},
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "list of strings" in result["error"]["message"]
@@ -663,7 +663,7 @@ class TestBuildQuery:
                 {"operator": "order_by", "field": "sys_created_on"},
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "active=true^ORDERBYsys_created_on"
@@ -683,7 +683,7 @@ class TestBuildQuery:
                 },
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "active=true^ORDERBYDESCsys_created_on"
@@ -698,7 +698,7 @@ class TestBuildQuery:
                 {"operator": "equals", "field": "name", "value": "foo^bar"},
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         # The ^ in the value should be escaped to ^^
@@ -712,7 +712,7 @@ class TestBuildQuery:
         """Time operator without value key returns error (line 96)."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "hours_ago", "field": "sys_created_on"}]',
+            table="incident", conditions='[{"operator": "hours_ago", "field": "sys_created_on"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "error"
@@ -730,7 +730,7 @@ class TestBuildQuery:
             "servicenow_mcp.tools.table.ServiceNowQuery",
             side_effect=RuntimeError("boom"),
         ):
-            raw = await tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+            raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
         assert "boom" in result["error"]["message"]
@@ -748,7 +748,7 @@ class TestBuildQuery:
         register_tools(mcp, settings, auth_provider)
         tools = get_tool_functions(mcp)
 
-        raw = await tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
         result = decode_response(raw)
         token = result["data"]["query_token"]
 
@@ -763,7 +763,7 @@ class TestBuildQuery:
         """Test ends_with string operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "ends_with", "field": "email", "value": "@example.com"}]'
+            table="incident", conditions='[{"operator": "ends_with", "field": "email", "value": "@example.com"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -773,7 +773,7 @@ class TestBuildQuery:
     async def test_not_like(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test not_like string operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "not_like", "field": "name", "value": "test"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "not_like", "field": "name", "value": "test"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "nameNOT LIKEtest"
@@ -782,7 +782,7 @@ class TestBuildQuery:
     async def test_anything(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test anything unary operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "anything", "field": "state"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "anything", "field": "state"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "stateANYTHING"
@@ -791,7 +791,7 @@ class TestBuildQuery:
     async def test_empty_string(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test empty_string unary operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "empty_string", "field": "description"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "empty_string", "field": "description"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "descriptionEMPTYSTRING"
@@ -800,7 +800,7 @@ class TestBuildQuery:
     async def test_val_changes(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test val_changes unary operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "val_changes", "field": "state"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "val_changes", "field": "state"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "stateVALCHANGES"
@@ -810,7 +810,7 @@ class TestBuildQuery:
         """Test gt_field comparison operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "gt_field", "field": "sys_updated_on", "other_field": "sys_created_on"}]'
+            table="incident", conditions='[{"operator": "gt_field", "field": "sys_updated_on", "other_field": "sys_created_on"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -821,7 +821,7 @@ class TestBuildQuery:
         """Test same_as field comparison operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "same_as", "field": "assigned_to", "other_field": "opened_by"}]'
+            table="incident", conditions='[{"operator": "same_as", "field": "assigned_to", "other_field": "opened_by"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -834,7 +834,7 @@ class TestBuildQuery:
         """Field operators should accept 'value' as fallback for 'other_field'."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "lt_field", "field": "priority", "value": "impact"}]'
+            table="incident", conditions='[{"operator": "lt_field", "field": "priority", "value": "impact"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -846,7 +846,7 @@ class TestBuildQuery:
     ) -> None:
         """Field operators without other_field or value return error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "gt_field", "field": "priority"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "gt_field", "field": "priority"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
 
@@ -855,7 +855,7 @@ class TestBuildQuery:
         """Test between range operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "between", "field": "sys_created_on", "start": "2026-01-01", "end": "2026-12-31"}]'
+            table="incident", conditions='[{"operator": "between", "field": "sys_created_on", "start": "2026-01-01", "end": "2026-12-31"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -866,7 +866,7 @@ class TestBuildQuery:
         """between without end value returns error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "between", "field": "sys_created_on", "start": "2026-01-01"}]'
+            table="incident", conditions='[{"operator": "between", "field": "sys_created_on", "start": "2026-01-01"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "error"
@@ -876,7 +876,7 @@ class TestBuildQuery:
         """Test datepart operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "datepart", "field": "sys_created_on", "part": "dayofweek", "dp_operator": "=", "dp_value": "1"}]'
+            table="incident", conditions='[{"operator": "datepart", "field": "sys_created_on", "part": "dayofweek", "dp_operator": "=", "dp_value": "1"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -886,7 +886,7 @@ class TestBuildQuery:
     async def test_datepart_missing_part(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """datepart without required params returns error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "datepart", "field": "sys_created_on"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "datepart", "field": "sys_created_on"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
 
@@ -895,7 +895,7 @@ class TestBuildQuery:
         """Test on date operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "on", "field": "sys_created_on", "value": "2026-01-15"}]'
+            table="incident", conditions='[{"operator": "on", "field": "sys_created_on", "value": "2026-01-15"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -906,7 +906,7 @@ class TestBuildQuery:
         """Test relative_gt date operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "relative_gt", "field": "sys_created_on", "value": "@year@ago@1"}]'
+            table="incident", conditions='[{"operator": "relative_gt", "field": "sys_created_on", "value": "@year@ago@1"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -917,7 +917,7 @@ class TestBuildQuery:
         """Test more_than date operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "more_than", "field": "sys_updated_on", "value": "@hour@ago@3"}]'
+            table="incident", conditions='[{"operator": "more_than", "field": "sys_updated_on", "value": "@hour@ago@3"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -927,7 +927,7 @@ class TestBuildQuery:
     async def test_changes_from(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test changes_from change detection operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "changes_from", "field": "priority", "value": "3"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "changes_from", "field": "priority", "value": "3"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "priorityCHANGESFROM3"
@@ -936,7 +936,7 @@ class TestBuildQuery:
     async def test_changes_to(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Test changes_to change detection operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["build_query"](conditions='[{"operator": "changes_to", "field": "state", "value": "6"}]')
+        raw = await tools["build_query"](table="incident", conditions='[{"operator": "changes_to", "field": "state", "value": "6"}]')
         result = decode_response(raw)
         assert result["status"] == "success"
         assert result["data"]["query"] == "stateCHANGESTO6"
@@ -946,7 +946,7 @@ class TestBuildQuery:
         """Test dynamic reference operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "dynamic", "field": "cmdb_ci", "value": "javascript:getCIFilter()"}]'
+            table="incident", conditions='[{"operator": "dynamic", "field": "cmdb_ci", "value": "javascript:getCIFilter()"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -957,7 +957,7 @@ class TestBuildQuery:
         """Test in_hierarchy reference operator."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "in_hierarchy", "field": "cmdb_ci", "value": "abc123"}]'
+            table="incident", conditions='[{"operator": "in_hierarchy", "field": "cmdb_ci", "value": "abc123"}]'
         )
         result = decode_response(raw)
         assert result["status"] == "success"
@@ -974,7 +974,7 @@ class TestBuildQuery:
                 {"operator": "equals", "field": "priority", "value": "1"},
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert "NQ" in result["data"]["query"]
@@ -995,7 +995,7 @@ class TestBuildQuery:
                 },
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "success"
         assert "RLQUERY" in result["data"]["query"]
@@ -1015,7 +1015,7 @@ class TestBuildQuery:
                 },
             ]
         )
-        raw = await tools["build_query"](conditions=conditions)
+        raw = await tools["build_query"](table="incident", conditions=conditions)
         result = decode_response(raw)
         assert result["status"] == "error"
 
@@ -1026,7 +1026,7 @@ class TestBuildQuery:
         """Time operator with non-integer value returns structured error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": "hours_ago", "field": "sys_created_on", "value": "abc"}]',
+            table="incident", conditions='[{"operator": "hours_ago", "field": "sys_created_on", "value": "abc"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "error"
@@ -1039,7 +1039,7 @@ class TestBuildQuery:
         """Non-string operator value returns type error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["build_query"](
-            conditions='[{"operator": 123, "field": "state"}]',
+            table="incident", conditions='[{"operator": 123, "field": "state"}]',
         )
         result = decode_response(raw)
         assert result["status"] == "error"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -203,7 +203,7 @@ class TestAtfGetTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_test"](test_id="missing")
+        raw = await tools["atf_get_test"](test_id="f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -524,7 +524,7 @@ class TestAtfRunTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_test"](test_id="test_no_id", poll=True)
+        raw = await tools["atf_run_test"](test_id="11110000000000000000000000000000", poll=True)
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -537,7 +537,7 @@ class TestAtfRunTest:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "exec_timeout"}},
+                json={"result": {"snboqId": "01010101010101010101010101010101"}},
             )
         )
         # Progress always in progress
@@ -550,7 +550,7 @@ class TestAtfRunTest:
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["atf_run_test"](
-            test_id="test_long",
+            test_id="22220000000000000000000000000000",
             poll=True,
             poll_interval=2,
             max_poll_duration=10,
@@ -559,7 +559,7 @@ class TestAtfRunTest:
 
         assert result["status"] == "success"
         assert result["data"]["status"] == "polling_timeout"
-        assert result["data"]["execution_id"] == "exec_timeout"
+        assert result["data"]["execution_id"] == "01010101010101010101010101010101"
         assert result["data"]["last_known_state"] == "in progress"
         assert "warnings" in result
 
@@ -570,7 +570,7 @@ class TestAtfRunTest:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "exec_fail"}},
+                json={"result": {"snboqId": "02020202020202020202020202020202"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/sn_atf_tg/test_runner_progress").mock(
@@ -582,7 +582,7 @@ class TestAtfRunTest:
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["atf_run_test"](
-            test_id="test_fail",
+            test_id="33330000000000000000000000000000",
             poll=True,
             poll_interval=2,
             max_poll_duration=10,
@@ -591,7 +591,7 @@ class TestAtfRunTest:
 
         assert result["status"] == "success"
         assert result["data"]["status"] == "failure"
-        assert result["data"]["execution_id"] == "exec_fail"
+        assert result["data"]["execution_id"] == "02020202020202020202020202020202"
 
 
 class TestAtfRunSuite:
@@ -604,7 +604,7 @@ class TestAtfRunSuite:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "suite_exec123"}},
+                json={"result": {"snboqId": "03030303030303030303030303030303"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/sn_atf_tg/test_runner_progress").mock(
@@ -624,7 +624,7 @@ class TestAtfRunSuite:
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["execution_id"] == "suite_exec123"
+        assert result["data"]["execution_id"] == "03030303030303030303030303030303"
         assert result["data"]["status"] == "completed"
         assert result["data"]["suite_id"] == "5761f555263e769e9d805337dbe8314c"
 
@@ -635,16 +635,16 @@ class TestAtfRunSuite:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "suite_no_poll"}},
+                json={"result": {"snboqId": "04040404040404040404040404040404"}},
             )
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_suite"](suite_id="suite_fast", poll=False)
+        raw = await tools["atf_run_suite"](suite_id="44440000000000000000000000000000", poll=False)
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["execution_id"] == "suite_no_poll"
+        assert result["data"]["execution_id"] == "04040404040404040404040404040404"
         assert result["data"]["status"] == "started"
         assert result["data"]["polling"] is False
 
@@ -673,7 +673,7 @@ class TestAtfRunSuite:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_suite"](suite_id="suite_no_id", poll=True)
+        raw = await tools["atf_run_suite"](suite_id="55550000000000000000000000000000", poll=True)
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -686,7 +686,7 @@ class TestAtfRunSuite:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "suite_exec_timeout"}},
+                json={"result": {"snboqId": "05050505050505050505050505050505"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/sn_atf_tg/test_runner_progress").mock(
@@ -698,7 +698,7 @@ class TestAtfRunSuite:
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["atf_run_suite"](
-            suite_id="suite_long",
+            suite_id="66660000000000000000000000000000",
             poll=True,
             poll_interval=2,
             max_poll_duration=10,
@@ -707,8 +707,8 @@ class TestAtfRunSuite:
 
         assert result["status"] == "success"
         assert result["data"]["status"] == "polling_timeout"
-        assert result["data"]["execution_id"] == "suite_exec_timeout"
-        assert result["data"]["suite_id"] == "suite_long"
+        assert result["data"]["execution_id"] == "05050505050505050505050505050505"
+        assert result["data"]["suite_id"] == "66660000000000000000000000000000"
         assert result["data"]["last_known_state"] == "in progress"
         assert "warnings" in result
 
@@ -719,7 +719,7 @@ class TestAtfRunSuite:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "suite_cancel"}},
+                json={"result": {"snboqId": "06060606060606060606060606060606"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/sn_atf_tg/test_runner_progress").mock(
@@ -731,7 +731,7 @@ class TestAtfRunSuite:
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["atf_run_suite"](
-            suite_id="suite_cancel",
+            suite_id="77770000000000000000000000000000",
             poll=True,
             poll_interval=2,
             max_poll_duration=10,
@@ -740,7 +740,7 @@ class TestAtfRunSuite:
 
         assert result["status"] == "success"
         assert result["data"]["status"] == "cancelled"
-        assert result["data"]["execution_id"] == "suite_cancel"
+        assert result["data"]["execution_id"] == "06060606060606060606060606060606"
 
 
 class TestAtfTestHealth:
@@ -768,7 +768,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test_stable", days=30, limit=50)
+        raw = await tools["atf_test_health"](test_id="88880000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -800,7 +800,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test_flaky", days=30, limit=50)
+        raw = await tools["atf_test_health"](test_id="99990000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -863,7 +863,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test_degrading", days=30, limit=50)
+        raw = await tools["atf_test_health"](test_id="aaaa0000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -883,7 +883,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test_no_data", days=30, limit=50)
+        raw = await tools["atf_test_health"](test_id="bbbb0000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -972,7 +972,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test_improving", days=30, limit=50)
+        raw = await tools["atf_test_health"](test_id="cccc0000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1005,7 +1005,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test_few_runs", days=30, limit=50)
+        raw = await tools["atf_test_health"](test_id="dddd0000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1034,7 +1034,7 @@ class TestAtfTestHealth:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](suite_id="suite_healthy", days=30, limit=50)
+        raw = await tools["atf_test_health"](suite_id="eeee0000000000000000000000000000", days=30, limit=50)
         result = decode_response(raw)
 
         assert result["status"] == "success"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -405,7 +405,9 @@ class TestAtfGetResults:
     async def test_get_results_both_ids_provided(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns error when both test_id and suite_id are provided."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_results"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28", suite_id="5fbf10a1272bc00c1777003333454539")
+        raw = await tools["atf_get_results"](
+            test_id="7288edd0fc3ffcbe93a0cf06e3568e28", suite_id="5fbf10a1272bc00c1777003333454539"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -465,7 +467,9 @@ class TestAtfRunTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_test"](test_id="a51821834d0fe748cf923a6ee607e647", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_test"](
+            test_id="a51821834d0fe748cf923a6ee607e647", poll=True, poll_interval=2, max_poll_duration=10
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -902,7 +906,9 @@ class TestAtfTestHealth:
     async def test_health_both_ids_provided(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Call with both test_id and suite_id. Assert error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28", suite_id="5fbf10a1272bc00c1777003333454539")
+        raw = await tools["atf_test_health"](
+            test_id="7288edd0fc3ffcbe93a0cf06e3568e28", suite_id="5fbf10a1272bc00c1777003333454539"
+        )
         result = decode_response(raw)
 
         assert result["status"] == "error"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -51,7 +51,7 @@ class TestAtfListTests:
                 json={
                     "result": [
                         {
-                            "sys_id": "test1",
+                            "sys_id": "b444ac06613fc8d63795be9ad0beaf55",
                             "name": "Validate incident creation",
                             "description": "Test incident table automation",
                             "active": "true",
@@ -59,7 +59,7 @@ class TestAtfListTests:
                             "test_origin": "manual",
                         },
                         {
-                            "sys_id": "test2",
+                            "sys_id": "109f4b3c50d7b0df729d299bc6f8e9ef",
                             "name": "Check user permissions",
                             "description": "Verify ITIL role assignment",
                             "active": "true",
@@ -78,8 +78,8 @@ class TestAtfListTests:
 
         assert result["status"] == "success"
         assert result["data"]["record_count"] == 2
-        assert result["data"]["records"][0]["sys_id"] == "test1"
-        assert result["data"]["records"][1]["sys_id"] == "test2"
+        assert result["data"]["records"][0]["sys_id"] == "b444ac06613fc8d63795be9ad0beaf55"
+        assert result["data"]["records"][1]["sys_id"] == "109f4b3c50d7b0df729d299bc6f8e9ef"
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -91,7 +91,7 @@ class TestAtfListTests:
                 json={
                     "result": [
                         {
-                            "sys_id": "test1",
+                            "sys_id": "b444ac06613fc8d63795be9ad0beaf55",
                             "name": "Active test only",
                             "description": "Test",
                             "active": "true",
@@ -143,12 +143,12 @@ class TestAtfGetTest:
     async def test_get_test_success(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns test record and steps in combined response."""
         # Mock test record
-        respx.get(f"{BASE_URL}/api/now/table/sys_atf_test/test123").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_atf_test/7288edd0fc3ffcbe93a0cf06e3568e28").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "test123",
+                        "sys_id": "7288edd0fc3ffcbe93a0cf06e3568e28",
                         "name": "Incident workflow test",
                         "description": "Validates incident state transitions",
                         "active": "true",
@@ -163,14 +163,14 @@ class TestAtfGetTest:
                 json={
                     "result": [
                         {
-                            "sys_id": "step1",
+                            "sys_id": "84f1443f50ba4a894ac616a5f064c686",
                             "display_name": "Open record",
                             "step_config": "Record Producer",
                             "order": "1",
                             "inputs": "{}",
                         },
                         {
-                            "sys_id": "step2",
+                            "sys_id": "4a663a0c99bf1bd49e069a66286dda78",
                             "display_name": "Validate state",
                             "step_config": "Field Values Validation",
                             "order": "2",
@@ -183,11 +183,11 @@ class TestAtfGetTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_test"](test_id="test123")
+        raw = await tools["atf_get_test"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["test"]["sys_id"] == "test123"
+        assert result["data"]["test"]["sys_id"] == "7288edd0fc3ffcbe93a0cf06e3568e28"
         assert result["data"]["step_count"] == 2
         assert len(result["data"]["steps"]) == 2
 
@@ -212,12 +212,12 @@ class TestAtfGetTest:
     @respx.mock
     async def test_get_test_with_steps(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns test with 3 steps ordered correctly."""
-        respx.get(f"{BASE_URL}/api/now/table/sys_atf_test/test456").mock(
+        respx.get(f"{BASE_URL}/api/now/table/sys_atf_test/a51821834d0fe748cf923a6ee607e647").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "test456",
+                        "sys_id": "a51821834d0fe748cf923a6ee607e647",
                         "name": "Multi-step test",
                         "description": "Complex workflow",
                         "active": "true",
@@ -231,21 +231,21 @@ class TestAtfGetTest:
                 json={
                     "result": [
                         {
-                            "sys_id": "s1",
+                            "sys_id": "640d87e741e6aa4c669a82a4cd304787",
                             "display_name": "Step 1",
                             "order": "1",
                             "step_config": "Config",
                             "inputs": "{}",
                         },
                         {
-                            "sys_id": "s2",
+                            "sys_id": "4205714cdfe14ed9e3d030ddf7887781",
                             "display_name": "Step 2",
                             "order": "2",
                             "step_config": "Config",
                             "inputs": "{}",
                         },
                         {
-                            "sys_id": "s3",
+                            "sys_id": "dd33a084ba223dd231b0aa962f77a592",
                             "display_name": "Step 3",
                             "order": "3",
                             "step_config": "Config",
@@ -258,7 +258,7 @@ class TestAtfGetTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_test"](test_id="test456")
+        raw = await tools["atf_get_test"](test_id="a51821834d0fe748cf923a6ee607e647")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -282,7 +282,7 @@ class TestAtfListSuites:
                 json={
                     "result": [
                         {
-                            "sys_id": "suite1",
+                            "sys_id": "617a1ac5c6b3bf6aa248f570575c6752",
                             "name": "Regression Suite",
                             "description": "Full regression tests",
                             "active": "true",
@@ -307,7 +307,7 @@ class TestAtfListSuites:
 
         assert result["status"] == "success"
         assert result["data"]["record_count"] == 1
-        assert result["data"]["suites"][0]["sys_id"] == "suite1"
+        assert result["data"]["suites"][0]["sys_id"] == "617a1ac5c6b3bf6aa248f570575c6752"
         assert result["data"]["suites"][0]["member_count"] == "5"
 
     @pytest.mark.asyncio()
@@ -344,7 +344,7 @@ class TestAtfGetResults:
                 json={
                     "result": [
                         {
-                            "sys_id": "result1",
+                            "sys_id": "e80eb64ba7e143bde0ea09702b4417a7",
                             "status": "success",
                             "start_time": "2026-02-20 10:00:00",
                             "end_time": "2026-02-20 10:00:15",
@@ -359,7 +359,7 @@ class TestAtfGetResults:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_results"](test_id="test123")
+        raw = await tools["atf_get_results"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -393,7 +393,7 @@ class TestAtfGetResults:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_results"](suite_id="suite456")
+        raw = await tools["atf_get_results"](suite_id="5fbf10a1272bc00c1777003333454539")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -405,7 +405,7 @@ class TestAtfGetResults:
     async def test_get_results_both_ids_provided(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns error when both test_id and suite_id are provided."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_results"](test_id="test123", suite_id="suite456")
+        raw = await tools["atf_get_results"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28", suite_id="5fbf10a1272bc00c1777003333454539")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -434,7 +434,7 @@ class TestAtfGetResults:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_get_results"](test_id="test999")
+        raw = await tools["atf_get_results"](test_id="6d851dca996d8dc604e7625e49045f60")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -453,7 +453,7 @@ class TestAtfRunTest:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "exec123"}},
+                json={"result": {"snboqId": "251cd4a5ab4671b4df3e44be2bfb2635"}},
             )
         )
         # Mock progress endpoint - completed immediately
@@ -465,14 +465,14 @@ class TestAtfRunTest:
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_test"](test_id="test456", poll=True, poll_interval=2, max_poll_duration=10)
+        raw = await tools["atf_run_test"](test_id="a51821834d0fe748cf923a6ee607e647", poll=True, poll_interval=2, max_poll_duration=10)
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["execution_id"] == "exec123"
+        assert result["data"]["execution_id"] == "251cd4a5ab4671b4df3e44be2bfb2635"
         assert result["data"]["status"] == "completed"
         assert result["data"]["progress"] == 100
-        assert result["data"]["test_id"] == "test456"
+        assert result["data"]["test_id"] == "a51821834d0fe748cf923a6ee607e647"
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -481,19 +481,19 @@ class TestAtfRunTest:
         respx.post(f"{BASE_URL}/api/now/sn_atf_tg/test_runner").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"snboqId": "exec789"}},
+                json={"result": {"snboqId": "6d870f06aaaf54f00bca318fe10612d4"}},
             )
         )
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_run_test"](test_id="test999", poll=False)
+        raw = await tools["atf_run_test"](test_id="6d851dca996d8dc604e7625e49045f60", poll=False)
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["execution_id"] == "exec789"
+        assert result["data"]["execution_id"] == "6d870f06aaaf54f00bca318fe10612d4"
         assert result["data"]["status"] == "started"
         assert result["data"]["polling"] is False
-        assert result["data"]["test_id"] == "test999"
+        assert result["data"]["test_id"] == "6d851dca996d8dc604e7625e49045f60"
 
     @pytest.mark.asyncio()
     async def test_run_test_write_gate_blocks(
@@ -502,7 +502,7 @@ class TestAtfRunTest:
         """Write gate blocks execution in production environment."""
         tools, _query_store = _register_and_get_tools(prod_settings, prod_auth_provider)
 
-        raw = await tools["atf_run_test"](test_id="test123")
+        raw = await tools["atf_run_test"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -612,7 +612,7 @@ class TestAtfRunSuite:
 
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
         raw = await tools["atf_run_suite"](
-            suite_id="suite789",
+            suite_id="5761f555263e769e9d805337dbe8314c",
             poll=True,
             poll_interval=2,
             max_poll_duration=10,
@@ -622,7 +622,7 @@ class TestAtfRunSuite:
         assert result["status"] == "success"
         assert result["data"]["execution_id"] == "suite_exec123"
         assert result["data"]["status"] == "completed"
-        assert result["data"]["suite_id"] == "suite789"
+        assert result["data"]["suite_id"] == "5761f555263e769e9d805337dbe8314c"
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -651,7 +651,7 @@ class TestAtfRunSuite:
         """Write gate blocks suite execution in production."""
         tools, _query_store = _register_and_get_tools(prod_settings, prod_auth_provider)
 
-        raw = await tools["atf_run_suite"](suite_id="suite999")
+        raw = await tools["atf_run_suite"](suite_id="7cce8eebf30cbc1823469b4830873c8c")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -813,42 +813,42 @@ class TestAtfTestHealth:
                 json={
                     "result": [
                         {
-                            "sys_id": "r1",
+                            "sys_id": "5573e39b6600496d40f493d00ec76584",
                             "status": "success",
                             "sys_created_on": "2026-02-01 10:00:00",
                         },
                         {
-                            "sys_id": "r2",
+                            "sys_id": "a50126cc2d6c726de0ca203c3b659f65",
                             "status": "success",
                             "sys_created_on": "2026-02-02 10:00:00",
                         },
                         {
-                            "sys_id": "r3",
+                            "sys_id": "aa893358be4b506d8aeb52b29b8a9cac",
                             "status": "success",
                             "sys_created_on": "2026-02-03 10:00:00",
                         },
                         {
-                            "sys_id": "r4",
+                            "sys_id": "7e264138d0ca103b872057862b9b0359",
                             "status": "success",
                             "sys_created_on": "2026-02-04 10:00:00",
                         },
                         {
-                            "sys_id": "r5",
+                            "sys_id": "51236c5daf199e04c283254bc3ac655a",
                             "status": "failure",
                             "sys_created_on": "2026-02-05 10:00:00",
                         },
                         {
-                            "sys_id": "r6",
+                            "sys_id": "9bf579a927659749fe98171e8ab27ac0",
                             "status": "failure",
                             "sys_created_on": "2026-02-06 10:00:00",
                         },
                         {
-                            "sys_id": "r7",
+                            "sys_id": "daf1ccf042adbc9eba53bea801d6170e",
                             "status": "failure",
                             "sys_created_on": "2026-02-07 10:00:00",
                         },
                         {
-                            "sys_id": "r8",
+                            "sys_id": "4e436c8053f56559b1b98f9168983e4d",
                             "status": "failure",
                             "sys_created_on": "2026-02-08 10:00:00",
                         },
@@ -902,7 +902,7 @@ class TestAtfTestHealth:
     async def test_health_both_ids_provided(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Call with both test_id and suite_id. Assert error."""
         tools, _query_store = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["atf_test_health"](test_id="test123", suite_id="suite456")
+        raw = await tools["atf_test_health"](test_id="7288edd0fc3ffcbe93a0cf06e3568e28", suite_id="5fbf10a1272bc00c1777003333454539")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -920,42 +920,42 @@ class TestAtfTestHealth:
                 json={
                     "result": [
                         {
-                            "sys_id": "r1",
+                            "sys_id": "5573e39b6600496d40f493d00ec76584",
                             "status": "failure",
                             "sys_created_on": "2026-02-01 10:00:00",
                         },
                         {
-                            "sys_id": "r2",
+                            "sys_id": "a50126cc2d6c726de0ca203c3b659f65",
                             "status": "failure",
                             "sys_created_on": "2026-02-02 10:00:00",
                         },
                         {
-                            "sys_id": "r3",
+                            "sys_id": "aa893358be4b506d8aeb52b29b8a9cac",
                             "status": "failure",
                             "sys_created_on": "2026-02-03 10:00:00",
                         },
                         {
-                            "sys_id": "r4",
+                            "sys_id": "7e264138d0ca103b872057862b9b0359",
                             "status": "failure",
                             "sys_created_on": "2026-02-04 10:00:00",
                         },
                         {
-                            "sys_id": "r5",
+                            "sys_id": "51236c5daf199e04c283254bc3ac655a",
                             "status": "success",
                             "sys_created_on": "2026-02-05 10:00:00",
                         },
                         {
-                            "sys_id": "r6",
+                            "sys_id": "9bf579a927659749fe98171e8ab27ac0",
                             "status": "success",
                             "sys_created_on": "2026-02-06 10:00:00",
                         },
                         {
-                            "sys_id": "r7",
+                            "sys_id": "daf1ccf042adbc9eba53bea801d6170e",
                             "status": "success",
                             "sys_created_on": "2026-02-07 10:00:00",
                         },
                         {
-                            "sys_id": "r8",
+                            "sys_id": "4e436c8053f56559b1b98f9168983e4d",
                             "status": "success",
                             "sys_created_on": "2026-02-08 10:00:00",
                         },
@@ -983,12 +983,12 @@ class TestAtfTestHealth:
                 json={
                     "result": [
                         {
-                            "sys_id": "r1",
+                            "sys_id": "5573e39b6600496d40f493d00ec76584",
                             "status": "success",
                             "sys_created_on": "2026-02-01 10:00:00",
                         },
                         {
-                            "sys_id": "r2",
+                            "sys_id": "a50126cc2d6c726de0ca203c3b659f65",
                             "status": "failure",
                             "sys_created_on": "2026-02-02 10:00:00",
                         },

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -105,7 +105,7 @@ class TestAtfListTests:
         )
 
         tools, query_store = _register_and_get_tools(settings, auth_provider)
-        token = query_store.create({"query": "active=true"})
+        token = query_store.create({"query": "active=true", "table": "sys_atf_test"})
         raw = await tools["atf_list_tests"](query_token=token)
         result = decode_response(raw)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1132,3 +1132,80 @@ class TestValidateSysId:
     def test_empty_string(self) -> None:
         with pytest.raises(ValueError, match="Invalid sys_id"):
             validate_sys_id("")
+
+
+# ---------------------------------------------------------------------------
+# resolve_query_token - table binding enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestResolveQueryTokenTableBinding:
+    """Tests for the table-binding check inside resolve_query_token.
+
+    Phase 4 (MED-1) binds every query token to the table it was built for,
+    so a token built against one table cannot be replayed against another.
+    """
+
+    def test_matching_table_resolves_to_query(self) -> None:
+        """Token whose payload.table matches expected_table returns the query."""
+        from servicenow_mcp.state import QueryTokenStore
+        from servicenow_mcp.utils import resolve_query_token
+
+        store = QueryTokenStore(ttl_seconds=60)
+        token = store.create({"table": "incident", "query": "active=true"})
+
+        resolved = resolve_query_token(token, store, "incident", correlation_id="cid-1")
+
+        assert resolved == "active=true"
+
+    def test_mismatched_table_raises_policy_error(self) -> None:
+        """A token built for one table cannot be used against another."""
+        from servicenow_mcp.errors import PolicyError
+        from servicenow_mcp.state import QueryTokenStore
+        from servicenow_mcp.utils import resolve_query_token
+
+        store = QueryTokenStore(ttl_seconds=60)
+        # Pretend the caller built a query for sys_properties, then tried to
+        # replay it against incident.
+        token = store.create({"table": "sys_properties", "query": "name=glide.ui.session_timeout"})
+
+        with pytest.raises(PolicyError, match="built for table 'sys_properties'"):
+            resolve_query_token(token, store, "incident", correlation_id="cid-1")
+
+    def test_missing_table_key_raises_policy_error(self) -> None:
+        """QueryTokenStore.create rejects payloads that lack a 'table' key.
+
+        This is a hard structural invariant: unbound tokens cannot exist, so
+        the table-binding check inside resolve_query_token can never be
+        bypassed by a malformed payload reaching a tool call path.
+        """
+        from servicenow_mcp.state import QueryTokenStore
+
+        store = QueryTokenStore(ttl_seconds=60)
+
+        with pytest.raises(ValueError, match="non-empty 'table' key"):
+            store.create({"query": "active=true"})  # no 'table' key
+
+        with pytest.raises(ValueError, match="non-empty 'table' key"):
+            store.create({"table": "", "query": "active=true"})  # empty table
+
+    def test_empty_token_returns_empty_string(self) -> None:
+        """Empty token is a no-op - resolves to an empty query without table check."""
+        from servicenow_mcp.state import QueryTokenStore
+        from servicenow_mcp.utils import resolve_query_token
+
+        store = QueryTokenStore(ttl_seconds=60)
+
+        resolved = resolve_query_token("", store, "incident", correlation_id="cid-1")
+
+        assert resolved == ""
+
+    def test_invalid_token_raises_value_error(self) -> None:
+        """An unknown or expired token raises ValueError (not PolicyError)."""
+        from servicenow_mcp.state import QueryTokenStore
+        from servicenow_mcp.utils import resolve_query_token
+
+        store = QueryTokenStore(ttl_seconds=60)
+
+        with pytest.raises(ValueError, match="Invalid or expired query token"):
+            resolve_query_token("nonexistent-token", store, "incident", correlation_id="cid-1")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1133,6 +1133,37 @@ class TestValidateSysId:
         with pytest.raises(ValueError, match="Invalid sys_id"):
             validate_sys_id("")
 
+    @pytest.mark.parametrize(
+        "attack",
+        [
+            "../../etc/passwd",
+            "%2e%2e%2f",
+            "a" * 31 + "/",
+            "/" + "a" * 31,
+            "a" * 16 + "/" + "a" * 15,
+            "a" * 32 + "/../other",
+            "a" * 32 + "?sysparm_fields=password",
+            "a" * 32 + "#fragment",
+            "a" * 32 + "&admin=true",
+            "a" * 32 + "\x00",
+            "a" * 32 + " ",
+            " " + "a" * 32,
+            "a" * 32 + "\n",
+        ],
+    )
+    def test_rejects_path_traversal_and_smuggling(self, attack: str) -> None:
+        """validate_sys_id must reject any string containing URL/path metacharacters.
+
+        The 32-hex regex is the single chokepoint that guarantees sys_id values
+        can be safely interpolated into REST URL paths. This test asserts the
+        regex anchors (``^...$``) and character class hold against the most
+        common injection shapes: directory traversal, URL-encoded traversal,
+        query-string smuggling, fragment appending, null bytes, and whitespace
+        padding.
+        """
+        with pytest.raises(ValueError, match="Invalid sys_id"):
+            validate_sys_id(attack)
+
 
 # ---------------------------------------------------------------------------
 # resolve_query_token - table binding enforcement

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -642,12 +642,12 @@ class TestWorkflowStatus:
     @respx.mock
     async def test_empty_executing_all_completed(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns empty executing list when all activities have finished."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx_done").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/c7d0e000000000000000000000000001").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx_done",
+                        "sys_id": "c7d0e000000000000000000000000001",
                         "name": "Completed WF",
                         "state": "Finished",
                         "started": "2026-02-20 08:00:00",
@@ -682,7 +682,7 @@ class TestWorkflowStatus:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_status"](context_sys_id="ctx_done")
+        raw = await tools["workflow_status"](context_sys_id="c7d0e000000000000000000000000001")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -693,12 +693,12 @@ class TestWorkflowStatus:
     @respx.mock
     async def test_multiple_executing_activities(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns multiple currently-executing activities."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx_multi").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/c7d0e000000000000000000000000002").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx_multi",
+                        "sys_id": "c7d0e000000000000000000000000002",
                         "name": "Parallel WF",
                         "state": "Executing",
                     }
@@ -744,7 +744,7 @@ class TestWorkflowStatus:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_status"](context_sys_id="ctx_multi")
+        raw = await tools["workflow_status"](context_sys_id="c7d0e000000000000000000000000002")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -754,12 +754,12 @@ class TestWorkflowStatus:
     @respx.mock
     async def test_history_with_faults(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns history entries with populated fault_description."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx_fault").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/c7d0e000000000000000000000000003").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx_fault",
+                        "sys_id": "c7d0e000000000000000000000000003",
                         "name": "Faulted WF",
                         "state": "Finished",
                     }
@@ -803,7 +803,7 @@ class TestWorkflowStatus:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_status"](context_sys_id="ctx_fault")
+        raw = await tools["workflow_status"](context_sys_id="c7d0e000000000000000000000000003")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -906,7 +906,14 @@ class TestWorkflowActivityDetail:
         assert result["data"]["definition"]["name"] == "Approval - User"
         assert result["data"]["definition"]["category"] == "Approvals"
         assert len(result["data"]["variables"]) == 1
-        assert result["data"]["variables"][0]["value"] == "current.state = 2;"
+        # Script-body masking is on by default; this assertion covers the
+        # unmasked round-trip path exposed by ``include_script_body=True``.
+        raw_with_body = await tools["workflow_activity_detail"](
+            activity_sys_id="a37b4556fc38ce6b2a3fd1521b1291bc",
+            include_script_body=True,
+        )
+        result_with_body = decode_response(raw_with_body)
+        assert result_with_body["data"]["variables"][0]["value"] == "current.state = 2;"
 
     @pytest.mark.asyncio()
     @respx.mock
@@ -1016,7 +1023,10 @@ class TestWorkflowActivityDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_activity_detail"](activity_sys_id="20de94ee488dbd2b7154c3afbf85cd22")
+        raw = await tools["workflow_activity_detail"](
+            activity_sys_id="20de94ee488dbd2b7154c3afbf85cd22",
+            include_script_body=True,
+        )
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1269,7 +1279,7 @@ class TestWorkflowDictReferenceFields:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """workflow_activity_detail handles activity_definition returned as a dict."""
-        dict_definition = {"display_value": "act_def_001", "link": "https://test.service-now.com/api/..."}
+        dict_definition = {"display_value": "ac7de000000000000000000000000001", "link": "https://test.service-now.com/api/..."}
 
         # Phase 1: raw activity with dict reference
         respx.get(f"{BASE_URL}/api/now/table/wf_activity/2eac3cfb70af19b72304086d2d97c52d").mock(
@@ -1301,10 +1311,10 @@ class TestWorkflowDictReferenceFields:
         respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
-        respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/act_def_001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/ac7de000000000000000000000000001").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "act_def_001", "name": "Run Script Definition"}},
+                json={"result": {"sys_id": "ac7de000000000000000000000000001", "name": "Run Script Definition"}},
             )
         )
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -864,7 +864,9 @@ class TestWorkflowActivityDetail:
             )
             return httpx.Response(200, json={"result": result})
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/a37b4556fc38ce6b2a3fd1521b1291bc").mock(side_effect=_act001_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/a37b4556fc38ce6b2a3fd1521b1291bc").mock(
+            side_effect=_act001_side_effect
+        )
         # Phase 2: element definition with display values
         respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/f45ee39efdcca5805d1e7e2eaa97f27b").mock(
             return_value=httpx.Response(
@@ -935,7 +937,9 @@ class TestWorkflowActivityDetail:
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/a40bb1d2559337415c49dfd982cf2fe2").mock(side_effect=_nodef_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/a40bb1d2559337415c49dfd982cf2fe2").mock(
+            side_effect=_nodef_side_effect
+        )
         respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
@@ -986,7 +990,9 @@ class TestWorkflowActivityDetail:
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/20de94ee488dbd2b7154c3afbf85cd22").mock(side_effect=_act_vars_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/20de94ee488dbd2b7154c3afbf85cd22").mock(
+            side_effect=_act_vars_side_effect
+        )
         respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/def_script").mock(
             return_value=httpx.Response(
                 200,
@@ -1213,11 +1219,19 @@ class TestWorkflowDictReferenceFields:
         activity_definition and document_key are the ones that may come back
         as dicts when display_value query params are used.
         """
-        dict_activity_def = {"display_value": "f45ee39efdcca5805d1e7e2eaa97f27b", "link": "https://test.service-now.com/api/..."}
-        dict_doc_key = {"display_value": "a37b4556fc38ce6b2a3fd1521b1291bc", "link": "https://test.service-now.com/api/..."}
+        dict_activity_def = {
+            "display_value": "f45ee39efdcca5805d1e7e2eaa97f27b",
+            "link": "https://test.service-now.com/api/...",
+        }
+        dict_doc_key = {
+            "display_value": "a37b4556fc38ce6b2a3fd1521b1291bc",
+            "link": "https://test.service-now.com/api/...",
+        }
 
         respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/789b9a03486e4434d8e435a024103c95").mock(
-            return_value=httpx.Response(200, json={"result": {"sys_id": "789b9a03486e4434d8e435a024103c95", "name": "Test WF"}})
+            return_value=httpx.Response(
+                200, json={"result": {"sys_id": "789b9a03486e4434d8e435a024103c95", "name": "Test WF"}}
+            )
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
             return_value=httpx.Response(
@@ -1279,7 +1293,10 @@ class TestWorkflowDictReferenceFields:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """workflow_activity_detail handles activity_definition returned as a dict."""
-        dict_definition = {"display_value": "ac7de000000000000000000000000001", "link": "https://test.service-now.com/api/..."}
+        dict_definition = {
+            "display_value": "ac7de000000000000000000000000001",
+            "link": "https://test.service-now.com/api/...",
+        }
 
         # Phase 1: raw activity with dict reference
         respx.get(f"{BASE_URL}/api/now/table/wf_activity/2eac3cfb70af19b72304086d2d97c52d").mock(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -73,12 +73,12 @@ class TestWorkflowContexts:
                 json={
                     "result": [
                         {
-                            "sys_id": "wfc001",
+                            "sys_id": "0b194673d7cf75a9b42d71790986d412",
                             "name": "Incident Workflow",
                             "state": "Executing",
                             "started": "2026-02-20 09:00:00",
                             "ended": "",
-                            "workflow_version": "wfv001",
+                            "workflow_version": "e35fec24db6d035c7a6fa33e76847858",
                             "table": "incident",
                             "result": "",
                             "running_duration": "00:05:00",
@@ -95,14 +95,14 @@ class TestWorkflowContexts:
                 json={
                     "result": [
                         {
-                            "sys_id": "fc001",
+                            "sys_id": "b45e2ae965e607a079b6677d64ba7c83",
                             "name": "Auto-assign Flow",
                             "state": "Completed",
                             "started": "2026-02-20 09:00:00",
                             "ended": "2026-02-20 09:00:05",
-                            "flow_version": "fv001",
+                            "flow_version": "fc9fb9c558787ac4d0406eeb7e1814ac",
                             "source_table": "incident",
-                            "source_record": "inc001",
+                            "source_record": "6d55028a7049dbf2f4275991d6fc81cf",
                         },
                     ]
                 },
@@ -111,7 +111,7 @@ class TestWorkflowContexts:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_contexts"](record_sys_id="inc001")
+        raw = await tools["workflow_contexts"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -132,7 +132,7 @@ class TestWorkflowContexts:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_contexts"](record_sys_id="inc999")
+        raw = await tools["workflow_contexts"](record_sys_id="2edef9aa2e99060fd11a80ae6eed85b5")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -149,12 +149,12 @@ class TestWorkflowContexts:
                 json={
                     "result": [
                         {
-                            "sys_id": "wfc002",
+                            "sys_id": "36ddcab7c62bc858d677d1883197e5c3",
                             "name": "Finished WF",
                             "state": "Finished",
                             "started": "2026-02-20 08:00:00",
                             "ended": "2026-02-20 08:05:00",
-                            "workflow_version": "wfv002",
+                            "workflow_version": "5780f78f6d55b5bf954f58a084659629",
                             "table": "incident",
                             "result": "success",
                             "running_duration": "00:05:00",
@@ -170,7 +170,7 @@ class TestWorkflowContexts:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_contexts"](record_sys_id="inc001", state="finished")
+        raw = await tools["workflow_contexts"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf", state="finished")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -192,7 +192,7 @@ class TestWorkflowContexts:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_contexts"](record_sys_id="inc001", table="incident")
+        raw = await tools["workflow_contexts"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf", table="incident")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -214,7 +214,7 @@ class TestWorkflowContexts:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_contexts"](record_sys_id="inc001")
+        raw = await tools["workflow_contexts"](record_sys_id="6d55028a7049dbf2f4275991d6fc81cf")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -234,13 +234,13 @@ class TestWorkflowMap:
     @respx.mock
     async def test_returns_full_map(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns version, activities, and transitions."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/e35fec24db6d035c7a6fa33e76847858").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "wfv001",
-                        "name": "Incident Workflow v2",
+                        "sys_id": "e35fec24db6d035c7a6fa33e76847858",
+                        "name": "Incident Workflow a1047eab1035d58682a53557e0b2a75e",
                         "table": "incident",
                         "active": "true",
                         "published": "true",
@@ -254,9 +254,9 @@ class TestWorkflowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "act001",
+                            "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                             "name": "Begin",
-                            "activity_definition": "def001",
+                            "activity_definition": "f45ee39efdcca5805d1e7e2eaa97f27b",
                             "activity_definition.name": "Begin",
                             "activity_definition.category": "Core",
                             "x": "50",
@@ -268,9 +268,9 @@ class TestWorkflowMap:
                             "stage": "",
                         },
                         {
-                            "sys_id": "act002",
+                            "sys_id": "6ae7ca85d4792cabe5bafd3b8d148725",
                             "name": "Approval",
-                            "activity_definition": "def002",
+                            "activity_definition": "b7c009d7ad464b132e5a45f7f541ac3e",
                             "activity_definition.name": "Approval - User",
                             "activity_definition.category": "Approvals",
                             "x": "200",
@@ -292,10 +292,10 @@ class TestWorkflowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "tr001",
-                            "from": "act001",
+                            "sys_id": "82b655b7980ce1431a5665bd5e3fc4fb",
+                            "from": "a37b4556fc38ce6b2a3fd1521b1291bc",
                             "from.name": "Begin",
-                            "to": "act002",
+                            "to": "6ae7ca85d4792cabe5bafd3b8d148725",
                             "to.name": "Approval",
                             "condition": "",
                         },
@@ -310,10 +310,10 @@ class TestWorkflowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "sv001",
+                            "sys_id": "eaa2e11f5972c0fd8e423f1c6234180d",
                             "variable": "var_def_001",
                             "value": "some_script_body",
-                            "document_key": "act002",
+                            "document_key": "6ae7ca85d4792cabe5bafd3b8d148725",
                         },
                     ]
                 },
@@ -322,11 +322,11 @@ class TestWorkflowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="wfv001")
+        raw = await tools["workflow_map"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["version"]["name"] == "Incident Workflow v2"
+        assert result["data"]["version"]["name"] == "Incident Workflow a1047eab1035d58682a53557e0b2a75e"
         assert len(result["data"]["activities"]) == 2
         assert len(result["data"]["transitions"]) == 1
         assert result["data"]["transitions"][0]["from.name"] == "Begin"
@@ -385,19 +385,19 @@ class TestWorkflowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "a1",
+                            "sys_id": "f29bc91bbdab169fc0c0a326965953d1",
                             "name": "First",
                             "x": "10",
                             "y": "50",
                         },
                         {
-                            "sys_id": "a2",
+                            "sys_id": "b9f85daa6f83cf02ce5c31913d1f64d3",
                             "name": "Second",
                             "x": "200",
                             "y": "50",
                         },
                         {
-                            "sys_id": "a3",
+                            "sys_id": "252bc06763afb3b6c2a0802f7346700a",
                             "name": "Third",
                             "x": "400",
                             "y": "50",
@@ -427,7 +427,7 @@ class TestWorkflowMap:
     @respx.mock
     async def test_error_on_missing_version(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns success with a warning when the workflow version is not found (graceful degradation)."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/bad_id").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/35a1af58a3b00bde3d8af97f82562ac2").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
@@ -438,7 +438,7 @@ class TestWorkflowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="bad_id")
+        raw = await tools["workflow_map"](workflow_version_sys_id="35a1af58a3b00bde3d8af97f82562ac2")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -461,13 +461,13 @@ class TestWorkflowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "a1",
+                            "sys_id": "f29bc91bbdab169fc0c0a326965953d1",
                             "name": "Script 1",
                             "x": "10",
                             "y": "50",
                         },
                         {
-                            "sys_id": "a2",
+                            "sys_id": "b9f85daa6f83cf02ce5c31913d1f64d3",
                             "name": "Script 2",
                             "x": "200",
                             "y": "50",
@@ -486,22 +486,22 @@ class TestWorkflowMap:
                 json={
                     "result": [
                         {
-                            "sys_id": "sv1",
-                            "variable": "var1",
+                            "sys_id": "30a262ee0cddf15a17abb23e11148aa3",
+                            "variable": "a1dd4114c98069523cdf1d90ff3a4322",
                             "value": "script_a1",
-                            "document_key": "a1",
+                            "document_key": "f29bc91bbdab169fc0c0a326965953d1",
                         },
                         {
-                            "sys_id": "sv2",
-                            "variable": "var2",
+                            "sys_id": "2f0c71c73a82a38798e5249c3cfcecd6",
+                            "variable": "9b63072850833c63c5200f2c35b3edc4",
                             "value": "script_a2",
-                            "document_key": "a2",
+                            "document_key": "b9f85daa6f83cf02ce5c31913d1f64d3",
                         },
                         {
-                            "sys_id": "sv3",
-                            "variable": "var3",
+                            "sys_id": "8c958ae3b81b07ee490d75b7677f1b23",
+                            "variable": "216971a1b9ae32b8e314c5908f4e6f32",
                             "value": "condition_a1",
-                            "document_key": "a1",
+                            "document_key": "f29bc91bbdab169fc0c0a326965953d1",
                         },
                     ]
                 },
@@ -516,8 +516,8 @@ class TestWorkflowMap:
         assert result["status"] == "success"
         activities = result["data"]["activities"]
         # a1 should have 2 variables, a2 should have 1
-        a1 = next(a for a in activities if a["sys_id"] == "a1")
-        a2 = next(a for a in activities if a["sys_id"] == "a2")
+        a1 = next(a for a in activities if a["sys_id"] == "f29bc91bbdab169fc0c0a326965953d1")
+        a2 = next(a for a in activities if a["sys_id"] == "b9f85daa6f83cf02ce5c31913d1f64d3")
         assert len(a1["variables"]) == 2
         assert len(a2["variables"]) == 1
 
@@ -568,12 +568,12 @@ class TestWorkflowStatus:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """Returns context record alongside executing and history lists."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/18dbe9bd70e88bd7d141d13c8a46e7d7").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "ctx001",
+                        "sys_id": "18dbe9bd70e88bd7d141d13c8a46e7d7",
                         "name": "Incident WF",
                         "state": "Executing",
                         "started": "2026-02-20 09:00:00",
@@ -588,8 +588,8 @@ class TestWorkflowStatus:
                 json={
                     "result": [
                         {
-                            "sys_id": "ex001",
-                            "activity": "act001",
+                            "sys_id": "594e89ed796189a6c8478cdb53c74590",
+                            "activity": "a37b4556fc38ce6b2a3fd1521b1291bc",
                             "activity.name": "Approval",
                             "activity.activity_definition.name": "Approval - User",
                             "state": "executing",
@@ -610,8 +610,8 @@ class TestWorkflowStatus:
                 json={
                     "result": [
                         {
-                            "sys_id": "hist001",
-                            "activity": "act000",
+                            "sys_id": "8163f692da15397336fa06c365f6d8d5",
+                            "activity": "1038802d0f0b75fbcd213663da9b65e4",
                             "activity.name": "Begin",
                             "activity.activity_definition.name": "Begin",
                             "state": "finished",
@@ -628,7 +628,7 @@ class TestWorkflowStatus:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_status"](context_sys_id="ctx001")
+        raw = await tools["workflow_status"](context_sys_id="18dbe9bd70e88bd7d141d13c8a46e7d7")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -665,8 +665,8 @@ class TestWorkflowStatus:
                 json={
                     "result": [
                         {
-                            "sys_id": "h1",
-                            "activity": "a1",
+                            "sys_id": "ac4ae97285c19b13201deb9b192d9213",
+                            "activity": "f29bc91bbdab169fc0c0a326965953d1",
                             "activity.name": "Begin",
                             "state": "finished",
                             "started": "2026-02-20 08:00:00",
@@ -711,24 +711,24 @@ class TestWorkflowStatus:
                 json={
                     "result": [
                         {
-                            "sys_id": "ex1",
-                            "activity": "a1",
+                            "sys_id": "d2044f50319b6b469429ec5351129c8e",
+                            "activity": "f29bc91bbdab169fc0c0a326965953d1",
                             "activity.name": "Task A",
                             "state": "executing",
                             "started": "2026-02-20 09:00:00",
                             "fault_description": "",
                         },
                         {
-                            "sys_id": "ex2",
-                            "activity": "a2",
+                            "sys_id": "f28239a0fde944f345b70dcb6b6a24a2",
+                            "activity": "b9f85daa6f83cf02ce5c31913d1f64d3",
                             "activity.name": "Task B",
                             "state": "executing",
                             "started": "2026-02-20 09:00:00",
                             "fault_description": "",
                         },
                         {
-                            "sys_id": "ex3",
-                            "activity": "a3",
+                            "sys_id": "9f7f3ade76b193090f617a43abc94ead",
+                            "activity": "252bc06763afb3b6c2a0802f7346700a",
                             "activity.name": "Task C",
                             "state": "executing",
                             "started": "2026-02-20 09:00:01",
@@ -775,8 +775,8 @@ class TestWorkflowStatus:
                 json={
                     "result": [
                         {
-                            "sys_id": "h1",
-                            "activity": "a1",
+                            "sys_id": "ac4ae97285c19b13201deb9b192d9213",
+                            "activity": "f29bc91bbdab169fc0c0a326965953d1",
                             "activity.name": "Run Script",
                             "state": "faulted",
                             "started": "2026-02-20 09:00:00",
@@ -786,8 +786,8 @@ class TestWorkflowStatus:
                             "activity_index": "1",
                         },
                         {
-                            "sys_id": "h2",
-                            "activity": "a2",
+                            "sys_id": "bf1c365741a4bfb5fee5c3150335ab4f",
+                            "activity": "b9f85daa6f83cf02ce5c31913d1f64d3",
                             "activity.name": "Notification",
                             "state": "faulted",
                             "started": "2026-02-20 09:00:03",
@@ -816,11 +816,11 @@ class TestWorkflowStatus:
     @respx.mock
     async def test_error_on_missing_context(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns error envelope when wf_context is not found."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_context/ctx404").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_context/05b6177456ea350bf56f9bc663468a10").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Record not found"}})
         )
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_status"](context_sys_id="ctx404")
+        raw = await tools["workflow_status"](context_sys_id="05b6177456ea350bf56f9bc663468a10")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -847,15 +847,15 @@ class TestWorkflowActivityDetail:
         def _act001_side_effect(request: httpx.Request) -> httpx.Response:
             result = (
                 {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Approval",
-                    "activity_definition": "def001",
+                    "activity_definition": "f45ee39efdcca5805d1e7e2eaa97f27b",
                     "x": "200",
                     "y": "100",
                 }
                 if "sysparm_display_value" not in str(request.url)
                 else {
-                    "sys_id": "act001",
+                    "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                     "name": "Approval",
                     "activity_definition": "Approval - User",
                     "x": "200",
@@ -864,14 +864,14 @@ class TestWorkflowActivityDetail:
             )
             return httpx.Response(200, json={"result": result})
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act001").mock(side_effect=_act001_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/a37b4556fc38ce6b2a3fd1521b1291bc").mock(side_effect=_act001_side_effect)
         # Phase 2: element definition with display values
-        respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/def001").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/f45ee39efdcca5805d1e7e2eaa97f27b").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "def001",
+                        "sys_id": "f45ee39efdcca5805d1e7e2eaa97f27b",
                         "name": "Approval - User",
                         "category": "Approvals",
                         "description": "Generates a user approval request",
@@ -886,10 +886,10 @@ class TestWorkflowActivityDetail:
                 json={
                     "result": [
                         {
-                            "sys_id": "var001",
+                            "sys_id": "47a920e21ce3b82c733a27e71b6e24b7",
                             "variable": "Script",
                             "value": "current.state = 2;",
-                            "document_key": "act001",
+                            "document_key": "a37b4556fc38ce6b2a3fd1521b1291bc",
                         },
                     ]
                 },
@@ -898,11 +898,11 @@ class TestWorkflowActivityDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_activity_detail"](activity_sys_id="act001")
+        raw = await tools["workflow_activity_detail"](activity_sys_id="a37b4556fc38ce6b2a3fd1521b1291bc")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["activity"]["sys_id"] == "act001"
+        assert result["data"]["activity"]["sys_id"] == "a37b4556fc38ce6b2a3fd1521b1291bc"
         assert result["data"]["definition"]["name"] == "Approval - User"
         assert result["data"]["definition"]["category"] == "Approvals"
         assert len(result["data"]["variables"]) == 1
@@ -946,12 +946,12 @@ class TestWorkflowActivityDetail:
     @respx.mock
     async def test_error_on_missing_activity(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns error when the activity record is not found."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/bad_id").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/35a1af58a3b00bde3d8af97f82562ac2").mock(
             return_value=httpx.Response(404, json={"error": {"message": "Not found"}})
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_activity_detail"](activity_sys_id="bad_id")
+        raw = await tools["workflow_activity_detail"](activity_sys_id="35a1af58a3b00bde3d8af97f82562ac2")
         result = decode_response(raw)
 
         assert result["status"] == "error"
@@ -998,13 +998,13 @@ class TestWorkflowActivityDetail:
                 json={
                     "result": [
                         {
-                            "sys_id": "sv1",
+                            "sys_id": "30a262ee0cddf15a17abb23e11148aa3",
                             "variable": "Script",
                             "value": "gs.log('hello');",
                             "document_key": "act_vars",
                         },
                         {
-                            "sys_id": "sv2",
+                            "sys_id": "2f0c71c73a82a38798e5249c3cfcecd6",
                             "variable": "Condition",
                             "value": "current.active == true",
                             "document_key": "act_vars",
@@ -1044,26 +1044,26 @@ class TestWorkflowVersionList:
                 json={
                     "result": [
                         {
-                            "sys_id": "wfv001",
-                            "name": "Incident Workflow v1",
+                            "sys_id": "e35fec24db6d035c7a6fa33e76847858",
+                            "name": "Incident Workflow 5a6df720540c20d95d530d3fd6885511",
                             "table": "incident",
                             "description": "Handles incident lifecycle",
                             "active": "true",
                             "published": "true",
                             "checked_out": "",
                             "checked_out_by": "",
-                            "workflow": "wf001",
+                            "workflow": "7d252727b60e4ff223a6aa6f13e46417",
                         },
                         {
-                            "sys_id": "wfv002",
-                            "name": "Incident Workflow v2",
+                            "sys_id": "5780f78f6d55b5bf954f58a084659629",
+                            "name": "Incident Workflow a1047eab1035d58682a53557e0b2a75e",
                             "table": "incident",
                             "description": "Updated incident lifecycle",
                             "active": "true",
                             "published": "true",
                             "checked_out": "",
                             "checked_out_by": "",
-                            "workflow": "wf001",
+                            "workflow": "7d252727b60e4ff223a6aa6f13e46417",
                         },
                     ]
                 },
@@ -1142,7 +1142,7 @@ class TestWorkflowVersionList:
                 json={
                     "result": [
                         {
-                            "sys_id": "wfv003",
+                            "sys_id": "6732202e50cf54c4edbc514a820a4e2e",
                             "name": "Problem Workflow",
                             "table": "problem",
                             "description": "Problem management",
@@ -1203,8 +1203,8 @@ class TestWorkflowDictReferenceFields:
         activity_definition and document_key are the ones that may come back
         as dicts when display_value query params are used.
         """
-        dict_activity_def = {"display_value": "def001", "link": "https://test.service-now.com/api/..."}
-        dict_doc_key = {"display_value": "act001", "link": "https://test.service-now.com/api/..."}
+        dict_activity_def = {"display_value": "f45ee39efdcca5805d1e7e2eaa97f27b", "link": "https://test.service-now.com/api/..."}
+        dict_doc_key = {"display_value": "a37b4556fc38ce6b2a3fd1521b1291bc", "link": "https://test.service-now.com/api/..."}
 
         respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_dict_test").mock(
             return_value=httpx.Response(200, json={"result": {"sys_id": "wfv_dict_test", "name": "Test WF"}})
@@ -1215,7 +1215,7 @@ class TestWorkflowDictReferenceFields:
                 json={
                     "result": [
                         {
-                            "sys_id": "act001",
+                            "sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc",
                             "name": "Script Step",
                             "activity_definition": dict_activity_def,
                             "activity_definition.name": "Run Script",
@@ -1242,7 +1242,7 @@ class TestWorkflowDictReferenceFields:
                 json={
                     "result": [
                         {
-                            "sys_id": "var001",
+                            "sys_id": "47a920e21ce3b82c733a27e71b6e24b7",
                             "variable": "script",
                             "value": "gs.log('hello');",
                             "document_key": dict_doc_key,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1342,3 +1342,76 @@ class TestWorkflowDictReferenceFields:
         assert result["status"] == "success"
         assert result["data"]["definition"] is not None
         assert result["data"]["definition"]["name"] == "Run Script Definition"
+
+
+# ---------------------------------------------------------------------------
+# PolicyError propagation - allowlist misconfiguration must fail loud
+# ---------------------------------------------------------------------------
+
+
+class TestPrivilegedReadFailsLoud:
+    """A misconfigured privileged-read allowlist must raise, not warn.
+
+    ``_fetch_and_attach_variables`` wraps its read in a narrow except so
+    transient HTTP failures degrade to a warning. ``PolicyError`` is
+    deliberately NOT caught - an empty or wrong allowlist is a programmer
+    bug and must propagate to the tool-call boundary where it surfaces as
+    an error envelope rather than a silently successful response.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_policy_error_propagates_from_helper(
+        self, settings: Settings, auth_provider: BasicAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Monkeypatch the allowlist to empty; ``PolicyError`` must escape."""
+        from servicenow_mcp.client import ServiceNowClient
+        from servicenow_mcp.errors import PolicyError
+        from servicenow_mcp.tools import workflow as workflow_module
+
+        monkeypatch.setattr(workflow_module, "_PRIVILEGED_VARIABLE_TABLES", frozenset())
+
+        activity_records = [{"sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc"}]
+        async with ServiceNowClient(settings, auth_provider) as client:
+            with pytest.raises(PolicyError, match="not in the caller's"):
+                await workflow_module._fetch_and_attach_variables(
+                    client, activity_records, settings, include_script_body=False
+                )
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_policy_error_surfaces_as_tool_error(
+        self, settings: Settings, auth_provider: BasicAuthProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """At the tool-call boundary, ``PolicyError`` becomes status='error' - not a warning."""
+        from servicenow_mcp.tools import workflow as workflow_module
+
+        monkeypatch.setattr(workflow_module, "_PRIVILEGED_VARIABLE_TABLES", frozenset())
+
+        # Stub the two tables that ``workflow_map`` reads before it reaches
+        # the privileged path; we need the call to progress far enough to
+        # invoke ``_fetch_and_attach_variables``.
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/e35fec24db6d035c7a6fa33e76847858").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": {"sys_id": "e35fec24db6d035c7a6fa33e76847858", "name": "WF"}},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [{"sys_id": "a37b4556fc38ce6b2a3fd1521b1291bc", "name": "Begin"}]},
+                headers={"X-Total-Count": "1"},
+            )
+        )
+        respx.get(f"{BASE_URL}/api/now/table/wf_transition").mock(
+            return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
+        )
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["workflow_map"](workflow_version_sys_id="e35fec24db6d035c7a6fa33e76847858")
+        result = decode_response(raw)
+
+        assert result["status"] == "error"
+        # ``format_response`` serialises exception messages as ``{"message": ...}``.
+        error_text = result["error"]["message"] if isinstance(result["error"], dict) else result["error"]
+        assert "not in the caller's" in error_text

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -339,12 +339,12 @@ class TestWorkflowMap:
     @respx.mock
     async def test_empty_activities_and_transitions(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Returns version with empty activities and transitions lists."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_empty").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/7e5366f16c281ccf6eb5fab870d009b3").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "wfv_empty",
+                        "sys_id": "7e5366f16c281ccf6eb5fab870d009b3",
                         "name": "Empty Workflow",
                         "table": "incident",
                         "active": "true",
@@ -361,7 +361,7 @@ class TestWorkflowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_empty")
+        raw = await tools["workflow_map"](workflow_version_sys_id="7e5366f16c281ccf6eb5fab870d009b3")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -372,10 +372,10 @@ class TestWorkflowMap:
     @respx.mock
     async def test_activities_sorted_by_x_position(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Activities are returned ordered by x position from the query."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_sort").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/2759e538b7ba0684c83e050d1a9f0977").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "wfv_sort", "name": "Sort Test WF"}},
+                json={"result": {"sys_id": "2759e538b7ba0684c83e050d1a9f0977", "name": "Sort Test WF"}},
             )
         )
         # Activities returned pre-sorted by x (as ServiceNow would return them)
@@ -415,7 +415,7 @@ class TestWorkflowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_sort")
+        raw = await tools["workflow_map"](workflow_version_sys_id="2759e538b7ba0684c83e050d1a9f0977")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -449,10 +449,10 @@ class TestWorkflowMap:
     @respx.mock
     async def test_map_groups_variables_by_activity(self, settings: Settings, auth_provider: BasicAuthProvider) -> None:
         """Variables are grouped correctly per activity in the map."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_vars").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/f4e5800ef04e1ddae096cab27268a211").mock(
             return_value=httpx.Response(
                 200,
-                json={"result": {"sys_id": "wfv_vars", "name": "Vars Test WF"}},
+                json={"result": {"sys_id": "f4e5800ef04e1ddae096cab27268a211", "name": "Vars Test WF"}},
             )
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
@@ -510,7 +510,7 @@ class TestWorkflowMap:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_vars")
+        raw = await tools["workflow_map"](workflow_version_sys_id="f4e5800ef04e1ddae096cab27268a211")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -527,12 +527,12 @@ class TestWorkflowMap:
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """No sys_variable_value call when there are no activities."""
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_none").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/a7d9eb2e84eb49b6fcca92d84b48c1b4").mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "result": {
-                        "sys_id": "wfv_none",
+                        "sys_id": "a7d9eb2e84eb49b6fcca92d84b48c1b4",
                         "name": "No Activities WF",
                     }
                 },
@@ -547,7 +547,7 @@ class TestWorkflowMap:
         # Do NOT mock sys_variable_value - if it's called, the test will fail with ConnectionError
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_none")
+        raw = await tools["workflow_map"](workflow_version_sys_id="a7d9eb2e84eb49b6fcca92d84b48c1b4")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -919,7 +919,7 @@ class TestWorkflowActivityDetail:
                 200,
                 json={
                     "result": {
-                        "sys_id": "act_nodef",
+                        "sys_id": "a40bb1d2559337415c49dfd982cf2fe2",
                         "name": "Custom Activity",
                         "activity_definition": "",
                         "x": "100",
@@ -928,17 +928,17 @@ class TestWorkflowActivityDetail:
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act_nodef").mock(side_effect=_nodef_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/a40bb1d2559337415c49dfd982cf2fe2").mock(side_effect=_nodef_side_effect)
         respx.get(f"{BASE_URL}/api/now/table/sys_variable_value").mock(
             return_value=httpx.Response(200, json={"result": []}, headers={"X-Total-Count": "0"})
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_activity_detail"](activity_sys_id="act_nodef")
+        raw = await tools["workflow_activity_detail"](activity_sys_id="a40bb1d2559337415c49dfd982cf2fe2")
         result = decode_response(raw)
 
         assert result["status"] == "success"
-        assert result["data"]["activity"]["sys_id"] == "act_nodef"
+        assert result["data"]["activity"]["sys_id"] == "a40bb1d2559337415c49dfd982cf2fe2"
         assert result["data"]["definition"] is None
         assert result["data"]["variables"] == []
 
@@ -970,7 +970,7 @@ class TestWorkflowActivityDetail:
                 200,
                 json={
                     "result": {
-                        "sys_id": "act_vars",
+                        "sys_id": "20de94ee488dbd2b7154c3afbf85cd22",
                         "name": "Run Script",
                         "activity_definition": "def_script",
                         "x": "100",
@@ -979,7 +979,7 @@ class TestWorkflowActivityDetail:
                 },
             )
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act_vars").mock(side_effect=_act_vars_side_effect)
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/20de94ee488dbd2b7154c3afbf85cd22").mock(side_effect=_act_vars_side_effect)
         respx.get(f"{BASE_URL}/api/now/table/wf_element_definition/def_script").mock(
             return_value=httpx.Response(
                 200,
@@ -1001,13 +1001,13 @@ class TestWorkflowActivityDetail:
                             "sys_id": "30a262ee0cddf15a17abb23e11148aa3",
                             "variable": "Script",
                             "value": "gs.log('hello');",
-                            "document_key": "act_vars",
+                            "document_key": "20de94ee488dbd2b7154c3afbf85cd22",
                         },
                         {
                             "sys_id": "2f0c71c73a82a38798e5249c3cfcecd6",
                             "variable": "Condition",
                             "value": "current.active == true",
-                            "document_key": "act_vars",
+                            "document_key": "20de94ee488dbd2b7154c3afbf85cd22",
                         },
                     ]
                 },
@@ -1016,7 +1016,7 @@ class TestWorkflowActivityDetail:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_activity_detail"](activity_sys_id="act_vars")
+        raw = await tools["workflow_activity_detail"](activity_sys_id="20de94ee488dbd2b7154c3afbf85cd22")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1106,7 +1106,7 @@ class TestWorkflowVersionList:
                 json={
                     "result": [
                         {
-                            "sys_id": "wfv_inactive",
+                            "sys_id": "ff36fb9fb5cad6865cdbd6293b2a5ad1",
                             "name": "Old Workflow",
                             "table": "incident",
                             "active": "false",
@@ -1206,8 +1206,8 @@ class TestWorkflowDictReferenceFields:
         dict_activity_def = {"display_value": "f45ee39efdcca5805d1e7e2eaa97f27b", "link": "https://test.service-now.com/api/..."}
         dict_doc_key = {"display_value": "a37b4556fc38ce6b2a3fd1521b1291bc", "link": "https://test.service-now.com/api/..."}
 
-        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/wfv_dict_test").mock(
-            return_value=httpx.Response(200, json={"result": {"sys_id": "wfv_dict_test", "name": "Test WF"}})
+        respx.get(f"{BASE_URL}/api/now/table/wf_workflow_version/789b9a03486e4434d8e435a024103c95").mock(
+            return_value=httpx.Response(200, json={"result": {"sys_id": "789b9a03486e4434d8e435a024103c95", "name": "Test WF"}})
         )
         respx.get(f"{BASE_URL}/api/now/table/wf_activity").mock(
             return_value=httpx.Response(
@@ -1254,7 +1254,7 @@ class TestWorkflowDictReferenceFields:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_map"](workflow_version_sys_id="wfv_dict_test")
+        raw = await tools["workflow_map"](workflow_version_sys_id="789b9a03486e4434d8e435a024103c95")
         result = decode_response(raw)
 
         assert result["status"] == "success"
@@ -1272,14 +1272,14 @@ class TestWorkflowDictReferenceFields:
         dict_definition = {"display_value": "act_def_001", "link": "https://test.service-now.com/api/..."}
 
         # Phase 1: raw activity with dict reference
-        respx.get(f"{BASE_URL}/api/now/table/wf_activity/act_dict_test").mock(
+        respx.get(f"{BASE_URL}/api/now/table/wf_activity/2eac3cfb70af19b72304086d2d97c52d").mock(
             side_effect=[
                 # First call: raw (display_values=False)
                 httpx.Response(
                     200,
                     json={
                         "result": {
-                            "sys_id": "act_dict_test",
+                            "sys_id": "2eac3cfb70af19b72304086d2d97c52d",
                             "name": "My Activity",
                             "activity_definition": dict_definition,
                         }
@@ -1290,7 +1290,7 @@ class TestWorkflowDictReferenceFields:
                     200,
                     json={
                         "result": {
-                            "sys_id": "act_dict_test",
+                            "sys_id": "2eac3cfb70af19b72304086d2d97c52d",
                             "name": "My Activity",
                             "activity_definition": "Run Script",
                         }
@@ -1309,7 +1309,7 @@ class TestWorkflowDictReferenceFields:
         )
 
         tools = _register_and_get_tools(settings, auth_provider)
-        raw = await tools["workflow_activity_detail"](activity_sys_id="act_dict_test")
+        raw = await tools["workflow_activity_detail"](activity_sys_id="2eac3cfb70af19b72304086d2d97c52d")
         result = decode_response(raw)
 
         assert result["status"] == "success"


### PR DESCRIPTION
## Summary

Five-phase pentest remediation covering findings from three parallel pentest passes (reviewer, explore, pentest agents). Static-only testing; no live ServiceNow instance touched.

## Phase 1 - Broad hardening
- HIGH-2: expanded sensitive-field regex (~30 new keywords incl. `pwd`, `bearer`, `ssh_key`, `passphrase`, `keystore`, `cookie`, `apikey`, `privatekey`)
- HIGH-4: pre-decode base64 size check on attachment_upload
- HIGH-5: `_parse_write_payload` validates all JSON payload keys via `validate_identifier`
- HIGH-6: `cmdb_list` enforces query safety; added `filter_query` param; `cmdb_ci*` added to default large-table CSV
- Prod hard-refuse: RuntimeError at bootstrap if `SERVICENOW_ALLOW_DANGEROUS_BYPASS=true` in production

## Phase 2 - Sentry PII controls
- CRIT-2: `send_default_pii=False` and `traces_sample_rate=0.05` as opt-in settings
- `@tool_handler` Sentry context ships `arg_keys` sorted list, never values
- `_extract_error_message` scrubs long quoted substrings and truncates at 500 chars

## Phase 3 - Script body masking
- HIGH-1: `TABLE_SCRIPT_FIELDS` registry (23 tables) + `SCRIPT_BODY_MASK`
- `mask_sensitive_fields(record, table=None, *, include_script_body=False)` - backward compatible, credential mask beats script mask
- 13 tools gained `include_script_body` opt-in across metadata, changes, workflow, flow_designer, record, table modules
- MED-3: `table_aggregate` CSV field params validated per-part

## Phase 4 - Table access and sys_id validation
- HIGH-3: `DENIED_TABLES` expanded by 9 (sys_user, sys_properties, sys_security_acl, sys_auth_profile, sys_data_source, sys_variable_value, sys_script_email, ecc_agent, ecc_queue)
- New internal `client.get_records_privileged(table, *, allowed_tables, ...)` - allowlist-gated, masking always applies, folds `max_row_limit` clamp and large-table date check
- MED-1: `QueryTokenStore` payloads must carry a `table`; `resolve_query_token` raises `PolicyError` on mismatch
- MED-4: new `validate_sys_id` (32-char lowercase hex); applied to `_table_url`, `_attachment_url`, `_email_url`, `_import_set_url`, `_cmdb_url`, plus all sc_/atf_ client methods
- Bonus: `validate_identifier` / `validate_sys_id` switched from `re.match` to `re.fullmatch` to close trailing-newline bypass

## Phase 5 - Write gating and supply chain
- CRIT-1: `artifact_create` / `artifact_update` replaced by `artifact_create_preview` + `artifact_update_preview` + `artifact_apply` (mirrors record_write; single-use token consume; `write_gate` checked at apply time)
- HIGH-7: `attachment_download` / `attachment_download_by_name` default to metadata-only; opt-in `include_content=True` for base64 bytes
- MED-5: `toon-format` vendored into `src/servicenow_mcp/_vendor/toon_format/`; git dependency removed

## Deferred

- MED-2 (dot-walk field-path validation across table boundary) - filed as a separate issue; requires schema-lookup design work

## Breaking changes

- `artifact_create` and `artifact_update` tool names removed; callers must switch to the preview/apply trio.
- `attachment_download` / `attachment_download_by_name` no longer return `content_base64` by default; pass `include_content=True` to restore prior shape.

## Verification

- ruff check: clean
- ruff format --check: clean
- mypy src/: clean
- pytest: 1229 passed (integration deselected)