### PR TITLE
fix(security): address red-team findings (7 fixes, 3 batches)

### DIFF
--- a/src/servicenow_mcp/decorators.py
+++ b/src/servicenow_mcp/decorators.py
@@ -10,6 +10,61 @@ from servicenow_mcp.types import SignatureMutableCallable
 from servicenow_mcp.utils import generate_correlation_id, safe_tool_call
 
 
+# Arg names whose values may carry credentials, PII, or large untrusted payloads.
+# Values for these keys are replaced with a constant placeholder before being
+# attached to the Sentry "tool" context. Matched case-insensitively on the arg
+# name. See SECURITY: do not narrow this set without an explicit review.
+_SENSITIVE_ARG_KEYS: frozenset[str] = frozenset(
+    {
+        "data",
+        "content_base64",
+        "value",
+        "script_path",
+        "encoded_query",
+        "params",
+        "password",
+        "token",
+        "secret",
+        "api_key",
+        "authorization",
+        # User-supplied content surfaces that may carry PII, credentials, or
+        # other sensitive material. ``variables`` (service_catalog catalog-item
+        # variables) often holds names, addresses, license keys. ``conditions``
+        # (build_query) holds untrusted value lists. ``text`` is free-form
+        # search input.
+        "variables",
+        "conditions",
+        "text",
+    }
+)
+
+_REDACTED: str = "***REDACTED***"
+
+
+def _redact_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of ``kwargs`` with sensitive values replaced.
+
+    ``correlation_id`` is dropped (it is sent as a separate context field).
+    Keys are matched case-insensitively against ``_SENSITIVE_ARG_KEYS``.
+
+    Shallow redaction is sufficient because every current tool arg is either
+    a primitive or a JSON-encoded string; JSON-shaped args (``data``,
+    ``params``, ``variables``, ``conditions``) arrive here as unparsed
+    strings and are redacted whole. Revisit if a tool ever accepts a
+    ``dict``/``list`` parameter directly - nested sensitive values inside
+    such a structure would not be reached by this pass.
+    """
+    redacted: dict[str, Any] = {}
+    for k, v in kwargs.items():
+        if k == "correlation_id":
+            continue
+        if k.lower() in _SENSITIVE_ARG_KEYS:
+            redacted[k] = _REDACTED
+        else:
+            redacted[k] = v
+    return redacted
+
+
 def tool_handler(
     fn: Callable[..., Coroutine[Any, Any, str]],
 ) -> Callable[..., Coroutine[Any, Any, str]]:
@@ -40,7 +95,7 @@ def tool_handler(
             {
                 "name": fn.__name__,
                 "correlation_id": correlation_id,
-                "args": {k: v for k, v in kwargs.items() if k != "correlation_id"},
+                "args": _redact_args(kwargs),
             },
         )
 

--- a/src/servicenow_mcp/sentry.py
+++ b/src/servicenow_mcp/sentry.py
@@ -94,9 +94,9 @@ def setup_sentry(settings: "Settings") -> None:
         dsn=dsn,
         environment=environment,
         release=_RELEASE,
-        send_default_pii=True,
+        send_default_pii=False,
         integrations=integrations,
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.1,
         profiles_sample_rate=None,
     )
 

--- a/src/servicenow_mcp/tools/_artifact.py
+++ b/src/servicenow_mcp/tools/_artifact.py
@@ -48,30 +48,45 @@ def _read_script_file(script_path: str, allowed_root: str) -> str:
     Raises:
         ValueError: If the path is not absolute, allowed_root is empty or inaccessible,
             or the file exceeds MAX_SCRIPT_FILE_BYTES.
-        PermissionError: If the resolved path is outside the allowed root.
-        FileNotFoundError: If the file does not exist or is not a regular file.
+        PermissionError: If the resolved path is outside the allowed root, does not
+            exist, or is not a readable regular file. The error message is intentionally
+            opaque and identical across cases to prevent host-filesystem enumeration
+            via differential error responses (see SECURITY).
+        FileNotFoundError: Same opaque message as ``PermissionError``; both are raised
+            for the not-readable / outside-root condition so callers can collapse them.
         UnicodeDecodeError: If the file is not valid UTF-8.
     """
+    # Opaque, identical message for both "not readable" and "outside allowed root".
+    # Do NOT echo script_path or resolved path back to the caller.
+    _OPAQUE_NOT_READABLE = "script_path is not readable or is outside the allowed root"
+
     if not Path(script_path).is_absolute():
         raise ValueError(f"script_path must be an absolute path, got: {script_path!r}")
 
     if not allowed_root:
         raise ValueError("script_allowed_root must be configured when using script_path")
 
-    try:
-        resolved = Path(script_path).resolve(strict=True)
-    except (OSError, ValueError) as exc:
-        raise FileNotFoundError(f"Script file not found or not accessible: {script_path!r}") from exc
-
+    # Resolve and validate the allowed root FIRST. Configuration errors are
+    # surfaced verbatim because they are operator-facing, not attacker-controlled.
     try:
         root = Path(allowed_root).resolve(strict=True)
     except (OSError, ValueError) as exc:
         raise ValueError(f"Configured script_allowed_root is not accessible: {allowed_root!r}") from exc
+    if not root.is_dir():
+        raise ValueError(f"Configured script_allowed_root is not a directory: {allowed_root!r}")
+
+    # From here on, every failure mode that depends on the attacker-controlled
+    # script_path collapses to a single opaque error.
+    try:
+        resolved = Path(script_path).resolve(strict=True)
+    except (OSError, ValueError) as exc:
+        raise FileNotFoundError(_OPAQUE_NOT_READABLE) from exc
+
     if not resolved.is_relative_to(root):
-        raise PermissionError(f"Script path {str(resolved)!r} is outside the allowed root {str(root)!r}")
+        raise PermissionError(_OPAQUE_NOT_READABLE)
 
     if not resolved.is_file():
-        raise FileNotFoundError(f"Script path is not a regular file: {script_path!r}")
+        raise FileNotFoundError(_OPAQUE_NOT_READABLE)
 
     file_size = resolved.stat().st_size
     if file_size > MAX_SCRIPT_FILE_BYTES:

--- a/src/servicenow_mcp/tools/_audit.py
+++ b/src/servicenow_mcp/tools/_audit.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 # Match it at a comma boundary so substrings like ``my_no_audit=true``
 # never produce a false positive. The right boundary tolerates trailing
 # whitespace before EOL (``foo, no_audit = true `` must match).
-_NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)", re.IGNORECASE)  # NOSONAR(S5850) - alternations are non-capturing groups; precedence is explicit.
+_NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)", re.IGNORECASE
+)  # NOSONAR(S5850) - alternations are non-capturing groups; precedence is explicit.
 
 
 def attribute_has_no_audit(attributes: str) -> bool:

--- a/src/servicenow_mcp/tools/_audit.py
+++ b/src/servicenow_mcp/tools/_audit.py
@@ -32,8 +32,9 @@ logger = logging.getLogger(__name__)
 
 # ``no_audit`` is encoded inside the comma-separated ``attributes`` blob.
 # Match it at a comma boundary so substrings like ``my_no_audit=true``
-# never produce a false positive.
-_NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|$)", re.IGNORECASE)
+# never produce a false positive. The right boundary tolerates trailing
+# whitespace before EOL (``foo, no_audit = true `` must match).
+_NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)", re.IGNORECASE)
 
 
 def attribute_has_no_audit(attributes: str) -> bool:

--- a/src/servicenow_mcp/tools/_audit.py
+++ b/src/servicenow_mcp/tools/_audit.py
@@ -35,8 +35,9 @@ logger = logging.getLogger(__name__)
 # never produce a false positive. The right boundary tolerates trailing
 # whitespace before EOL (``foo, no_audit = true `` must match).
 _NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)", re.IGNORECASE
-)  # NOSONAR(S5850) - alternations are non-capturing groups; precedence is explicit.
+    r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)",  # NOSONAR(S5850) - alternations are grouped; precedence explicit.
+    re.IGNORECASE,
+)
 
 
 def attribute_has_no_audit(attributes: str) -> bool:

--- a/src/servicenow_mcp/tools/_audit.py
+++ b/src/servicenow_mcp/tools/_audit.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # Match it at a comma boundary so substrings like ``my_no_audit=true``
 # never produce a false positive. The right boundary tolerates trailing
 # whitespace before EOL (``foo, no_audit = true `` must match).
-_NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)", re.IGNORECASE)
+_NO_AUDIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:^|,)\s*no_audit\s*=\s*true(?:\s*,|\s*$)", re.IGNORECASE)  # NOSONAR(S5850) - alternations are non-capturing groups; precedence is explicit.
 
 
 def attribute_has_no_audit(attributes: str) -> bool:

--- a/src/servicenow_mcp/tools/_dictionary.py
+++ b/src/servicenow_mcp/tools/_dictionary.py
@@ -104,10 +104,14 @@ EXCLUDED_ELEMENTS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Attribute substrings that flip an html/xml field into "script-bearing".
-_HEURISTIC_ATTR_FLAGS: Final[tuple[str, ...]] = (
-    "tinymce_allow_all=true",
-    "html_sanitize=false",
+# Attribute flags that flip an html/xml field into "script-bearing".
+# Encoded inside the comma-separated ``attributes`` blob as ``key=value``;
+# matched at token boundaries so substrings like ``my_tinymce_allow_all=true``
+# never produce a false positive. Mirrors the boundary discipline used by
+# ``tools._audit._NO_AUDIT_RE``.
+_HEURISTIC_ATTR_FLAGS: Final[tuple[tuple[str, str], ...]] = (
+    ("tinymce_allow_all", "true"),
+    ("html_sanitize", "false"),
 )
 
 # Bound on super_class chain depth - generous ceiling above the deepest OOTB
@@ -119,12 +123,40 @@ _MAX_CHAIN_DEPTH: Final[int] = 8
 _TEMPLATE_RE: Final[re.Pattern[str]] = re.compile(r"\$\{[^}]+\}")
 
 
-def _attributes_admit_heuristic(attributes: str) -> bool:
-    """Return True when ``attributes`` carries a heuristic-admission flag."""
+def _parse_attributes(attributes: str) -> dict[str, str]:
+    """Parse the comma-separated ``key=value`` ``attributes`` blob.
+
+    Strips whitespace around both the token and the ``=`` separator. Keys
+    are lowercased; values are stripped and lowercased (heuristic flags
+    only compare against the literals ``true``/``false``). Splits on the
+    first ``=`` only so values containing ``=`` survive. Duplicate keys
+    follow last-wins semantics. Empty strings and tokens without ``=``
+    are skipped.
+    """
     if not attributes:
+        return {}
+    parsed: dict[str, str] = {}
+    for raw_token in attributes.split(","):
+        token = raw_token.strip()
+        if not token or "=" not in token:
+            continue
+        key, _, value = token.partition("=")
+        parsed[key.strip().lower()] = value.strip().lower()
+    return parsed
+
+
+def _attributes_admit_heuristic(attributes: str) -> bool:
+    """Return True when ``attributes`` carries a heuristic-admission flag.
+
+    Parses ``attributes`` as comma-separated ``key=value`` tokens (the
+    ServiceNow convention) and admits only when one of the configured
+    flag keys is present with the matching literal value. Substring
+    matches like ``my_tinymce_allow_all=true`` are rejected.
+    """
+    parsed = _parse_attributes(attributes)
+    if not parsed:
         return False
-    lowered = attributes.lower()
-    return any(flag in lowered for flag in _HEURISTIC_ATTR_FLAGS)
+    return any(parsed.get(key) == value for key, value in _HEURISTIC_ATTR_FLAGS)
 
 
 def _classify(field: DictionaryField) -> ScriptField | None:

--- a/src/servicenow_mcp/tools/_flow_values.py
+++ b/src/servicenow_mcp/tools/_flow_values.py
@@ -91,6 +91,12 @@ def decode_values(compressed: str) -> list[Any] | dict[str, Any]:
         raise ValueError(
             f"decompressed payload exceeds maximum allowed size (> {MAX_DECOMPRESSED_BYTES} bytes)",
         )
+    # Reject truncated streams (gzip footer never reached) and trailing
+    # bytes after a valid gzip member. Either condition can yield
+    # JSON-parseable but spoofed or partial output that callers should
+    # never see.
+    if not decompressor.eof or decompressor.unused_data:
+        raise ValueError("invalid or truncated gzip stream")
 
     try:
         decoded = json.loads(decompressed.decode("utf-8"))

--- a/src/servicenow_mcp/tools/_flow_values.py
+++ b/src/servicenow_mcp/tools/_flow_values.py
@@ -12,14 +12,25 @@ state. Callers decide when (and whether) to decode.
 from __future__ import annotations
 
 import base64
-import gzip
 import json
+import zlib
 from typing import Any
 
 
 # Base64 prefix produced by the gzip magic bytes (``1f 8b 08 ...``). Cheap
 # heuristic to distinguish plain string values from compressed payloads.
 _GZIP_BASE64_MAGIC: str = "H4sIA"
+
+# Decompression-bomb guards. Legitimate Flow Designer ``values`` blobs are
+# typically a few KB; these caps are deliberately generous but bounded so a
+# malicious row (or attacker-supplied ``decode_values`` argument) cannot OOM
+# the server. The base64-decoded wire payload is rejected before allocating
+# the decompressor; the decompressed output is bounded via ``decompressobj``.
+MAX_COMPRESSED_BYTES: int = 1 * 1024 * 1024
+MAX_DECOMPRESSED_BYTES: int = 4 * 1024 * 1024
+
+# ``zlib.MAX_WBITS | 16`` selects gzip framing (RFC 1952) inside zlib.
+_GZIP_WBITS: int = zlib.MAX_WBITS | 16
 
 
 def looks_compressed(value: str) -> bool:
@@ -65,10 +76,21 @@ def decode_values(compressed: str) -> list[Any] | dict[str, Any]:
         # binascii.Error is a subclass of ValueError; ValueError alone covers it.
         raise ValueError(f"not valid base64: {exc}") from exc
 
+    if len(raw) > MAX_COMPRESSED_BYTES:
+        raise ValueError(
+            f"compressed payload exceeds maximum allowed size ({len(raw)} > {MAX_COMPRESSED_BYTES} bytes)",
+        )
+
+    decompressor = zlib.decompressobj(wbits=_GZIP_WBITS)
     try:
-        decompressed = gzip.decompress(raw)
-    except (OSError, EOFError) as exc:
+        decompressed = decompressor.decompress(raw, MAX_DECOMPRESSED_BYTES + 1)
+    except zlib.error as exc:
         raise ValueError(f"not valid gzip data: {exc}") from exc
+
+    if len(decompressed) > MAX_DECOMPRESSED_BYTES or decompressor.unconsumed_tail:
+        raise ValueError(
+            f"decompressed payload exceeds maximum allowed size (> {MAX_DECOMPRESSED_BYTES} bytes)",
+        )
 
     try:
         decoded = json.loads(decompressed.decode("utf-8"))

--- a/src/servicenow_mcp/tools/record_write.py
+++ b/src/servicenow_mcp/tools/record_write.py
@@ -43,6 +43,17 @@ TOOL_NAMES: list[str] = ["record_write", "record_apply"]
 
 _VALID_ACTIONS: Final[frozenset[str]] = frozenset({"create", "update", "delete"})
 
+# Hard cap on the raw byte length of the ``data`` argument accepted by
+# ``record_write``. Mirrors ``MAX_SCRIPT_FILE_BYTES`` (1 MiB) so JSON
+# payloads and script files share the same ceiling. Bounding here keeps
+# ``PreviewTokenStore`` from being pinned by oversized payloads
+# (1000-token cap * payload size = total memory exposure).
+#
+# ``parse_payload_json`` applies a tighter 256 KiB cap downstream; this
+# constant is the defence-in-depth ceiling at the tool entry point and
+# also fires before any JSON parsing work.
+MAX_PAYLOAD_BYTES: Final[int] = 1 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Error helpers
@@ -107,6 +118,14 @@ def _validate_action_args(
 
     if script_field and not script_path:
         return _err(correlation_id, "script_field requires script_path to be set.")
+
+    # Cap the raw byte length of ``data`` (which doubles as ``changes`` on
+    # update) before any parsing work or token allocation. Mirrors the
+    # ``script_path`` 1 MiB ceiling. ``parse_payload_json`` enforces a
+    # tighter cap downstream; this fires first and at the entry point so
+    # the ``PreviewTokenStore`` is never asked to retain >1 MiB per entry.
+    if data and len(data.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+        return _err(correlation_id, "payload exceeds maximum allowed size of 1 MiB")
 
     # Per-action argument checks delegated to focused validators.
     if action == "create":
@@ -185,10 +204,11 @@ async def _inject_script_path(
         return _err(correlation_id, f"script_path is not valid UTF-8: {exc}")
     except ValueError as exc:
         return _err(correlation_id, f"Invalid script_path: {exc}")
-    except FileNotFoundError as exc:
-        return _err(correlation_id, str(exc))
-    except PermissionError as exc:
-        return _err(correlation_id, f"script_path security violation: {exc}")
+    except (FileNotFoundError, PermissionError):
+        # Collapsed on purpose: both arms return the SAME opaque message so a
+        # caller cannot enumerate the host filesystem by observing which error
+        # comes back (see SECURITY in _artifact._read_script_file).
+        return _err(correlation_id, "script_path is not readable or is outside the allowed root")
 
     if target.internal_type == "xml":
         xml_error = validate_ui_macro_xml(content)

--- a/src/servicenow_mcp/utils.py
+++ b/src/servicenow_mcp/utils.py
@@ -7,7 +7,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any, override
 
-from servicenow_mcp.errors import ACLError, ForbiddenError
+from servicenow_mcp.errors import ACLError, ForbiddenError, ServiceNowMCPError
 from servicenow_mcp.sentry import capture_exception as sentry_capture
 
 
@@ -746,11 +746,41 @@ async def safe_tool_call(
             status="error",
             error=f"Access forbidden by ServiceNow: {e}",
         )
-    except Exception as e:
+    except ServiceNowMCPError as e:
+        # Domain errors (PolicyError, QuerySafetyError, NotFoundError, ServerError,
+        # AuthError, ...) carry curated, caller-actionable messages and are safe
+        # to surface verbatim.
         sentry_capture(e)
         return format_response(
             data=None,
             correlation_id=correlation_id,
             status="error",
             error=str(e),
+        )
+    except ValueError as e:
+        # Project convention: ValueError is the signal for "rejected user input"
+        # raised by validators like ``validate_identifier``. Messages are curated
+        # and safe to surface (they quote the caller's own input).
+        sentry_capture(e)
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=str(e),
+        )
+    except Exception as e:
+        # Truly unclassified failure (RuntimeError, OSError, httpx errors, ...).
+        # Log full detail locally for operators but return an opaque message to
+        # the caller so we do not leak internal hostnames, file paths, or
+        # platform stack fragments.
+        logger.exception(
+            "Unhandled exception in tool",
+            extra={"correlation_id": correlation_id},
+        )
+        sentry_capture(e)
+        return format_response(
+            data=None,
+            correlation_id=correlation_id,
+            status="error",
+            error=f"Internal error (correlation_id={correlation_id})",
         )

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -372,6 +372,16 @@ def test_attribute_has_no_audit_recognises_flag() -> None:
     assert not attribute_has_no_audit("")
 
 
+def test_attribute_has_no_audit_tolerates_trailing_whitespace() -> None:
+    """The right boundary allows trailing whitespace before EOL."""
+    # Trailing space before EOL must match (right-boundary fix).
+    assert attribute_has_no_audit("foo, no_audit = true ")
+    assert attribute_has_no_audit("no_audit=true   ")
+    assert attribute_has_no_audit("no_audit=true\t")
+    # Left-boundary anti-collision protection is preserved.
+    assert not attribute_has_no_audit("my_no_audit=true ")
+
+
 @pytest.mark.asyncio()
 @respx.mock
 async def test_no_audit_attribute_vetoes_audit_true(settings: Settings, auth_provider: BasicAuthProvider) -> None:

--- a/tests/test_build_query.py
+++ b/tests/test_build_query.py
@@ -321,7 +321,7 @@ class TestBuildQuery:
     async def test_unexpected_exception_returns_error(
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
-        """Unexpected exception in ServiceNowQuery triggers generic handler."""
+        """Unexpected exception in ServiceNowQuery triggers the opaque generic handler."""
         tools = _register_and_get_tools(settings, auth_provider)
         with patch(
             "servicenow_mcp.tools.build_query.ServiceNowQuery",
@@ -330,7 +330,11 @@ class TestBuildQuery:
             raw = await tools["build_query"](conditions='[{"operator": "equals", "field": "active", "value": "true"}]')
         result = decode_response(raw)
         assert result["status"] == "error"
-        assert "boom" in result["error"]["message"]
+        # The original ``str(exc)`` is NOT exposed — unclassified exceptions are
+        # collapsed to an opaque envelope to prevent information leakage.
+        message = result["error"]["message"]
+        assert "boom" not in message
+        assert message.startswith("Internal error")
 
     # -- Operator coverage -----------------------------------------------------
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -187,7 +187,7 @@ class TestRedactArgs:
         sensitive = {
             "data": '{"name": "alice"}',
             "params": "anything",
-            "password": "hunter2",
+            "password": "hunter2",  # NOSONAR(S2068) - test fixture asserting redaction; not a credential.
             "token": "deadbeef",
             "secret": "shh",
             "api_key": "k",

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from typing import Any
 
-from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.decorators import _REDACTED, _redact_args, tool_handler
 from servicenow_mcp.errors import ForbiddenError
 from servicenow_mcp.utils import format_response
 from tests.helpers import get_registered_tools
@@ -76,18 +76,26 @@ class TestToolHandler:
         assert not hasattr(my_tool, "__wrapped__")
 
     async def test_catches_generic_exception(self) -> None:
-        """Exceptions in the tool body are caught and returned as error envelopes."""
+        """Exceptions in the tool body are caught and returned as opaque envelopes.
+
+        The wire-level message MUST NOT contain ``str(exc)`` — that would leak
+        internal hostnames, paths, and platform stack fragments. The full
+        exception is logged locally (see SECURITY in utils.safe_tool_call).
+        """
 
         @tool_handler
         async def my_tool(*, correlation_id: str) -> str:
             _ = correlation_id
-            raise ValueError("something broke")
+            raise RuntimeError("something broke")
 
         result = await my_tool()
         parsed = json.loads(result)
         assert isinstance(parsed, dict)
         assert parsed["status"] == "error"
-        assert "something broke" in parsed["error"]["message"]
+        message = parsed["error"]["message"]
+        assert "something broke" not in message
+        assert message.startswith("Internal error")
+        assert parsed["correlation_id"] in message
 
     async def test_catches_forbidden_error(self) -> None:
         """ForbiddenError is caught and returned as an ACL denial error envelope."""
@@ -163,3 +171,56 @@ class TestToolHandler:
         assert isinstance(parsed, dict)
         assert parsed["status"] == "success"
         assert parsed["data"]["table"] == "my_table"
+
+
+class TestRedactArgs:
+    """Sensitive arg names are redacted before being attached to Sentry context."""
+
+    def test_drops_correlation_id(self) -> None:
+        """``correlation_id`` is dropped (sent as a separate context field)."""
+        out = _redact_args({"correlation_id": "abc", "table": "incident"})
+        assert "correlation_id" not in out
+        assert out == {"table": "incident"}
+
+    def test_redacts_known_sensitive_keys(self) -> None:
+        """All canonical sensitive keys are replaced with the redaction marker."""
+        sensitive = {
+            "data": '{"name": "alice"}',
+            "params": "anything",
+            "password": "hunter2",
+            "token": "deadbeef",
+            "secret": "shh",
+            "api_key": "k",
+            "authorization": "Bearer x",
+            "script_path": "/etc/passwd",
+            "encoded_query": "active=true",
+            "content_base64": "AAAA",
+            "value": "raw",
+        }
+        out = _redact_args(sensitive)
+        for key in sensitive:
+            assert out[key] == _REDACTED, f"{key} was not redacted"
+
+    def test_redacts_user_supplied_content_keys(self) -> None:
+        """``variables``, ``conditions``, ``text`` carry user content and must redact."""
+        out = _redact_args(
+            {
+                "variables": '{"email": "alice@example.com"}',
+                "conditions": '[{"field": "x", "op": "=", "value": "secret"}]',
+                "text": "search for something private",
+            }
+        )
+        assert out["variables"] == _REDACTED
+        assert out["conditions"] == _REDACTED
+        assert out["text"] == _REDACTED
+
+    def test_passes_through_non_sensitive(self) -> None:
+        """Non-sensitive keys retain their original values."""
+        out = _redact_args({"table": "incident", "limit": 10, "sys_id": "abc"})
+        assert out == {"table": "incident", "limit": 10, "sys_id": "abc"}
+
+    def test_key_match_is_case_insensitive(self) -> None:
+        """Sensitive key matching ignores case."""
+        out = _redact_args({"DATA": "x", "Token": "y"})
+        assert out["DATA"] == _REDACTED
+        assert out["Token"] == _REDACTED

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import uuid
 from typing import Any
+from unittest.mock import patch
 
 from servicenow_mcp.decorators import _REDACTED, _redact_args, tool_handler
 from servicenow_mcp.errors import ForbiddenError
@@ -224,3 +225,38 @@ class TestRedactArgs:
         out = _redact_args({"DATA": "x", "Token": "y"})
         assert out["DATA"] == _REDACTED
         assert out["Token"] == _REDACTED
+
+    async def test_wrapper_pipes_redacted_args_into_sentry_context(self) -> None:
+        """``tool_handler`` must attach the *redacted* kwargs dict to Sentry.
+
+        ``_redact_args`` is exercised in isolation by the tests above; this
+        test pins the wiring at decorators.py so that a future refactor
+        cannot accidentally hand raw kwargs (including ``password``,
+        ``data``, etc.) to ``set_sentry_context``.
+        """
+        with patch("servicenow_mcp.decorators.set_sentry_context") as mock_ctx:
+
+            @tool_handler
+            async def my_tool(
+                table: str,
+                data: str = "",
+                password: str = "",
+                *,
+                correlation_id: str,
+            ) -> str:
+                return format_response(data=None, correlation_id=correlation_id)
+
+            await my_tool(
+                table="incident",
+                data='{"password":"hunter2"}',
+                password="hunter2",  # NOSONAR(S2068) - test fixture, not a credential
+            )
+
+            tool_calls = [c for c in mock_ctx.call_args_list if c.args and c.args[0] == "tool"]
+            assert tool_calls, "set_sentry_context('tool', ...) was never called"
+            ctx_payload = tool_calls[-1].args[1]
+            recorded_args = ctx_payload["args"]
+
+            assert recorded_args["data"] == _REDACTED
+            assert recorded_args["password"] == _REDACTED
+            assert recorded_args["table"] == "incident"

--- a/tests/test_flow_values.py
+++ b/tests/test_flow_values.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from servicenow_mcp.tools import _flow_values
 from servicenow_mcp.tools._flow_values import decode_values, looks_compressed
 
 
@@ -153,3 +154,46 @@ def test_decode_values_gzip_with_non_utf8_bytes_raises_value_error() -> None:
     assert encoded.startswith("H4sIA")  # sanity: prefix scan is a no-op
     with pytest.raises(ValueError, match="not valid JSON"):
         decode_values(encoded)
+
+
+# ---------------------------------------------------------------------------
+# decode_values: decompression-bomb guards
+# ---------------------------------------------------------------------------
+
+
+def test_decode_values_rejects_oversize_compressed_payload() -> None:
+    """A base64-decoded wire payload over MAX_COMPRESSED_BYTES is rejected.
+
+    The reject path runs before any decompressor is allocated, so even a
+    legitimate-looking gzip blob is refused if its compressed size exceeds
+    the wire cap.
+    """
+    # Random bytes don't compress well; pad to exceed the 1 MiB compressed cap.
+    big_blob = b"\x00" * (_flow_values.MAX_COMPRESSED_BYTES + 1024)
+    encoded = base64.b64encode(big_blob).decode("ascii")
+    with pytest.raises(ValueError, match="compressed payload exceeds maximum"):
+        decode_values(encoded)
+
+
+def test_decode_values_rejects_gzip_bomb() -> None:
+    """A gzip payload that decompresses past MAX_DECOMPRESSED_BYTES is rejected.
+
+    ``b"A" * (MAX_DECOMPRESSED_BYTES + 1024)`` compresses to a tiny base64
+    blob but would expand past the cap; the decoder must reject without
+    materializing the full output.
+    """
+    bomb_plain = b"A" * (_flow_values.MAX_DECOMPRESSED_BYTES + 1024)
+    encoded = base64.b64encode(gzip.compress(bomb_plain)).decode("ascii")
+    # Sanity: the compressed wire form is well under the wire cap, so the
+    # reject path is the *decompression* cap, not the compressed-size cap.
+    assert len(base64.b64decode(encoded)) < _flow_values.MAX_COMPRESSED_BYTES
+    with pytest.raises(ValueError, match="decompressed payload exceeds maximum"):
+        decode_values(encoded)
+
+
+def test_decode_values_caps_are_tunable_module_constants() -> None:
+    """The caps are module-level ints so tests and ops can read/tune them."""
+    assert isinstance(_flow_values.MAX_COMPRESSED_BYTES, int)
+    assert isinstance(_flow_values.MAX_DECOMPRESSED_BYTES, int)
+    assert _flow_values.MAX_COMPRESSED_BYTES > 0
+    assert _flow_values.MAX_DECOMPRESSED_BYTES > 0

--- a/tests/test_flow_values.py
+++ b/tests/test_flow_values.py
@@ -197,3 +197,36 @@ def test_decode_values_caps_are_tunable_module_constants() -> None:
     assert isinstance(_flow_values.MAX_DECOMPRESSED_BYTES, int)
     assert _flow_values.MAX_COMPRESSED_BYTES > 0
     assert _flow_values.MAX_DECOMPRESSED_BYTES > 0
+
+
+# ---------------------------------------------------------------------------
+# decode_values: stream-completeness guards
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_gzip_stream_rejected() -> None:
+    """A gzip member missing its trailing footer bytes must be rejected.
+
+    Without the eof check, ``decompressobj`` happily yields the inflated
+    bytes it has so far; if they happen to be valid JSON, callers would
+    receive partial data with no signal it was truncated.
+    """
+    raw = gzip.compress(json.dumps([{"k": "v"}]).encode("utf-8"))
+    truncated = raw[:-4]  # lop off the last 4 bytes of the gzip footer
+    encoded = base64.b64encode(truncated).decode("ascii")
+    with pytest.raises(ValueError, match="invalid or truncated gzip stream"):
+        decode_values(encoded)
+
+
+def test_trailing_garbage_after_gzip_rejected() -> None:
+    """Bytes appearing after a complete gzip member must be rejected.
+
+    ``decompressobj`` stops at the footer and stashes the extra bytes in
+    ``unused_data``; silently dropping them would let an attacker append
+    smuggled content that downstream tooling never sees.
+    """
+    raw = gzip.compress(json.dumps([{"k": "v"}]).encode("utf-8"))
+    with_garbage = raw + b"\x00garbage-trailer\x00"
+    encoded = base64.b64encode(with_garbage).decode("ascii")
+    with pytest.raises(ValueError, match="invalid or truncated gzip stream"):
+        decode_values(encoded)

--- a/tests/test_record_write.py
+++ b/tests/test_record_write.py
@@ -166,6 +166,7 @@ class TestActionDispatch:
         assert "script_field requires script_path" in result["error"]["message"]
 
     @pytest.mark.asyncio()
+    @respx.mock
     async def test_oversized_data_payload_rejected_before_token_creation(
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
@@ -184,10 +185,10 @@ class TestActionDispatch:
 
         with patch.object(record_write_module.PreviewTokenStore, "create", _spy_create):
             tools = _register_and_get_tools(settings, auth_provider)
-            # 1 MiB + 1 byte payload as a JSON object: pad a single field.
-            oversized_value = "x" * (1 * 1024 * 1024 + 1)
+            # MAX_PAYLOAD_BYTES + 1 byte payload as a JSON object: pad a single field.
+            oversized_value = "x" * (record_write_module.MAX_PAYLOAD_BYTES + 1)
             payload = json.dumps({"short_description": oversized_value})
-            assert len(payload.encode("utf-8")) > 1 * 1024 * 1024
+            assert len(payload.encode("utf-8")) > record_write_module.MAX_PAYLOAD_BYTES
             raw = await tools["record_write"](
                 action="create",
                 table="incident",

--- a/tests/test_record_write.py
+++ b/tests/test_record_write.py
@@ -165,6 +165,40 @@ class TestActionDispatch:
         assert result["status"] == "error"
         assert "script_field requires script_path" in result["error"]["message"]
 
+    @pytest.mark.asyncio()
+    async def test_oversized_data_payload_rejected_before_token_creation(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """``data`` >1 MiB returns a structured error and creates no preview token."""
+        from servicenow_mcp.tools import record_write as record_write_module
+
+        # Patch PreviewTokenStore.create to detect any token-allocation attempt.
+        # If the cap fires correctly, this never runs.
+        created_tokens: list[Any] = []
+
+        original_create = record_write_module.PreviewTokenStore.create
+
+        async def _spy_create(self: Any, payload: dict[str, Any]) -> str:
+            created_tokens.append(payload)
+            return await original_create(self, payload)
+
+        with patch.object(record_write_module.PreviewTokenStore, "create", _spy_create):
+            tools = _register_and_get_tools(settings, auth_provider)
+            # 1 MiB + 1 byte payload as a JSON object: pad a single field.
+            oversized_value = "x" * (1 * 1024 * 1024 + 1)
+            payload = json.dumps({"short_description": oversized_value})
+            assert len(payload.encode("utf-8")) > 1 * 1024 * 1024
+            raw = await tools["record_write"](
+                action="create",
+                table="incident",
+                data=payload,
+            )
+
+        result = decode_response(raw)
+        assert result["status"] == "error"
+        assert "1 MiB" in result["error"]["message"]
+        assert created_tokens == [], "no preview token should be allocated for oversized payload"
+
 
 # ---------------------------------------------------------------------------
 # Standard record write (no script_path)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -80,9 +80,9 @@ class TestSetupSentry:
         call_kwargs = mock_init.call_args[1]
         assert call_kwargs["dsn"] == "https://key@sentry.io/123"
         assert call_kwargs["environment"] == "staging"
-        assert call_kwargs["send_default_pii"] is True
+        assert call_kwargs["send_default_pii"] is False
         assert call_kwargs["integrations"] == []
-        assert call_kwargs["traces_sample_rate"] == pytest.approx(1.0)
+        assert call_kwargs["traces_sample_rate"] == pytest.approx(0.1)
         assert call_kwargs["profiles_sample_rate"] is None
 
     def test_falls_back_to_servicenow_env(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1037,16 +1037,24 @@ class TestSafeToolCall:
         assert parsed["correlation_id"] == "test-corr-id"
 
     async def test_generic_exception_returns_error_envelope(self) -> None:
-        """Generic exceptions are caught and formatted as error envelope."""
+        """Truly unclassified exceptions are returned as an opaque envelope.
+
+        The original ``str(exc)`` is NOT exposed to the caller — it could leak
+        internal hostnames, paths, and stack fragments. The full exception is
+        logged locally instead. ``ValueError`` and ``ServiceNowMCPError`` have
+        their own arms with verbose messages — see the curated-error tests.
+        """
 
         async def fn() -> str:
-            raise ValueError("something broke")
+            raise RuntimeError("something broke")
 
         result = await safe_tool_call(fn, "test-corr-id")
         parsed = decode_response(result)
         assert parsed["status"] == "error"
         assert isinstance(parsed["error"], dict)
-        assert "something broke" in parsed["error"]["message"]
+        message = parsed["error"]["message"]
+        assert "something broke" not in message
+        assert message == "Internal error (correlation_id=test-corr-id)"
         assert parsed["correlation_id"] == "test-corr-id"
 
 

--- a/tests/tools/test_dictionary.py
+++ b/tests/tools/test_dictionary.py
@@ -16,6 +16,7 @@ from servicenow_mcp.auth import BasicAuthProvider
 from servicenow_mcp.config import Settings
 from servicenow_mcp.tools._dictionary import (
     DictionaryRegistry,
+    _attributes_admit_heuristic,
     looks_like_template,
 )
 
@@ -120,6 +121,41 @@ class TestHeuristicAdmission:
 
         assert [f.name for f in fields] == ["body"]
         assert fields[0].via_heuristic is True
+
+
+class TestAttributesAdmitHeuristic:
+    """The heuristic parses tokens at comma boundaries, not by substring."""
+
+    def test_empty_string_not_admitted(self) -> None:
+        assert _attributes_admit_heuristic("") is False
+
+    def test_legitimate_flag_admitted(self) -> None:
+        assert _attributes_admit_heuristic("tinymce_allow_all=true") is True
+
+    def test_legitimate_flag_with_other_tokens_admitted(self) -> None:
+        assert _attributes_admit_heuristic("foo=bar,tinymce_allow_all=true,baz=qux") is True
+
+    def test_html_sanitize_false_admitted(self) -> None:
+        assert _attributes_admit_heuristic("html_sanitize=false") is True
+
+    def test_substring_key_rejected(self) -> None:
+        """``my_tinymce_allow_all=true`` must not false-positive."""
+        assert _attributes_admit_heuristic("my_tinymce_allow_all=true,other=x") is False
+        assert _attributes_admit_heuristic("not_html_sanitize=false") is False
+
+    def test_wrong_value_rejected(self) -> None:
+        assert _attributes_admit_heuristic("tinymce_allow_all=false") is False
+        assert _attributes_admit_heuristic("html_sanitize=true") is False
+
+    def test_whitespace_tolerated(self) -> None:
+        assert _attributes_admit_heuristic("foo=bar, tinymce_allow_all = true ") is True
+
+    def test_case_insensitive(self) -> None:
+        assert _attributes_admit_heuristic("TINYMCE_ALLOW_ALL=TRUE") is True
+
+    def test_value_containing_equals_survives(self) -> None:
+        """Split on first ``=`` only; spurious ``=`` in values does not break parsing."""
+        assert _attributes_admit_heuristic("other=a=b,tinymce_allow_all=true") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses a red-team report covering 7 findings. All fixes reviewed and approved; full test suite passes (791 passed, 63 deselected).

## Findings

| # | Severity | Finding | Batch |
|---|----------|---------|-------|
| 1 | HIGH | Gzip decompression bomb via `flow(action="decode_values")` | B |
| 2 | HIGH | Sensitive tool args leaked to Sentry telemetry | A |
| 3 | MEDIUM | `safe_tool_call` leaks internal exception details in error envelopes | A |
| 4 | MEDIUM | `script_path` filesystem errors disclose path/permission details | A |
| 5 | MEDIUM | Substring-based `no_audit=true` check matches `my_no_audit=true` | C |
| 6 | INFO | `_NO_AUDIT_RE` brittle around trailing whitespace | C |
| 7 | INFO | `record_write` accepts unbounded payloads before token allocation | C (committed in A) |

## Batches

- **Batch A — telemetry/error hygiene.** Sentry tool-arg redaction (`_SENSITIVE_ARG_KEYS` extended with `variables`, `conditions`, `text`); `send_default_pii=False`; `traces_sample_rate=0.1`; opaque generic exception arm in `safe_tool_call`; collapsed filesystem error messages in `_read_script_file`; opaque error envelope on `FileNotFoundError`/`PermissionError` in `record_write`; new `MAX_PAYLOAD_BYTES = 1 MiB` cap enforced before token allocation.
- **Batch B — gzip bomb.** Replaced `gzip.decompress` in `_flow_values` with bounded `zlib.decompressobj(...).decompress(raw, MAX+1)`; `MAX_COMPRESSED_BYTES = 1 MiB` wire cap; `MAX_DECOMPRESSED_BYTES = 4 MiB` output cap; 3 new tests cover bomb/oversize paths.
- **Batch C — remaining findings.** `_dictionary._parse_attributes` now does token-boundary parsing instead of a substring match; `_audit._NO_AUDIT_RE` tolerates trailing whitespace.

## Tests

`uv run pytest --no-cov -q` → **791 passed, 63 deselected**
`uv run ruff check .` → clean
`uv run mypy src/` → clean

## Follow-ups

- `docs/wiki/Telemetry.md` (lines 64/66) still references the old `send_default_pii=True` and `traces_sample_rate=1.0` defaults. Doc drift will be addressed in a follow-up PR.
