### PR TITLE
docs: sync docs and CHANGELOG with PR #85 security hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,8 @@ SERVICENOW_PASSWORD=your-password-here
 # -----------------------------------------------------------------------------
 
 # Tool package preset or comma-separated group names
-# Presets: full, core_readonly, none, itil, developer, readonly, analyst,
-#          incident_management, change_management, cmdb, problem_management,
-#          request_management, knowledge_management, service_catalog
+# Presets: full, readonly, core_readonly, none. Comma-separated tool group
+# names are also accepted (e.g., MCP_TOOL_PACKAGE=query,describe).
 # MCP_TOOL_PACKAGE=full
 
 # Environment label - set to "prod" or "production" to enable production guards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ reason = write_blocked_reason("incident", settings)
 
 **Tool functions never raise to MCP.** The `@tool_handler` decorator combined with `safe_tool_call()` catches all exceptions and returns serialized error envelopes automatically. Manual try/except blocks are NOT needed in tool functions.
 
+`safe_tool_call()` arms, in order: `ACLError`, `ForbiddenError`, `ServiceNowMCPError`, `ValueError` - these four preserve verbose, caller-actionable messages. The final generic `Exception` arm returns an opaque `"Internal error (correlation_id=<uuid>)"` envelope and logs full detail via `logger.exception` + `sentry_capture(e)`.
+
 When Sentry is active, `safe_tool_call()` also calls `sentry_capture(e)` to capture exceptions before returning the error envelope.
 
 ## 🎯 @tool_handler Decorator - THE CENTRAL PATTERN
@@ -161,9 +163,9 @@ async def my_tool(param: str, correlation_id: str = "") -> str:
 What `@tool_handler` does:
 
 1. Auto-generates `correlation_id` via `generate_correlation_id()` (UUID4).
-2. Wraps the function call in `safe_tool_call()` which catches `ForbiddenError` and `Exception`, returning serialized error envelopes.
+2. Wraps the function call in `safe_tool_call()` which catches `ACLError`, `ForbiddenError`, `ServiceNowMCPError`, and `ValueError` (verbose envelopes) plus generic `Exception` (opaque `"Internal error (correlation_id=...)"` envelope with `logger.exception` + `sentry_capture`).
 3. Hides `correlation_id` from the FastMCP tool schema by overriding `__signature__` and deleting `__wrapped__`.
-4. Sets Sentry tags (`tool.name`, `tool.correlation_id`) and context with tool name, correlation_id, and args.
+4. Sets Sentry tags (`tool.name`, `tool.correlation_id`) and context with tool name, correlation_id, and redacted args. Sensitive argument keys are replaced with `"***REDACTED***"` before transmission to Sentry (see Sentry Module section).
 
 ## 📊 Response Format
 
@@ -258,7 +260,7 @@ Script-bearing artifacts (Business Rules, Script Includes, UI Macros, etc.) are 
 1. Walks `sys_db_object.super_class` child-first, bounded at depth 8, with a cycle guard.
 2. Fetches active `sys_dictionary` rows for each table in the chain.
 3. Admits a field when its `internal_type` is in `UNAMBIGUOUS_SCRIPT_TYPES` (`script`, `script_plain`, `script_server`, `script_client`, `email_script`, `html_script`, `html_template`, `css`).
-4. For ambiguous types (`html`, `xml`), admits the field only when `attributes` contains `tinymce_allow_all=true` or `html_sanitize=false`.
+4. For ambiguous types (`html`, `xml`), admits the field only when `_parse_attributes(attributes)` yields an exact token-boundary match for `tinymce_allow_all=true` or `html_sanitize=false`. The parser splits on commas, partitions on the first `=`, and lowercases keys and values. Substring matches like `my_tinymce_allow_all=true` no longer admit.
 5. Drops anything in `EXCLUDED_ELEMENTS` (`translated_html`, `template_value`, `glide_var`, `json`, `conditions`, `condition_string`, `glide_action_list`, `variable_conditions`, `snapshot_template_value`, `variable_template_value`).
 6. Caches per-table results for the registry lifetime; `flush(table=None)` invalidates everything or a single table.
 
@@ -270,8 +272,8 @@ Discover the script fields for any table at runtime via `describe(action='list_s
 
 `record_write` accepts an optional `script_path` for any table that has at least one script-bearing field:
 
-- Path is resolved via `Path.resolve(strict=True)` to prevent symlink/traversal attacks.
-- The resolved path must be under the directory defined by the `script_allowed_root` setting.
+- `script_allowed_root` is resolved and `is_dir()`-validated **before** any user-controlled `script_path.resolve()`.
+- All user-path rejections (file missing, not regular, outside root, symlink escape) return a single opaque message: `"script_path is not readable or is outside the allowed root"`. Configuration errors (`script_allowed_root` unset or not a directory) and the >1 MiB file-size error remain verbose.
 - File is read as UTF-8; maximum size is 1 MB (`MAX_SCRIPT_FILE_BYTES`).
 - Content is written to the first script-bearing field detected by `DictionaryRegistry` (child-first, sys_dictionary row order), unless `script_field` overrides it.
 - When the resolved field has `internal_type == 'xml'`, the content is validated as well-formed XML (`xml.etree.ElementTree.fromstring`) before any platform call; malformed content yields a structured error.
@@ -288,6 +290,10 @@ Discover the script fields for any table at runtime via `describe(action='list_s
 ### record_read
 
 Read-only counterpart. `record_read(table, sys_id=..., name=...)` returns the masked record plus the `script_fields` list resolved by `DictionaryRegistry` for the table, enabling discovery-driven multi-field edits. Exactly one of `sys_id` or `name` must be supplied; ambiguous names (>1 match) and missing records return structured errors. Included in both `full` and `readonly` packages.
+
+### Payload Size Cap
+
+`record_write` enforces `MAX_PAYLOAD_BYTES = 1 MiB` on the `data` parameter (covers both `create.data` and `update.changes`). The check runs in `_validate_action_args` before `_prepare_payload`, before `parse_payload_json`, and before any `PreviewTokenStore.create` call. `record_apply` inherits the cap by construction because it only reads previously-validated tokens. Defence in depth: `parse_payload_json` has its own 256 KiB cap downstream; the 1 MiB outer cap is the entry-point ceiling.
 
 ## 🔄 ChoiceRegistry
 
@@ -338,7 +344,7 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 
 - Reads both V1 (`sys_hub_action_instance`, `sys_hub_flow_logic`, `sys_hub_trigger_instance`) and V2 (`sys_hub_action_instance_v2`, `sys_hub_flow_logic_instance_v2`, `sys_hub_trigger_instance_v2`) Flow Designer tables.
 - Joins V2 record-trigger conditions through `sys_flow_record_trigger.sys_id == trigger_v2.remote_trigger_id`.
-- Pure decoder lives in `tools/_flow_values.py` as `decode_values()` and `looks_compressed()`.
+- Pure decoder lives in `tools/_flow_values.py` as `decode_values()` and `looks_compressed()`. Decompression is bounded: `MAX_COMPRESSED_BYTES = 1 MiB` (wire cap, checked before allocating the decompressor) and `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected with `ValueError`.
 - Deliberately does not use undocumented `/api/now/processflow/*` endpoints.
 - Deliberately skips `sys_hub_flow_snapshot` because it is an opaque compiled cache.
 - Per-node decode failures add `decode_error` to that node only; the enclosing `inspect` response still succeeds.
@@ -360,7 +366,7 @@ Dispatched via the read-only `audit` tool. Available in the `full` and `readonly
 - `verdict` enum: `audited`, `not_audited_field_flag` (with `reason` of `audit_flag` or `no_audit_attribute`), `not_audited_table_flag`, `audited_but_inactive`, `inconclusive`.
 - The `sys_audit` table is one of the largest tables on the platform. Every action that reads it applies a default 90-day window. Callers MAY override the window via `window_days` (or an explicit `since` on `history`) but SHOULD keep the default - wider windows cause slow queries and risk timeouts. Responses include both the `window_days` actually used and a `window_note` describing it.
 - Field-level audit is resolved child-first along `super_class`; the first `sys_dictionary` row found wins, and `inherited_from` names the source table (or is `null` when the queried table declared its own row).
-- `no_audit=true` in the `attributes` blob is an absolute veto over the boolean `audit` column. It is matched at comma boundaries so substrings like `my_no_audit=true` do not false-positive.
+- `no_audit=true` in the `attributes` blob is an absolute veto over the boolean `audit` column. It is matched at comma boundaries so substrings like `my_no_audit=true` do not false-positive. Trailing whitespace before end-of-string is tolerated (`"no_audit=true "` correctly vetoes).
 - Positive control disambiguates "no field activity in window" from "audit not configured": zero field rows with non-zero table rows means `audited_but_inactive`; zero on both means `inconclusive`.
 - `AuditRegistry` caches table-level posture and per-(table, field) resolution for the server lifetime; `sys_audit` row counts are NEVER cached.
 - Deliberately does not inspect `sys_audit_delete`, `sys_audit_relation`, or `sys_history_line` - those are distinct stores with different schemas.
@@ -426,6 +432,16 @@ The registry contains 4 preset packages. Tool groups are loaded from `servicenow
 ## 🔒 Sentry Module
 
 Opt-in error tracking. `tool.name` tag values were updated in v0.10.0 to reflect the unified tool surface.
+
+### SDK Defaults
+
+- `send_default_pii=False` - no PII in breadcrumbs or request bodies.
+- `traces_sample_rate=0.1` - 10% of transactions sampled.
+- Both are operator-tunable via standard Sentry SDK env vars.
+
+### Argument Redaction
+
+`@tool_handler` redacts sensitive argument keys before attaching them to Sentry context. The `_SENSITIVE_ARG_KEYS` frozenset (case-insensitive, exact-name match): `data`, `content_base64`, `value`, `script_path`, `encoded_query`, `params`, `password`, `token`, `secret`, `api_key`, `authorization`, `variables`, `conditions`, `text`. Redacted value: `_REDACTED` (`"***REDACTED***"`). Redaction is shallow - JSON-shaped string args are replaced as a whole, not parsed and field-redacted. `correlation_id` is dropped from the args dict (already promoted to top-level context).
 
 ### Key Functions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,8 @@ What `@tool_handler` does:
 3. Hides `correlation_id` from the FastMCP tool schema by overriding `__signature__` and deleting `__wrapped__`.
 4. Sets Sentry tags (`tool.name`, `tool.correlation_id`) and context with tool name, correlation_id, and redacted args. Sensitive argument keys are replaced with `"***REDACTED***"` before transmission to Sentry (see Sentry Module section).
 
+One exception: `list_tool_packages` (registered directly in the server bootstrap) is NOT wrapped by `@tool_handler`. It returns the raw `serialize(list_packages())` payload with no error envelope and no `correlation_id`. Source: `src/servicenow_mcp/server.py:45-48`.
+
 ## 📊 Response Format
 
 All tools return a serialized JSON string via `format_response()`:
@@ -227,7 +229,7 @@ Agents pass ServiceNow encoded query strings directly to the `query` tool. Refer
 
 ## 🏗 Tool Registration
 
-The server bootstrap uses an unconditional 4-argument registration pattern for all tool groups.
+The server bootstrap uses an unconditional 5-argument registration pattern for all tool groups.
 
 ```python
 def register_tools(
@@ -235,9 +237,11 @@ def register_tools(
     settings: Settings,
     auth_provider: BasicAuthProvider,
     choices: ChoiceRegistry | None = None,
+    dictionary: DictionaryRegistry | None = None,
 ) -> None:
-    # Modules that do not require the ChoiceRegistry explicitly ignore it
-    del choices  # unused; signature retained for loader parity
+    # Modules that do not require the ChoiceRegistry or DictionaryRegistry
+    # explicitly ignore them
+    del choices, dictionary  # unused; signature retained for loader parity
 
     @mcp.tool()
     @tool_handler
@@ -314,7 +318,7 @@ Read-only counterpart. `record_read(table, sys_id=..., name=...)` returns the ma
 
 ## 🔍 Investigation Modules
 
-Dispatched via the `investigate` tool with `action='run'` or `action='explain'`. The `explain` action trial-dispatches across registered modules. Bare-table forms are not supported.
+Dispatched via the `investigate` tool with `action='run'`, `action='explain'`, or `action='describe'`. The `explain` action trial-dispatches across registered modules. The `describe` action returns the registry without platform I/O. Bare-table forms are not supported.
 
 ### 7 Available Investigations
 
@@ -380,7 +384,7 @@ Dispatched via the read-only `audit` tool. Available in the `full` and `readonly
 3. Creates `FastMCP('servicenow-platform-mcp')`.
 4. Calls `attach_servicenow_state(...)` to attach shared state.
 5. Always registers the `list_tool_packages` tool.
-6. Loads tool groups via `importlib` and calls an unconditional 4-argument `register_tools(...)`.
+6. Loads tool groups via `importlib` and calls an unconditional 5-argument `register_tools(...)`.
 7. `main()` runs with stdio transport; `shutdown_sentry()` is called in a finally block.
 
 ## 🌐 Client
@@ -399,6 +403,7 @@ Dispatched via the read-only `audit` tool. Available in the `full` and `readonly
 | `mcp_tool_package`        | `str`       | `"full"`                                               | `MCP_TOOL_PACKAGE`        |
 | `servicenow_env`          | `str`       | `"dev"`                                                | `SERVICENOW_ENV`          |
 | `max_row_limit`           | `int`       | `100` (range 1-10000)                                  | `MAX_ROW_LIMIT`           |
+| `httpx_timeout_seconds`   | `float`     | `30.0` (range 1.0-600.0)                               | `HTTPX_TIMEOUT_SECONDS`   |
 | `large_table_names_csv`   | `str`       | `"syslog,sys_audit,sys_log_transaction,sys_email_log"` | `LARGE_TABLE_NAMES_CSV`   |
 | `script_allowed_root`     | `str`       | `""`                                                     | `SCRIPT_ALLOWED_ROOT`     |
 | `sentry_dsn`              | `str`       | `""`                                                     | `SENTRY_DSN`              |
@@ -412,9 +417,9 @@ The registry contains 4 preset packages. Tool groups are loaded from `servicenow
 
 | Package | Tools | Description |
 |---|---|---|
-| `full` | 13 | Every group (full surface, includes `build_query`) |
-| `readonly` | 9 | Read tools + investigate + resolve_choice |
-| `core_readonly` | 5 | Query + describe + attachment only |
+| `full` | 14 | Every group (full surface, includes `build_query`); `record_write` group registers `record_write` + `record_apply`, `attachment` group registers `attachment` + `attachment_write` |
+| `readonly` | 10 | Read tools + investigate + resolve_choice + audit + flow (still loads `attachment_write`, runtime-gated by `write_gate`) |
+| `core_readonly` | 5 | Query + describe + attachment (loads `attachment_write` too, runtime-gated by `write_gate`) |
 | `none` | 1 | Only `list_tool_packages` loaded |
 
 - **Custom Packages:** Comma-separated group names are supported (e.g., `MCP_TOOL_PACKAGE=query,describe`).
@@ -461,12 +466,12 @@ Use **respx** library with `@respx.mock` decorator on async test methods.
 
 ### Tool Test Helpers
 
-Tool tests live alongside the rest of the suite in `tests/`. Standard tool registration for tests uses the 4-argument signature:
+Tool tests live alongside the rest of the suite in `tests/`. Standard tool registration for tests uses the 5-argument signature:
 
 ```python
-def _register_and_get_tools(settings, auth_provider, choices=None):
+def _register_and_get_tools(settings, auth_provider, choices=None, dictionary=None):
     mcp = FastMCP("test")
-    register_tools(mcp, settings, auth_provider, choices=choices)
+    register_tools(mcp, settings, auth_provider, choices=choices, dictionary=dictionary)
     return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 * `flow` unified tool for read-only Flow Designer inspection (Washington DC V2 + V1 fallback). Five actions: `inspect`, `find_by_table`, `decode_values`, `list_triggers`, `describe`. Available in `full` and `readonly` presets.
 
+### Security
+
+* Sentry SDK defaults changed to `send_default_pii=False` and `traces_sample_rate=0.1` to reduce data exposure and trace volume. Both remain operator-tunable via standard Sentry SDK env vars. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* Sensitive tool arguments (`data`, `content_base64`, `value`, `script_path`, `encoded_query`, `params`, `password`, `token`, `secret`, `api_key`, `authorization`, `variables`, `conditions`, `text`) are now redacted before transmission to Sentry. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* Unclassified exceptions now return an opaque `"Internal error (correlation_id=...)"` envelope to agents instead of leaking `str(e)`. Full detail is logged locally and captured to Sentry. Known exception types (`ACLError`, `ForbiddenError`, `ServiceNowMCPError`, `ValueError`) continue to surface curated messages. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* `script_path` rejections (missing file, not regular, outside root, symlink escape) now return a single opaque error message, closing the differential-error filesystem-enumeration channel. Root directory is validated before any user-controlled path resolution. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* Flow Designer `decode_values` decompression is now bounded: `MAX_COMPRESSED_BYTES = 1 MiB` (wire cap) and `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* `record_write` enforces `MAX_PAYLOAD_BYTES = 1 MiB` on the `data` parameter before parsing or token creation. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* Dictionary attribute parsing for ambiguous `html`/`xml` field types now uses token-boundary matching via `_parse_attributes()` instead of substring matching. `my_tinymce_allow_all=true` no longer falsely admits a field. ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+* Audit `no_audit=true` regex now tolerates trailing whitespace before end-of-string (`"no_audit=true "` correctly vetoes auditing). ([#85](https://github.com/Xerrion/servicenow-platform-mcp/pull/85))
+
 ## [0.10.0](https://github.com/Xerrion/servicenow-platform-mcp/compare/v0.9.1...v0.10.0) (2026-05-08)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for considering a contribution to **servicenow-platform-mcp** - an MCP server (Model Context Protocol) that gives AI clients structured access to ServiceNow instances.
+
+## Security Vulnerabilities
+
+Do **not** file a public issue for security bugs. See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
+## Reporting a Bug
+
+Open a GitHub issue with:
+
+- What you expected vs. what happened
+- The `correlation_id` from the error response (if available)
+- MCP client name and version
+- Tool package in use (`MCP_TOOL_PACKAGE` value)
+- Python version and OS
+- Redacted environment (instance URL domain is fine; never include credentials)
+
+## Proposing a Feature
+
+Open an issue to discuss before writing code. Describe the use case, not just the solution.
+
+## Submitting a Pull Request
+
+### Setup
+
+```bash
+git clone https://github.com/Xerrion/servicenow-platform-mcp.git
+cd servicenow-platform-mcp
+uv sync --group dev
+```
+
+### Workflow
+
+1. Create a feature branch from `main` (never commit to `main` directly).
+2. Make your changes - one concern per PR.
+3. Run the full check suite before pushing:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy src/
+uv run pytest
+```
+
+4. Commit with conventional messages: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`.
+5. Open the PR via `gh pr create` or the GitHub UI.
+6. Update documentation alongside any behavior change.
+
+### CI
+
+CI runs lint, type-check, and tests on Python 3.12, 3.13, and 3.14. All jobs must pass.
+
+## Code Style
+
+- **Formatter/linter**: Ruff - line length 120, double quotes, Python 3.12 target
+- **Type annotations**: all function signatures fully typed (`disallow_untyped_defs`)
+- **Imports**: absolute only, stdlib then third-party then local
+- **Naming**: `snake_case` functions, `PascalCase` classes, `UPPER_SNAKE_CASE` constants
+- **Package manager**: uv (not pip, not poetry)
+
+## Deeper Development Guide
+
+For architecture details, the tool-authoring recipe, testing patterns, and the release process, see [docs/wiki/Development.md](docs/wiki/Development.md).
+
+## Conduct
+
+Be respectful and constructive. Disagreements happen; keep them about the work.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,198 +1,156 @@
-# ServiceNow Platform MCP Server - Installation Guide
+# Installation
 
-> **For AI Agents:** You are helping your user install and configure the ServiceNow Platform MCP server.
-> Follow each step below in order. Ask the user questions where indicated, then generate the appropriate configuration.
+How to install, configure, and run the servicenow-platform-mcp server.
 
-## Step 0: Gather Credentials
+## Prerequisites
 
-Ask the user for their ServiceNow instance details:
+- **Python 3.12 or later** (3.13 and 3.14 are also supported).
+- **[uv](https://docs.astral.sh/uv/)** package manager.
+- **A ServiceNow instance** with REST API access and a user account that can authenticate via HTTP Basic Auth.
 
-1. **What is your ServiceNow instance URL?**
-   - Must start with `https://` (e.g., `https://dev12345.service-now.com`)
-   - Trailing slash will be stripped automatically
+## Install
 
-2. **What is your ServiceNow username?**
-   - Needs admin or appropriate roles for the tools being used
-
-3. **What is your ServiceNow password?**
-   - Will be stored in the MCP client config (environment variable, not committed to source)
-
-## Step 1: Determine Environment
-
-Ask the user:
-
-1. **Is this a production instance?**
-   - If **yes** - set `SERVICENOW_ENV=prod` (all write operations will be blocked)
-   - If **no** - set `SERVICENOW_ENV=dev` (default, writes allowed)
-
-2. **Do you want all tools or a specific subset?**
-   - **All tools** (default) - set `MCP_TOOL_PACKAGE=full` (13 tools, including `audit` and `flow`)
-   - **Read-only** - set `MCP_TOOL_PACKAGE=readonly` (9 tools, including `audit` and `flow`)
-   - **Minimal** - set `MCP_TOOL_PACKAGE=core_readonly` (5 tools: query, describe, attachment, attachment_write, list_tool_packages)
-   - **Custom** - comma-separated tool names (e.g., `query,describe,attachment`)
-
-## Step 2: Choose MCP Client
-
-Ask the user which MCP client they use, then generate the appropriate configuration file.
-
-### OpenCode
-
-Write to `~/.config/opencode/opencode.json`:
-
-```json
-{
-  "mcp": {
-    "servicenow": {
-      "type": "local",
-      "command": ["uvx", "servicenow-platform-mcp"],
-      "environment": {
-        "SERVICENOW_INSTANCE_URL": "<instance_url>",
-        "SERVICENOW_USERNAME": "<username>",
-        "SERVICENOW_PASSWORD": "<password>",
-        "MCP_TOOL_PACKAGE": "<package>",
-        "SERVICENOW_ENV": "<env>"
-      }
-    }
-  }
-}
+```bash
+git clone https://github.com/lassenn/servicenow-platform-mcp.git
+cd servicenow-platform-mcp
+uv sync --group dev
 ```
+
+No build step is needed. The server runs directly from source.
+
+## Credentials
+
+```bash
+cp .env.example .env.local
+```
+
+Open `.env.local` and fill in the three required variables:
+
+```bash
+SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
+SERVICENOW_USERNAME=your_user
+SERVICENOW_PASSWORD=your_password
+```
+
+`SERVICENOW_INSTANCE_URL` must use HTTPS. A trailing slash is stripped automatically.
+
+> **Note:** `.env.example` may list preset package names that no longer exist in the registry. Refer to the [Tool Packages](docs/wiki/Tool-Packages.md) page for current presets.
+
+## Choosing a tool package
+
+The `MCP_TOOL_PACKAGE` environment variable controls which tools the server exposes. Four presets exist:
+
+| Preset | Description |
+|---|---|
+| `full` | All 14 tools (read, write, investigate, flow, audit, catalog, build_query) |
+| `readonly` | 10 tools - read and inspect, no create/update/delete |
+| `core_readonly` | 5 tools - query, describe, attachment |
+| `none` | Only `list_tool_packages` (1 tool) |
+
+You can also pass a comma-separated list of tool group names for a custom surface (e.g. `MCP_TOOL_PACKAGE=query,describe,flow`).
+
+See [Tool Packages](docs/wiki/Tool-Packages.md) for the full group list and tool counts.
+
+## Production mode
+
+Set `SERVICENOW_ENV=production` when pointing at a production instance.
+
+This blocks **all** write operations regardless of table. The write gate returns an error envelope with the message `"Write operations are blocked in production environments"` for every call to `record_write`, `record_apply`, `attachment_write` (upload and delete), and catalog ordering actions. The gate is function-based and never raises - it returns a serialized error response to the caller.
+
+The eight permanently denied tables (`sys_user_has_password`, `oauth_credential`, `oauth_entity`, `sys_certificate`, `sys_ssh_key`, `sys_credentials`, `discovery_credentials`, `sys_user_token`) are blocked in every environment, including dev.
+
+## Running the server
+
+The entry point is `servicenow_mcp.server:main`. It uses stdio transport - no HTTP listener is started.
+
+```bash
+uv run python -m servicenow_mcp.server
+```
+
+In practice, an MCP client spawns the process and communicates over stdin/stdout.
+
+## Wiring an MCP client
 
 ### Claude Desktop
 
-Add to `claude_desktop_config.json`:
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
 
 ```json
 {
   "mcpServers": {
     "servicenow": {
-      "command": "uvx",
-      "args": ["servicenow-platform-mcp"],
+      "command": "uv",
+      "args": ["--directory", "/path/to/servicenow-platform-mcp", "run", "python", "-m", "servicenow_mcp.server"],
       "env": {
-        "SERVICENOW_INSTANCE_URL": "<instance_url>",
-        "SERVICENOW_USERNAME": "<username>",
-        "SERVICENOW_PASSWORD": "<password>",
-        "MCP_TOOL_PACKAGE": "<package>",
-        "SERVICENOW_ENV": "<env>"
+        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
+        "SERVICENOW_USERNAME": "your_user",
+        "SERVICENOW_PASSWORD": "your_password"
       }
     }
   }
 }
 ```
 
-### VS Code / Cursor (Copilot MCP)
+### OpenCode
 
-Write to `.vscode/mcp.json` in the workspace:
+Add to your `opencode.json`:
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "servicenow": {
-      "command": "uvx",
-      "args": ["servicenow-platform-mcp"],
+      "command": "uv",
+      "args": ["--directory", "/path/to/servicenow-platform-mcp", "run", "python", "-m", "servicenow_mcp.server"],
       "env": {
-        "SERVICENOW_INSTANCE_URL": "<instance_url>",
-        "SERVICENOW_USERNAME": "<username>",
-        "SERVICENOW_PASSWORD": "<password>",
-        "MCP_TOOL_PACKAGE": "<package>",
-        "SERVICENOW_ENV": "<env>"
+        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
+        "SERVICENOW_USERNAME": "your_user",
+        "SERVICENOW_PASSWORD": "your_password"
       }
     }
   }
 }
 ```
 
-### Generic stdio
+## Smoke test
 
-If the user's client is not listed above, provide the generic command:
+Once your client connects, call `list_tool_packages` with no arguments. This tool:
 
-```bash
-SERVICENOW_INSTANCE_URL=<instance_url> \
-SERVICENOW_USERNAME=<username> \
-SERVICENOW_PASSWORD=<password> \
-MCP_TOOL_PACKAGE=<package> \
-SERVICENOW_ENV=<env> \
-uvx servicenow-platform-mcp
-```
+- Does not contact ServiceNow (no auth required).
+- Returns the package registry as a raw JSON payload (no correlation_id, no error envelope).
+- Confirms the server process is running and the MCP transport is working.
 
-**Important:** Replace all `<placeholder>` values with the user's actual answers from Steps 0-1 before writing the config.
+If that succeeds, try `query` with `table="incident"` and `limit=1` to verify credentials and network connectivity.
 
-## Step 3: Optional Configuration
+## Troubleshooting
 
-Ask the user if they want to configure any of these optional settings:
+**Auth failure (401)**
 
-1. **Row limit** - Maximum records per query (default: 100, range: 1-10000)
-   - Add `"MAX_ROW_LIMIT": "<number>"` to the environment/env block
+- Verify `SERVICENOW_INSTANCE_URL` is the base URL with no path suffix.
+- Confirm the username and password in `.env.local` match an active ServiceNow user.
+- Check that Basic Auth is enabled on the instance (some organizations disable it).
 
-2. **Large tables** - Tables that require date-bounded queries (default: `syslog,sys_audit,sys_log_transaction,sys_email_log`)
-   - Add `"LARGE_TABLE_NAMES_CSV": "<comma_separated_tables>"` to the environment/env block
+**ForbiddenError on writes**
 
-3. **Script file root** - When using `record_write` with `script_path`, constrains file reads to a directory tree. All path rejections return a single opaque error.
-    - Add `"SCRIPT_ALLOWED_ROOT": "<absolute_path>"` to the environment/env block
+Two independent checks can block writes:
 
-4. **Sentry error tracking** - MCP servers run as child processes, so stdout/stderr is invisible. Sentry provides error visibility.
-   - Add `"SENTRY_DSN": "<dsn_url>"` to the environment/env block
-   - Optionally add `"SENTRY_ENVIRONMENT": "<label>"` (defaults to `SERVICENOW_ENV`)
+1. The eight denied tables are blocked unconditionally in every environment.
+2. `SERVICENOW_ENV=production` (or `prod`) blocks all writes regardless of table.
 
-## Step 4: Verify Setup
+Both return a serialized error envelope - the server never raises to the MCP client.
 
-After writing the configuration, tell the user to:
+**script_path returns an opaque error**
 
-1. **Restart their MCP client** (or reload the MCP server)
-2. **Test with a simple tool call** - try `list_tool_packages` to verify connectivity
-3. **If it fails**, check:
-   - Instance URL starts with `https://`
-   - Credentials are correct
-   - The user has network access to the ServiceNow instance
-   - `uvx` is installed (requires `uv` - install via `curl -LsSf https://astral.sh/uv/install.sh | sh`)
+The message `"script_path is not readable or is outside the allowed root"` collapses four distinct causes into one response for security:
 
-## Tool Reference
+1. The file does not exist.
+2. The path is not a regular file.
+3. The resolved path is outside `SCRIPT_ALLOWED_ROOT`.
+4. A symlink escapes the allowed root after resolution.
 
-The server provides 12 unified tools. Use `list_tool_packages` to see available tools at runtime. For detailed usage patterns and complex queries, see [Agent Recipes](docs/agent-recipes.md).
+Configuration errors (`SCRIPT_ALLOWED_ROOT` not set or not a directory) produce distinct, verbose messages.
 
-### query
-Search and retrieve records using ServiceNow encoded query strings. Supports `resolve_labels` for human-readable filtering and `display_values` for labeled results.
+## Next steps
 
-### build_query
-Stateless helper that compiles a JSON array of condition objects into a ServiceNow encoded query string (returned in `data.query`). Pass the returned string as the `query` parameter to the `query` tool. Available in the `full` package only - read-only presets pass encoded queries to `query` directly.
-
-### describe
-Retrieve table schema and metadata. Returns a slim set of field attributes by default (8 keys); use `verbose=true` for the full platform payload.
-
-### record_write
-Unified tool for `create`, `update`, and `delete` actions. When called with `preview=true` (default), it returns a `preview_token` consumed by `record_apply`. The `data` parameter is capped at 1 MiB (`MAX_PAYLOAD_BYTES`). Supports local script injection via `script_path` for any table whose dictionary fields are script-bearing (Business Rules, Script Includes, UI Pages, Widgets, UI Macros, ACLs, etc.) — script fields are discovered at runtime from `sys_dictionary`, no hardcoded catalog. Use `script_field` to target a specific field on tables that have more than one.
-
-### record_read
-Read-only counterpart to `record_write` for platform artifacts. Resolves a record by `sys_id` or `name` and returns the masked record plus the `script_fields` list so callers can drive multi-field edits without guessing field names.
-
-### record_apply
-Commits a write operation previously staged with `record_write(preview=true)`. Takes the returned `preview_token`.
-
-### attachment
-Dispatcher for read operations: `list`, `get`, `download`.
-
-### attachment_write
-Dispatcher for write operations: `upload`, `delete`. Included in all standard packages; blocked in production via runtime write gating.
-
-### investigate
-Runs automated diagnostic modules. Actions: `run` (execute module) or `explain` (interpret findings). Includes: `stale_automations`, `table_health`, `performance_bottlenecks`, and more.
-
-### resolve_choice
-Maps human-readable labels (e.g., "In Progress") to underlying ServiceNow choice values (e.g., "2").
-
-### service_catalog
-Dispatcher for Service Catalog operations: browse catalogs, categories, items, and manage carts.
-
-### list_tool_packages
-Always-on tool to list the active tool package and its available tools.
-
-## Safety Guardrails
-
-These guardrails are always active. They reduce risk but are not a guarantee - always validate in a sub-production environment.
-
-- **Table Deny List** - Sensitive tables (`sys_user_has_password`, `sys_credentials`, etc.) are blocked.
-- **Sensitive Field Masking** - Fields matching `password`, `token`, `secret`, and others are masked.
-- **Row Limit Caps** - Query limits capped at `MAX_ROW_LIMIT` (default 100).
-- **Large Table Protection** - Configured tables require date-bounded queries.
-- **Write Gating** - All write operations blocked when `SERVICENOW_ENV` is set to `prod` or `production`.
-- **Attachment Limits** - 10 MB maximum per attachment transfer.
-- **Standardized Responses** - All tools return JSON-serialized envelopes with `correlation_id`, `status`, and `data`.
+- [Getting Started](docs/wiki/Getting-Started.md) - first workflows and patterns.
+- [Tool Reference](docs/wiki/Tool-Reference.md) - per-tool parameters and behavior.
+- [Safety and Policy](docs/wiki/Safety-and-Policy.md) - denied tables, masking, query safety, write gating.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,8 +126,8 @@ Ask the user if they want to configure any of these optional settings:
 2. **Large tables** - Tables that require date-bounded queries (default: `syslog,sys_audit,sys_log_transaction,sys_email_log`)
    - Add `"LARGE_TABLE_NAMES_CSV": "<comma_separated_tables>"` to the environment/env block
 
-3. **Script file root** - When using `record_write` with `script_path`, constrains file reads to a directory tree
-   - Add `"SCRIPT_ALLOWED_ROOT": "<absolute_path>"` to the environment/env block
+3. **Script file root** - When using `record_write` with `script_path`, constrains file reads to a directory tree. All path rejections return a single opaque error.
+    - Add `"SCRIPT_ALLOWED_ROOT": "<absolute_path>"` to the environment/env block
 
 4. **Sentry error tracking** - MCP servers run as child processes, so stdout/stderr is invisible. Sentry provides error visibility.
    - Add `"SENTRY_DSN": "<dsn_url>"` to the environment/env block
@@ -159,7 +159,7 @@ Stateless helper that compiles a JSON array of condition objects into a ServiceN
 Retrieve table schema and metadata. Returns a slim set of field attributes by default (8 keys); use `verbose=true` for the full platform payload.
 
 ### record_write
-Unified tool for `create`, `update`, and `delete` actions. When called with `preview=true` (default), it returns a `preview_token` consumed by `record_apply`. Supports local script injection via `script_path` for any table whose dictionary fields are script-bearing (Business Rules, Script Includes, UI Pages, Widgets, UI Macros, ACLs, etc.) — script fields are discovered at runtime from `sys_dictionary`, no hardcoded catalog. Use `script_field` to target a specific field on tables that have more than one.
+Unified tool for `create`, `update`, and `delete` actions. When called with `preview=true` (default), it returns a `preview_token` consumed by `record_apply`. The `data` parameter is capped at 1 MiB (`MAX_PAYLOAD_BYTES`). Supports local script injection via `script_path` for any table whose dictionary fields are script-bearing (Business Rules, Script Includes, UI Pages, Widgets, UI Macros, ACLs, etc.) — script fields are discovered at runtime from `sys_dictionary`, no hardcoded catalog. Use `script_field` to target a specific field on tables that have more than one.
 
 ### record_read
 Read-only counterpart to `record_write` for platform artifacts. Resolves a record by `sys_id` or `name` and returns the masked record plus the `script_fields` list so callers can drive multi-field edits without guessing field names.

--- a/README.md
+++ b/README.md
@@ -1,197 +1,82 @@
-<p align="center">
-  <img src="assets/banner.svg" alt="servicenow-platform-mcp banner" width="900" />
-</p>
-
-<p align="center">
-  <a href="https://pypi.org/project/servicenow-platform-mcp/"><img src="https://img.shields.io/pypi/v/servicenow-platform-mcp" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/servicenow-platform-mcp/"><img src="https://img.shields.io/pypi/pyversions/servicenow-platform-mcp" alt="Python versions"></a>
-  <a href="https://github.com/Xerrion/servicenow-platform-mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Xerrion/servicenow-platform-mcp" alt="License"></a>
-</p>
-
 # servicenow-platform-mcp
 
-A comprehensive [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for ServiceNow. Provides 12 unified tools for platform introspection, change intelligence, debugging, record management, and automated investigations.
+A Python 3.12+ async MCP server that gives AI agents structured, policy-guarded access to ServiceNow. It exposes schema inspection, record CRUD, attachment operations, audit trail analysis, Flow Designer inspection, and platform investigations - all over the Model Context Protocol's stdio transport.
 
-## Quick Start
+## What you get
 
-**1. Set environment variables:**
+The server presents a unified tool surface to any MCP-compatible client. Capabilities include:
+
+- **Query and inspect** - encoded-query search, aggregation, field-level schema discovery, choice-label resolution.
+- **Read and write records** - including script-bearing artifacts (Business Rules, Script Includes, UI Macros) with file-based script injection and preview-then-apply confirmation.
+- **Attachments** - list, download, upload, and delete with size-capped base64 transfer.
+- **Audit** - field-level audit verdict resolution, batch checks, and masked history retrieval.
+- **Flow Designer** - inspect flows, decode compressed action values, find record-trigger bindings.
+- **Investigations** - pluggable analysis modules for stale automations, deprecated APIs, ACL conflicts, performance bottlenecks, and more.
+- **Service Catalog** - browse catalogs, order items, manage carts.
+
+## Tool-package presets
+
+Control the exposed surface with `MCP_TOOL_PACKAGE`. Four presets ship; custom comma-separated group lists are also accepted.
+
+| Preset | Tools | Purpose |
+|--------|-------|---------|
+| `full` | 14 | Complete surface including writes and query builder |
+| `readonly` | 10 | Read operations, investigations, audit, and flow inspection |
+| `core_readonly` | 5 | Query, describe, and attachment only |
+| `none` | 1 | Only the `list_tool_packages` introspection tool |
+
+## Quickstart
 
 ```bash
-export SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
-export SERVICENOW_USERNAME=admin
-export SERVICENOW_PASSWORD=your-password
+# Install dependencies
+uv sync
+
+# Configure credentials
+cp .env.example .env.local
+# Edit .env.local with your instance URL, username, and password
+
+# Run the server (stdio transport)
+servicenow-platform-mcp
 ```
 
-**2. Run the server:**
+Three environment variables are required:
 
-```bash
-uvx servicenow-platform-mcp
-```
+- `SERVICENOW_INSTANCE_URL` - your instance (HTTPS enforced, e.g. `https://dev12345.service-now.com`)
+- `SERVICENOW_USERNAME`
+- `SERVICENOW_PASSWORD`
 
-**3. Connect your MCP client** (see [Configuration](#configuration) below).
-
-## Configuration
-
-### OpenCode
-
-Add to `~/.config/opencode/opencode.json`:
-
-```json
-{
-  "mcp": {
-    "servicenow": {
-      "type": "local",
-      "command": ["uvx", "servicenow-platform-mcp"],
-      "environment": {
-        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
-        "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password"
-      }
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-Add to `claude_desktop_config.json`:
+### MCP client configuration
 
 ```json
 {
   "mcpServers": {
     "servicenow": {
-      "command": "uvx",
-      "args": ["servicenow-platform-mcp"],
-      "env": {
-        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
-        "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password"
-      }
+      "command": "servicenow-platform-mcp",
+      "transport": "stdio"
     }
   }
 }
 ```
 
-### VS Code / Cursor
+## Safety posture
 
-Add to `.vscode/mcp.json`:
+Eight sensitive tables (credential stores, OAuth entities, SSH keys) are unconditionally denied at the policy layer. Fields matching sensitive patterns - passwords, tokens, secrets, API keys, private keys, credentials - are masked in every response. Write operations use a preview-then-apply flow by default: the server returns a confirmation token that must be explicitly applied before any mutation reaches ServiceNow. In production environments (`SERVICENOW_ENV=prod` or `production`), all write operations are blocked at runtime regardless of which tool package is loaded.
 
-```json
-{
-  "servers": {
-    "servicenow": {
-      "command": "uvx",
-      "args": ["servicenow-platform-mcp"],
-      "env": {
-        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
-        "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password"
-      }
-    }
-  }
-}
-```
+## Where to go next
 
-### Generic stdio
-
-```bash
-SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com \
-SERVICENOW_USERNAME=admin \
-SERVICENOW_PASSWORD=your-password \
-uvx servicenow-platform-mcp
-```
-
-## Environment Variables
-
-| Variable | Description | Default | Required |
-|----------|-------------|---------|----------|
-| `SERVICENOW_INSTANCE_URL` | Full URL (must start with `https://`) | - | Yes |
-| `SERVICENOW_USERNAME` | ServiceNow username | - | Yes |
-| `SERVICENOW_PASSWORD` | ServiceNow password | - | Yes |
-| `MCP_TOOL_PACKAGE` | Tool package to load (`full`, `readonly`, `core_readonly`, `none`) | `full` | No |
-| `SERVICENOW_ENV` | Environment label (`dev`/`test`/`staging`/`prod`) | `dev` | No |
-| `MAX_ROW_LIMIT` | Max rows per query (1-10000) | `100` | No |
-| `LARGE_TABLE_NAMES_CSV` | Tables requiring date filters | `syslog,sys_audit,sys_log_transaction,sys_email_log` | No |
-| `SCRIPT_ALLOWED_ROOT` | Root dir for `script_path` in artifact write | `""` (disabled) | When using `script_path` |
-| `SENTRY_DSN` | Sentry DSN for error reporting | `""` | No |
-| `SENTRY_ENVIRONMENT` | Sentry environment label | Falls back to `SERVICENOW_ENV` | No |
-
-The server reads from `.env` and `.env.local` files automatically.
-
-## AI Agent Setup
-
-Copy and paste this prompt to your AI agent (Claude Code, Cursor, OpenCode, etc.):
-
-```
-Install and configure servicenow-platform-mcp by following the instructions here:
-https://raw.githubusercontent.com/Xerrion/servicenow-platform-mcp/refs/heads/main/INSTALL.md
-```
-
-Or read the [Installation Guide](INSTALL.md) directly. For usage examples and patterns, see [Agent Recipes](docs/agent-recipes.md).
-
-## Key Features
-
-- **Platform Introspection** - Describe table schemas with `describe` and query records with `query` using encoded queries.
-- **Record Management** - Unified `record_write` and `record_apply` tools for create, update, and delete with a mandatory preview-then-apply safety pattern. Payload data is capped at 1 MiB.
-- **Script-Bearing Records** - Write Business Rules, Script Includes, UI Pages, Widgets, UI Macros, ACLs, and any other table whose dictionary fields carry executable script or markup, all via `record_write` with local script file support and per-field targeting (`script_field`). Script fields are discovered at runtime from `sys_dictionary` — no hardcoded artifact catalog. Read the same surface back via `record_read`, or enumerate a table's script fields with `describe(action='list_script_fields', table='<table>')`.
-- **Attachment Operations** - Unified `attachment` for read operations and `attachment_write` for mutations.
-- **Investigations** - Automated analysis of system health, stale automations, performance bottlenecks, and more via `investigate`.
-- **Label Resolution** - Map human-readable choice labels to underlying values automatically with `resolve_choice`.
-- **Service Catalog** - Dispatcher-based `service_catalog` tool for browsing and ordering.
-
-## Example Usage
-
-### Describe a Table
-```python
-await describe(table="incident")
-```
-
-### Query Records
-```python
-# Fetch high priority incidents using an encoded query
-await query(
-    table="incident",
-    encoded_query="active=true^priority=1",
-    fields="number,short_description,priority"
-)
-```
-
-## Tool Packages
-
-Control which tools are loaded with `MCP_TOOL_PACKAGE`.
-
-| Package | Tools | Description |
-|---------|-------|-------------|
-| `full` | 13 | All unified tools, including `audit`, `flow`, and the `build_query` helper (default) |
-| `readonly` | 9 | Includes `record_read`, `audit`, `flow`, and `attachment_write` (write_gate blocks in prod) |
-| `core_readonly` | 5 | Minimal read surface (includes `attachment_write`) |
-| `none` | 1 | Just `list_tool_packages` |
-
-Custom packages are supported via comma-separated tool names: `MCP_TOOL_PACKAGE="query,describe,attachment"`.
-
-## Safety
-
-- **Table Deny List** - Blocks access to sensitive system tables (`sys_user_has_password`, `sys_credentials`, etc.).
-- **Sensitive Field Masking** - Passwords, tokens, and secrets are automatically masked in responses.
-- **Write Gating** - All mutations are blocked when `SERVICENOW_ENV` is set to `prod` or `production`.
-- **Query Safety** - Enforces row limits and mandatory date filters on high-volume system tables.
-
-These guardrails reduce risk but are not a guarantee - always validate in a sub-production environment.
-
-See the [Safety & Policy](https://github.com/Xerrion/servicenow-platform-mcp/wiki/Safety-and-Policy) wiki page for complete details.
-
-## Development
-
-```bash
-git clone https://github.com/Xerrion/servicenow-platform-mcp.git
-cd servicenow-platform-mcp
-uv sync --group dev
-uv run pytest                  # Run tests
-uv run ruff check .            # Lint
-uv run ruff format .           # Format
-uv run mypy src/               # Type check
-```
+- [Getting Started](docs/wiki/Getting-Started.md) - detailed setup and first-use walkthrough
+- [Configuration](docs/wiki/Configuration.md) - full environment variable reference
+- [Tool Reference](docs/wiki/Tool-Reference.md) - per-tool parameter and response documentation
+- [Tool Packages](docs/wiki/Tool-Packages.md) - preset details and custom package composition
+- [Architecture](docs/wiki/Architecture.md) - server bootstrap, decorator patterns, state management
+- [Safety and Policy](docs/wiki/Safety-and-Policy.md) - denied tables, masking, query safety, write gating
+- [Investigations](docs/wiki/Investigations.md) - available analysis modules and their parameters
+- [Telemetry](docs/wiki/Telemetry.md) - opt-in Sentry integration
+- [Development](docs/wiki/Development.md) - contributing, linting, testing
+- [INSTALL.md](INSTALL.md) - alternative installation methods
 
 ## License
 
-[MIT](LICENSE)
+MIT. See [LICENSE](LICENSE).
+
+Built by the ServiceNow MCP Contributors.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Or read the [Installation Guide](INSTALL.md) directly. For usage examples and pa
 ## Key Features
 
 - **Platform Introspection** - Describe table schemas with `describe` and query records with `query` using encoded queries.
-- **Record Management** - Unified `record_write` and `record_apply` tools for create, update, and delete with a mandatory preview-then-apply safety pattern.
+- **Record Management** - Unified `record_write` and `record_apply` tools for create, update, and delete with a mandatory preview-then-apply safety pattern. Payload data is capped at 1 MiB.
 - **Script-Bearing Records** - Write Business Rules, Script Includes, UI Pages, Widgets, UI Macros, ACLs, and any other table whose dictionary fields carry executable script or markup, all via `record_write` with local script file support and per-field targeting (`script_field`). Script fields are discovered at runtime from `sys_dictionary` — no hardcoded artifact catalog. Read the same surface back via `record_read`, or enumerate a table's script fields with `describe(action='list_script_fields', table='<table>')`.
 - **Attachment Operations** - Unified `attachment` for read operations and `attachment_write` for mutations.
 - **Investigations** - Automated analysis of system health, stale automations, performance bottlenecks, and more via `investigate`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+**servicenow-platform-mcp** is an MCP server that connects AI clients to ServiceNow instances over the Table API. It handles credentials, enforces access policy, and mediates reads and writes against production data.
+
+## Supported Versions
+
+| Version | Status |
+|---------|--------|
+| 0.10.x (latest on `main`) | Supported |
+| Older minor releases | Critical fixes at maintainer discretion |
+
+## Reporting a Vulnerability
+
+**Do not file a public GitHub issue for security bugs.**
+
+Preferred channels, in order:
+
+1. **GitHub private security advisory** - open one at <https://github.com/Xerrion/servicenow-platform-mcp/security/advisories/new>
+2. **Email** - send details to `security@<TODO>` (maintainer: replace with your security contact address)
+
+### What to Include
+
+- Steps to reproduce
+- Affected version(s)
+- Impact assessment (what an attacker gains)
+- Suggested fix, if you have one
+
+### Response Timeline
+
+- Acknowledgment within **5 business days** (subject to maintainer availability)
+- We will coordinate disclosure timing with you before any public announcement
+
+## Threat Model
+
+Key trust boundaries specific to this project:
+
+- **ServiceNow user privileges** - the MCP server authenticates as the configured ServiceNow user. All platform operations inherit that user's roles and ACLs. Restrict that user to least-privilege.
+- **Untrusted AI prompts** - any MCP client can invoke any tool the active package exposes. Limit exposure with `MCP_TOOL_PACKAGE` (e.g., `readonly` or `core_readonly`) and set `SERVICENOW_ENV=production` to enable write gating.
+- **Credentials in environment** - instance URL, username, and password live in env vars or `.env.local`. Never commit them.
+- **Defence-in-depth layers** - the denied-tables list, field masking, and write gating are server-side guardrails. They do not replace the platform's own ACLs, which remain the final authority.
+
+## Out of Scope
+
+The following should be reported to the respective upstream maintainers, not here:
+
+- Vulnerabilities in upstream Python dependencies (report to the dependency project)
+- Vulnerabilities in ServiceNow itself (report via ServiceNow's HI portal or responsible disclosure program)
+- Denial of service caused by misconfiguration (overly broad query limits, etc.)

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -1,308 +1,304 @@
-# 📖 Agent Recipes
+# Agent Recipes
 
-This document provides a set of "recipes" for common ServiceNow workflows using the unified 12-tool surface.
+Worked examples for AI agents (or developers scripting agents) integrating with the ServiceNow Platform MCP server. Each recipe is a self-contained call sequence you can adapt directly.
 
-The previous specialized helper tools (e.g., `incident_list`, `debug_trace`, `changes_updateset_inspect`) have been collapsed into a minimal, dispatcher-oriented API. Agents and developers now achieve complex tasks through multi-call joins, encoded query strings, and explicit choice resolution. These recipes demonstrate how to translate legacy tool usage into this new, more flexible vocabulary.
-
-## 🛠 The Unified Surface at a Glance
-
-| Tool | Purpose |
-| :--- | :--- |
-| `query` | Fetch records, aggregates, or single records from any table using encoded queries. |
-| `build_query` | Stateless helper - compiles a JSON array of condition objects into the encoded query string that `query` consumes. `full` package only. |
-| `describe` | Retrieve slim field metadata (8 keys) for a table to understand its structure. Use `action='list_script_fields'` with a `table` argument to discover the dictionary-driven script-bearing fields and the resolved super_class chain. |
-| `record_read` | Read a record by `sys_id` or `name`. Returns the masked record plus the `script_fields` list resolved from `sys_dictionary` for the table. |
-| `record_write` | Dispatcher for creating, updating, or deleting records (with `script_path` file injection and `script_field` targeting for tables with multiple script-bearing fields). |
-| `record_apply` | Commits a write operation previously staged with `preview=True`. |
-| `attachment` | Dispatcher for reading, listing, and downloading record attachments. |
-| `attachment_write` | Dispatcher for uploading or deleting record attachments. |
-| `investigate` | Runs pre-defined diagnostic investigations (e.g., health checks, bottleneck analysis). |
-| `resolve_choice` | Maps human-readable labels to underlying ServiceNow choice values. |
-| `service_catalog` | Dispatcher for Service Catalog operations (cart, categories, items). |
-| `flow` | Inspects Flow Designer artifacts, finds record-triggered flows, lists triggers, and decodes compressed `values` blobs. |
-
-## 🔍 Quick Reference: Encoded Query Syntax
-
-ServiceNow [Encoded Queries](https://docs.servicenow.com/bundle/vancouver-platform-user-interface/page/use/using-lists/concept/c_EncodedQueryStrings.html) are the primary filter mechanism for the `query` tool.
-
-| Operator | Syntax | Description |
-| :--- | :--- | :--- |
-| Equals | `state=1` | Field equals value |
-| Not Equals | `state!=1` | Field does not equal value |
-| In List | `priorityIN1,2` | Field is one of the comma-separated values |
-| Starts With | `short_descriptionSTARTSWITHOutage` | Field starts with string |
-| Contains | `short_descriptionLIKEvpn` | Field contains string |
-| Date Filter | `sys_created_on>=javascript:gs.daysAgoStart(7)` | Use for large tables (syslog, sys_audit) |
-| Sorting | `ORDERBYDESCnumber` | Append to query for ordering (use `ORDERBY<field>` for ascending) |
-| AND | `active=true^priority=1` | Combine conditions with carets |
-| OR | `state=1^ORstate=2` | Or condition for the same field |
-| Dot-walk | `assignment_group.nameSTARTSWITHNetwork` | Access fields on referenced tables |
-
-## 👨‍🍳 Recipes
-
-### 1. List my open incidents by priority
-**Goal:** Retrieve open incidents and filter by a human-readable priority label.  
-**Old way:** `incident_list(state="open", priority="high")`  
-**New way:**
-```python
-# Use resolve_labels to handle label-to-value mapping automatically
-# This appends (state=1^priority=1) to the encoded_query internally
-await query(
-    table="incident",
-    resolve_labels="state=open,priority=high",
-    fields="number,short_description,priority,state"
-)
-```
-**Notes:** `resolve_labels` is the most efficient way to query by label. It performs a ChoiceRegistry lookup before executing the query.
+For package configuration details, see [Tool Packages](wiki/Tool-Packages.md).
 
 ---
 
-### 2. Create an incident with proper state value
-**Goal:** Create a new record ensuring the 'state' field uses the correct underlying integer.  
-**Old way:** `incident_create(state="open", short_description="...")`  
-**New way:**
-```python
-import json
+## 1. Discover what is available
 
-# 1. Resolve the label to a value
-# Tool returns a JSON-serialized envelope string - parse it before indexing.
-state_resp = json.loads(await resolve_choice(table="incident", field="state", label="New"))
-state_val = state_resp["data"]["value"]  # "1"
+Start every session by learning which tool packages exist and what they contain.
 
-# 2. Stage the create (preview=True by default)
-# Returns a preview_token inside data
-preview = json.loads(await record_write(
-    action="create",
-    table="incident",
-    data='{"short_description": "Email service down", "state": "1"}'
-))
-
-# 3. Commit the change
-await record_apply(preview_token=preview["data"]["preview_token"])
 ```
-**Notes:** The preview/apply two-step is a mandatory safety mechanism for all writes. It allows the agent (or human) to inspect the impact before commitment. The `data` parameter is capped at 1 MiB (`MAX_PAYLOAD_BYTES`). Every tool returns a JSON-serialized envelope string (see `format_response` in `responses.py`); always `json.loads(...)` before indexing into `data`.
+list_tool_packages()
+```
+
+This returns the registry of preset packages (`full`, `readonly`, `core_readonly`, `none`) and the tool groups each contains. No `correlation_id` or error envelope - this tool is unwrapped.
+
+To discover which fields on a table carry executable script content:
+
+```
+describe(action="list_script_fields", table="sys_script_include")
+```
+
+Returns the super_class chain and a list of `{name, internal_type, inherited_from, via_heuristic}` entries for every script-bearing field detected from `sys_dictionary`.
 
 ---
 
-### 3. Build a complex multi-condition query
-**Goal:** Find incidents that are either New or In Progress, have High/Critical priority, and belong to a Network group.  
-**Old way:** `build_query(...)` then `table_query(...)`  
-**New way:**
-```python
-# Compose the query string directly
-# (state=1 OR state=2) AND (priority <= 2) AND (group name starts with Network)
-query_string = "stateIN1,2^priority<=2^assignment_group.nameSTARTSWITHNetwork"
+## 2. Field metadata
 
-await query(
-    table="incident",
-    encoded_query=query_string,
-    fields="number,short_description,assignment_group.name"
-)
+Retrieve the schema for any table with a bare `describe` call (no `action` parameter):
+
 ```
-**Notes:** Dot-walking (`assignment_group.name`) is supported. Use `^NQ` (New Query) for top-level OR conditions that require entirely separate filter sets.
+describe(table="incident")
+```
+
+Returns table metadata, field list (with label, type, max_length, mandatory, read_only, reference_table, choice_count), and field count.
+
+**Anti-pattern:** Do not pass an invented action value. For example, `action="fields"` produces:
+
+```
+"Unknown describe action 'fields'. Valid actions: ['list_script_fields']."
+```
+
+The only valid action is `list_script_fields`. Omit `action` entirely for normal field metadata.
 
 ---
 
-### 3a. Compose the same query with `build_query`
-**Goal:** Same result as Recipe 3, but expressed as structured JSON instead of hand-written encoded-query syntax. Useful when the conditions come from another tool, a UI, or any source that already speaks JSON.  
-**Availability:** `full` package only.
-```python
-import json
+## 3. Filtered query
 
-built = json.loads(await build_query(conditions=json.dumps([
-    {"operator": "in_list",     "field": "state",                  "value": ["1", "2"]},
-    {"operator": "less_or_equal", "field": "priority",             "value": "2"},
-    {"operator": "starts_with", "field": "assignment_group.name",  "value": "Network"},
-])))
+Fetch active high-priority incidents:
 
-await query(
-    table="incident",
-    encoded_query=built["data"]["query"],
-    fields="number,short_description,assignment_group.name"
-)
 ```
-**Notes:** `build_query` is stateless - it returns the encoded query string in `data.query` for the caller to forward. There is no token store and no shared state; if the second call fails, just call `build_query` again.
+query(table="incident", encoded_query="active=true^priority<=2", limit=20)
+```
+
+### Encoded-query cheat sheet
+
+| Syntax | Meaning |
+|--------|---------|
+| `^` | AND |
+| `^OR` | OR |
+| `=` | Equals |
+| `!=` | Not equals |
+| `<`, `<=`, `>`, `>=` | Numeric/date comparison |
+| `LIKE` | Contains (case-insensitive) |
+| `STARTSWITH` | Starts with |
+| `IN` | Value in comma-separated list |
+| `ISEMPTY` | Field is empty |
+| `ISNOTEMPTY` | Field is not empty |
+
+Example combining operators:
+
+```
+active=true^priority<=2^stateBETWEEN1@3^categoryIN network,hardware
+```
+
+Date-bounded queries are required for large tables (`syslog`, `sys_audit`, `sys_log_transaction`, `sys_email_log`). Add a date constraint like `sys_created_on>=2025-01-01`.
 
 ---
 
-### 4. Find recently modified business rules
-**Goal:** Audit recent logic changes in the system.  
-**Old way:** `meta_list_artifacts` or `meta_what_writes`  
-**New way:**
-```python
-await query(
-    table="sys_script",
-    encoded_query="active=true^sys_updated_on>=javascript:gs.daysAgoStart(7)",
-    fields="name,collection,sys_updated_on,sys_updated_by",
-    order_by="-sys_updated_on",
-    limit=50
-)
+## 4. Aggregate query
+
+Count incidents grouped by state:
+
 ```
-**Notes:** `sys_script` stores Business Rules. The `collection` field indicates the target table.
+query(table="incident", aggregate="count", group_by="state")
+```
+
+The `aggregate` parameter accepts comma-separated tokens: `count`, or `op:field` where op is one of `avg`, `sum`, `min`, `max`.
+
+```
+query(table="incident", aggregate="count,avg:reassignment_count", group_by="priority")
+```
+
+**Mode mutex rules:**
+
+- `sys_id` cannot combine with `aggregate` or `group_by`.
+- `group_by` requires `aggregate` to be set.
+
+Violating these returns an error envelope - not an exception.
 
 ---
 
-### 5. Inspect an Update Set's contents
-**Goal:** See exactly what files are included in a specific Update Set.  
-**Old way:** `changes_updateset_inspect`  
-**New way:**
-```python
-# 1. Verify the Update Set exists
-# await query(table="sys_update_set", sys_id="<sys_id>")
+## 5. Build an encoded query programmatically
 
-# 2. List the captured changes (sys_update_xml)
-await query(
-    table="sys_update_xml",
-    encoded_query="update_set=<sys_id>",
-    fields="name,type,target_name,action",
-    limit=100
-)
+The `build_query` tool (available in the `full` package only) accepts a JSON array of condition objects and returns the encoded query string:
+
 ```
-**Notes:** `sys_update_xml` is the "Customer Update" table where individual modifications are tracked.
+build_query(conditions='[{"operator":"equals","field":"active","value":"true"},{"operator":"less_or_equal","field":"priority","value":"2"},{"operator":"order_by","field":"sys_created_on","descending":true}]')
+```
+
+Returns `{"query": "active=true^priority<=2^ORDERBYDESCsys_created_on"}` in the `data` field. Pass the result directly to the `query` tool's `encoded_query` parameter.
 
 ---
 
-### 6. Debug recent script errors
-**Goal:** Search system logs for errors occurring in the last 15 minutes.  
-**Old way:** `debug_trace` or `debug_log_errors`  
-**New way:**
-```python
-# level=2 is Error. Date filter is mandatory for syslog.
-await query(
-    table="syslog",
-    encoded_query="level=2^sys_created_on>=javascript:gs.minutesAgo(15)",
-    fields="message,source,sys_created_on",
-    order_by="-sys_created_on",
-    limit=50
-)
+## 6. Read a single record
+
+By sys_id:
+
 ```
-**Notes:** Always include a time-based filter when querying `syslog` to avoid performance degradation and query rejection.
+record_read(table="sys_script_include", sys_id="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+```
+
+By name:
+
+```
+record_read(table="sys_script_include", name="MyScriptInclude")
+```
+
+Exactly one of `sys_id` or `name` must be supplied. Providing both returns:
+
+```
+"Provide exactly one of sys_id or name, not both."
+```
+
+The response includes the masked record and the `script_fields` list resolved by `DictionaryRegistry` for that table.
 
 ---
 
-### 7. Audit who last touched a record
-**Goal:** Get a history of field mutations for a specific record.  
-**Old way:** `debug_field_mutation_story`  
-**New way:**
-```python
-# sys_audit is a massive table; strict filtering is required.
-await query(
-    table="sys_audit",
-    encoded_query="tablename=incident^documentkey=<sys_id>",
-    fields="fieldname,oldvalue,newvalue,sys_created_by,sys_created_on",
-    order_by="-sys_created_on",
-    limit=100
-)
+## 7. Update with preview-then-apply
+
+The default write flow uses a two-call sequence with a single-use preview token.
+
+**Step 1 - Preview:**
+
 ```
-**Notes:** For high-volume production instances, always combine `documentkey` with a `sys_created_on` filter if the history is expected to be long.
-
----
-
-### 8. Discover a table's choice values for a field
-**Goal:** Understand the available states or categories for a table without guessing.  
-**Old way:** Implicitly handled by domain tools.  
-**New way:**
-```python
-import json
-
-# 1. Check if choices exist
-meta = json.loads(await describe(table="incident", fields="state"))
-# If meta["data"]["state"]["choice_count"] > 0...
-
-# 2. Get the full mapping (label="" returns all)
-choices = json.loads(await resolve_choice(table="incident", field="state"))
-```
-**Notes:** `resolve_choice` returns a dictionary mapping labels (e.g., "In Progress") to values (e.g., "2").
-
----
-
-### 9. Update a Business Rule from a local file
-**Goal:** Sync a script developed locally into a ServiceNow Business Rule.  
-**Old way:** `artifact_update`  
-**New way:**
-```python
-import json
-
-# Stage the update using a local path.
-# content is read, validated, and placed in the first script-bearing field
-# resolved by DictionaryRegistry (here: sys_script.script).
-preview = json.loads(await record_write(
-    action="update",
-    table="sys_script",
-    sys_id="<sys_id>",
-    script_path="/Users/dev/project/br_logic.js",
-    preview=True
-))
-
-# Commit
-await record_apply(preview_token=preview["data"]["preview_token"])
-```
-**Notes:** `script_path` must be within the directory defined by the `SCRIPT_ALLOWED_ROOT` setting. All path rejections return a single opaque error. Files are capped at 1MB and must be UTF-8.
-
----
-
-### 10. Aggregate incident counts by assignment group
-**Goal:** Perform ad-hoc reporting to find which groups have the most active work.  
-**Old way:** ad-hoc manual queries.  
-**New way:**
-```python
-import json
-
-# Get counts grouped by the reference field 'assignment_group'
-report = json.loads(await query(
-    table="incident",
-    encoded_query="active=true",
-    aggregate="count",
-    group_by="assignment_group"
-))
-
-# report["data"] will contain list of {assignment_group: "sys_id", count: "42"}
-```
-**Notes:** Aggregate queries return the raw sys_id of the group. Call `query` with `sys_id` mode on `sys_user_group` to resolve the top group's name if needed.
-
----
-
-### 11. Inspect Flow Designer artifacts
-
-**Goal:** Understand which flows run for a table, inspect one flow's canvas, or decode a compressed `values` field fetched manually.  
-**Old way:** Query `sys_hub_*` tables by hand and decode `values` outside the MCP server.  
-**New way:**
-
-```python
-# Find all flows triggered by a given table
-await flow(action="find_by_table", table="incident")
-
-# Inspect a specific flow by name
-await flow(action="inspect", name="My Flow")
-
-# Decode a values blob fetched manually via query
-await flow(action="decode_values", value="H4sIA...")
-
-# Survey active record-update triggers across the platform
-await flow(
-    action="list_triggers",
-    trigger_type="record_update",
-    active="true",
-    limit=50,
+record_write(
+  action="update",
+  table="incident",
+  sys_id="abc123def456abc123def456abc123de",
+  data='{"state": "6"}',
+  preview=true
 )
 ```
 
-**Notes:** `flow(action="inspect", ...)` reads both Washington DC+ V2 rows and V1 fallback rows. Per-node decode failures are isolated to that node as `decode_error`, so one bad `values` blob does not discard the full inspection result.
+Response includes a `preview_token` and a diff showing old vs new values (sensitive fields masked).
 
-## 💡 Tips and Patterns
+**Step 2 - Apply:**
 
-### Describe First
-When working with an unfamiliar table, always call `describe(table="...")` first. It provides the field names, types, and mandatory flags in a slim format (8 keys per field). This is significantly lower "context cost" for the agent than fetching actual records.
+```
+record_apply(preview_token="<token from step 1>")
+```
 
-### Use Display Values
-When you need human-readable labels for reference fields (like `assigned_to`) or choice fields (like `state`) in a single pass, use `display_values=True` in your `query` call. This returns a `_display` object alongside the raw values, avoiding the need for multiple `resolve_choice` calls.
+Tokens are single-use and expire after 5 minutes.
 
-### Large Table Constraints
-Queries against `syslog`, `sys_audit`, `sys_log_transaction`, and `sys_email_log` are gated. You **must** include a date filter (e.g., `sys_created_on>=javascript:gs.daysAgoStart(1)`) or the server will reject the query to protect instance performance.
+**Skipping preview:** Set `preview=false` for a direct commit without the token round-trip:
 
-### Pagination
-The `query` tool returns a `pagination` object containing `offset`, `limit`, and `total`. To fetch the next page, call the tool again with the same parameters but increment the `offset` by the `limit`.
+```
+record_write(action="create", table="incident", data='{"short_description":"New issue"}', preview=false)
+```
+
+**Production environments block ALL writes.** When `SERVICENOW_ENV` is `prod` or `production`, every write operation returns a gating error - no override exists at the tool level.
 
 ---
 
-For detailed per-tool API documentation, see [Tool Reference](./wiki/Tool-Reference.md).
+## 8. Upload an attachment
+
+```
+attachment_write(
+  action="upload",
+  table="incident",
+  table_sys_id="abc123def456abc123def456abc123de",
+  file_name="screenshot.png",
+  content_base64="iVBORw0KGgoAAAANS..."
+)
+```
+
+Maximum attachment size is 10 MB. The `content_base64` field must be standard base64-encoded file content. An optional `content_type` parameter defaults to `"application/octet-stream"`.
+
+---
+
+## 9. Run an investigation
+
+```
+investigate(action="run", name="stale_automations", params='{"stale_days":90}')
+```
+
+The `name` parameter selects from 7 registered investigations: `stale_automations`, `deprecated_apis`, `table_health`, `acl_conflicts`, `error_analysis`, `slow_transactions`, `performance_bottlenecks`.
+
+Three actions are available:
+
+| Action | Purpose |
+|--------|---------|
+| `run` | Execute the investigation (requires `name`) |
+| `explain` | Trial-run all modules against an `element_id` in `table:sys_id` format |
+| `describe` | Return available investigations and their parameters |
+
+Use `describe` with no `name` to list all investigations, or with a `name` to see that module's accepted parameters.
+
+---
+
+## 10. Resolve a choice label
+
+Map human-readable state labels to their numeric values:
+
+```
+resolve_choice(table="incident", field="state")
+```
+
+Returns all known label-to-value mappings for that field. To resolve a single label:
+
+```
+resolve_choice(table="incident", field="state", label="resolved")
+```
+
+Returns `{table: "incident", field: "state", label: "resolved", value: "6"}`.
+
+---
+
+## 11. Inspect a Flow
+
+```
+flow(action="inspect", name="My Approval Flow")
+```
+
+Returns the full flow structure: triggers, inputs, outputs, variables, decoded V2 action/logic nodes, canvas tree, published snapshot drift, and warnings.
+
+You can also pass `sys_id` instead of `name` (exactly one required).
+
+To find flows triggered by a specific table:
+
+```
+flow(action="find_by_table", table="incident")
+```
+
+To list triggers with filtering:
+
+```
+flow(action="list_triggers", table="incident", active="true")
+```
+
+The `active` parameter accepts three values: `"true"`, `"false"`, or `""` (empty string for no filter). Any other value returns:
+
+```
+"'active' must be 'true', 'false', or '' (got ...)"
+```
+
+---
+
+## 12. Audit a field
+
+Check whether a field is being audited:
+
+```
+audit(action="check_field", table="incident", field="priority")
+```
+
+Returns a verdict (`audited`, `not_audited_field_flag`, `not_audited_table_flag`, `audited_but_inactive`, or `inconclusive`), the super_class chain walk, attribute analysis, and recent activity counts.
+
+**Default 90-day window.** All audit actions that read `sys_audit` apply a 90-day lookback by default. The response includes a `window_note`:
+
+```
+"Default 90-day window used (sys_audit is large; widen with care)."
+```
+
+Override with `window_days` if needed, but keep the default unless you have a specific reason - wider windows risk slow queries and timeouts.
+
+To check multiple fields in one call:
+
+```
+audit(action="check_fields", table="incident", fields_csv="priority,state,assigned_to")
+```
+
+---
+
+## 13. Service Catalog
+
+List available catalogs:
+
+```
+service_catalog(action="catalogs_list")
+```
+
+Other catalog actions follow the same dispatch pattern - `catalog_get`, `categories_list`, `category_get`, `items_list`, `item_get`, `item_variables`, `order_now`, `add_to_cart`, `cart_get`, `cart_submit`, `cart_checkout`. Write actions (`order_now`, `add_to_cart`, `cart_submit`, `cart_checkout`) are subject to write gating.
+
+---
+
+## General notes
+
+- Every tool except `list_tool_packages` returns a JSON envelope with `correlation_id`, `status`, `data`, and optionally `error`, `pagination`, `warnings`.
+- Sensitive fields in responses are masked as `***MASKED***`.
+- Tables in the denied list (`sys_user_has_password`, `oauth_credential`, `oauth_entity`, `sys_certificate`, `sys_ssh_key`, `sys_credentials`, `discovery_credentials`, `sys_user_token`) are blocked from all operations.
+- Tool functions never raise to MCP - all errors are caught and returned as structured error envelopes.

--- a/docs/agent-recipes.md
+++ b/docs/agent-recipes.md
@@ -80,7 +80,7 @@ preview = json.loads(await record_write(
 # 3. Commit the change
 await record_apply(preview_token=preview["data"]["preview_token"])
 ```
-**Notes:** The preview/apply two-step is a mandatory safety mechanism for all writes. It allows the agent (or human) to inspect the impact before commitment. Every tool returns a JSON-serialized envelope string (see `format_response` in `responses.py`); always `json.loads(...)` before indexing into `data`.
+**Notes:** The preview/apply two-step is a mandatory safety mechanism for all writes. It allows the agent (or human) to inspect the impact before commitment. The `data` parameter is capped at 1 MiB (`MAX_PAYLOAD_BYTES`). Every tool returns a JSON-serialized envelope string (see `format_response` in `responses.py`); always `json.loads(...)` before indexing into `data`.
 
 ---
 
@@ -237,7 +237,7 @@ preview = json.loads(await record_write(
 # Commit
 await record_apply(preview_token=preview["data"]["preview_token"])
 ```
-**Notes:** `script_path` must be within the directory defined by the `SCRIPT_ALLOWED_ROOT` setting. Files are capped at 1MB and must be UTF-8.
+**Notes:** `script_path` must be within the directory defined by the `SCRIPT_ALLOWED_ROOT` setting. All path rejections return a single opaque error. Files are capped at 1MB and must be UTF-8.
 
 ---
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,41 +1,32 @@
 # Architecture
 
-Deep technical architecture of the `servicenow-platform-mcp` server - an async Python MCP server for ServiceNow platform introspection and management.
+How the servicenow-platform-mcp server is built, from process shape down to the moving parts inside a single tool call.
 
-## Overview
+## High-Level Shape
 
-The server is built on:
+The server is a Python 3.12+ async process that speaks the Model Context Protocol over stdio. It is built on FastMCP, uses httpx for all ServiceNow HTTP traffic, and ships as a src-layout package (`src/servicenow_mcp/`). The console entry point is `servicenow_mcp.server:main`.
 
-- **FastMCP** - MCP server framework providing tool registration and transport handling.
-- **httpx** - Async HTTP client for ServiceNow REST API communication.
-- **JSON** - Standard JSON serialization for all tool responses.
-- **pydantic-settings** - Configuration management via environment variables.
-- **sentry-sdk** - Error tracking for invisible child-process environments.
-
-Communication happens over **stdio transport**. The server runs as a child process of an AI agent, and all output is captured in a standardized JSON envelope.
-
-## Unified Tool Surface
-
-Version 0.10.0 introduced a unified 12-tool surface. Most tools are implemented as **dispatchers** that take an `action` parameter, reducing the total tool count while increasing flexibility.
-
-### Key Implementation Patterns
-
-- **Action Dispatchers:** Tools like `attachment`, `investigate`, and `service_catalog` use an `action` parameter to route requests to internal logic.
-- **Encoded Queries:** The `query` tool accepts ServiceNow encoded query strings directly. The optional `build_query` helper (in the `full` package) is a stateless transform that compiles a JSON array of condition objects into an encoded query string for callers that prefer structured input.
-- **Two-Stage Writes:** `record_write` (stage) and `record_apply` (commit) implement a mandatory safety flow for all mutations.
-- **Helper Modules:** Shared logic is extracted into specialized helpers:
-  - `_artifact.py`: Handles secure script file reads (path containment, UTF-8 decode, 1 MB cap) and the `xml` well-formedness check.
-  - `_dictionary.py`: `DictionaryRegistry` — runtime discovery of script-bearing fields per table by walking `sys_db_object.super_class` and filtering `sys_dictionary` rows. Replaces the previous hardcoded artifact catalog.
-  - `_describe_helpers.py`: Manages slim vs. verbose schema building.
-  - `_record_helpers.py`: Handles mandatory field validation and diff generation.
+There is no HTTP listener, no multi-tenant routing, and no background scheduling. The MCP client (an AI assistant runtime) launches the process and owns its lifecycle. All I/O is cooperative async on a single thread.
 
 ## Server Bootstrap
 
-The server entry point is `server.py`.
+`create_mcp_server()` in `server.py` assembles the runtime in this order:
 
-### Registration Pattern
+1. `Settings()` - loads configuration from environment variables via pydantic-settings (`.env` then `.env.local`).
+2. `create_auth(settings)` - returns a `BasicAuthProvider`.
+3. `setup_sentry(settings)` - initializes the Sentry SDK (no-op when DSN is empty or the SDK is missing).
+4. Sets Sentry server context (instance hostname, environment, production flag, tool package).
+5. `FastMCP("servicenow-platform-mcp")` - creates the protocol server instance.
+6. Creates shared registries: `ChoiceRegistry(settings, auth_provider)` and `DictionaryRegistry(settings, auth_provider)`.
+7. `attach_servicenow_state(mcp, settings, auth_provider, choices, dictionary)` - injects shared state onto the MCP instance.
+8. Registers the `list_tool_packages` tool inline (see below).
+9. Resolves the active package via `get_package(settings.mcp_tool_package)`, then for each group calls `importlib.import_module` and invokes the module's `register_tools`.
 
-The loader uses an unconditional 4-argument `register_tools()` pattern for all tool groups:
+`main()` runs `mcp.run(transport="stdio")` in a try/finally that calls `shutdown_sentry()` on exit.
+
+## Tool Registration
+
+Every tool group module exports a `register_tools` function with this exact signature:
 
 ```python
 def register_tools(
@@ -43,77 +34,118 @@ def register_tools(
     settings: Settings,
     auth_provider: BasicAuthProvider,
     choices: ChoiceRegistry | None = None,
+    dictionary: DictionaryRegistry | None = None,
 ) -> None:
     ...
 ```
 
-The bootstrap process dynamically imports modules from `servicenow_mcp.tools` and registers them.
+Inside, each tool is defined as a closure decorated with `@mcp.tool()` then `@tool_handler`:
 
-## Wire Format
+```python
+@mcp.tool()
+@tool_handler
+async def my_tool(param: str, correlation_id: str = "") -> str:
+    validate_identifier(param)
+    check_table_access(param)
+    async with ServiceNowClient(settings, auth_provider) as client:
+        result = await client.some_method(param)
+    return format_response(data=result, correlation_id=correlation_id)
+```
 
-All tool outputs are serialized using standard JSON. The TOON format from previous versions has been removed.
+The one exception is `list_tool_packages`, registered directly in `server.py` as a bare closure. It returns `serialize(list_packages())` with no `@tool_handler` wrapper, no `correlation_id`, and no error envelope. It is the only tool that is not wrapped by `@tool_handler`.
 
-### `format_response()` Envelope
+## The `@tool_handler` Decorator
 
-Every tool returns a standardized envelope:
+Defined in `decorators.py`, this decorator is the central safety and observability layer:
+
+1. **Injects `correlation_id`** - generates a UUID4 via `generate_correlation_id()` and passes it as a keyword argument to the wrapped function.
+2. **Hides `correlation_id` from the schema** - overrides `__signature__` and deletes `__wrapped__` so FastMCP does not expose it to callers.
+3. **Attaches Sentry telemetry** - sets tags (`tool.name`, `tool.correlation_id`) and a context blob with tool name, correlation ID, and redacted arguments. Sensitive argument keys are replaced wholesale with `"***REDACTED***"` before transmission (see [[Telemetry]] for the full key list).
+4. **Wraps execution in `safe_tool_call()`** which catches exceptions in this order:
+
+| Caught | Envelope behavior |
+|---|---|
+| `ACLError` | Verbose message |
+| `ForbiddenError` | Verbose message |
+| `ServiceNowMCPError` (all subclasses) | Verbose `str(e)` |
+| `ValueError` | Verbose `str(e)` |
+| Generic `Exception` | Opaque `"Internal error (correlation_id=...)"` - full detail goes to `logger.exception` and Sentry |
+
+Tool functions never raise to the MCP layer.
+
+## Response Envelope
+
+Every tool (except `list_tool_packages`) returns a serialized JSON string built by `format_response()` in `utils.py`:
 
 ```json
 {
-  "status": "success",
-  "correlation_id": "uuid-v4",
-  "data": { ... },
-  "pagination": { "offset": 0, "limit": 100, "total": 500 },
-  "warnings": []
+  "correlation_id": "...",
+  "status": "success | error",
+  "data": "<any>",
+  "error": {"message": "..."} | null,
+  "pagination": {"limit": 0, "offset": 0, "total": 0} | null,
+  "warnings": ["..."] | null
 }
 ```
 
-## State Management
+When `error` is passed as a plain string it is wrapped into `{"message": str}`. When passed as a dict it is used verbatim. The keys `error`, `pagination`, and `warnings` are omitted when their value is `None`; `correlation_id`, `status`, and `data` are always present (`data` is serialized as `null` when it is `None`).
 
-The server maintains minimal in-memory state via `state.py`.
+## Async Client
 
-- **PreviewTokenStore:** Mediates between `record_write` and `record_apply`. When `record_write` is called with `preview=true` (default), it stores the proposed mutation and returns a UUID token. `record_apply` then consumes this token to finalize the write. Tokens expire after 5 minutes.
-- **ChoiceRegistry:** Lazy-loads choice labels from the `sys_choice` table on first use and caches them for the lifetime of the process.
+`ServiceNowClient(settings, auth_provider)` is an async context manager over `httpx.AsyncClient`. The timeout is configured via `HTTPX_TIMEOUT_SECONDS` (default 30 seconds, range 1-600).
 
-The `QueryTokenStore` from previous versions has been deleted as agents now pass encoded queries directly.
-
-## Error Handling Flow
-
-The `@tool_handler` decorator (in `decorators.py`) wraps every tool invocation:
-
-1. **Correlation ID:** Generates a unique UUID4 for the request.
-2. **Sentry Context:** Attaches tool names and redacted arguments to the Sentry scope (sensitive keys are replaced with `"***REDACTED***"` before transmission).
-3. **Safe Execution:** Wraps the tool in `safe_tool_call()`, which catches all exceptions and returns them as `status: "error"` JSON envelopes. Known exception types (`ACLError`, `ForbiddenError`, `ServiceNowMCPError`, `ValueError`) preserve verbose messages; unclassified exceptions return an opaque `"Internal error (correlation_id=...)"` envelope with full detail logged locally and captured to Sentry.
-
-## Source Layout
-
-```
-src/servicenow_mcp/
-    server.py              # Entry point, bootstrap
-    client.py              # ServiceNow HTTP client (httpx)
-    policy.py              # Safety guardrails & write gating
-    state.py               # PreviewTokenStore
-    tools/
-        query.py
-        describe.py
-        record_write.py # Registers both record_write and record_apply
-        attachment.py   # Registers both attachment and attachment_write
-        investigate.py
-        resolve_choice.py
-        service_catalog.py
-        audit.py
-        flow.py
-        _artifact.py       # Artifact script security
-        _audit.py          # AuditRegistry: super_class walk + verdict resolution
-        _dictionary.py     # DictionaryRegistry: script-bearing field discovery
-        _flow_values.py    # gzip+base64+JSON values blob decoder
-        _describe_helpers.py
-        _record_helpers.py
+```python
+async with ServiceNowClient(settings, auth_provider) as client:
+    record = await client.get_record("incident", sys_id)
 ```
 
-## Client Retentions
+Auth headers are produced by `BasicAuthProvider.get_headers()` (async for future OAuth2 extensibility). Each request also carries an `X-Correlation-ID` header (a fresh UUID4).
 
-Per ADR §2.3, the core `ServiceNowClient` retains several specialized methods to support the unified dispatchers:
-- `list_reports` and `get_email`
-- `get_import_set_record`
-- Full `sc_*` method suite for Service Catalog
-- Legacy investigation methods used by the `investigate` tool
+`_raise_for_status()` maps HTTP status codes to the exception hierarchy defined in `errors.py`:
+
+| HTTP | Exception |
+|---|---|
+| 401 | `AuthError` |
+| 403 | `ACLError` (when body matches ACL indicator regex) or `ForbiddenError` |
+| 404 | `NotFoundError` |
+| 500+ | `ServerError` |
+| Other 4xx | `ServiceNowMCPError` |
+
+## State
+
+The only in-memory mutable state is `PreviewTokenStore` in `state.py`:
+
+- TTL: 300 seconds (5 minutes).
+- Capacity: 1000 entries.
+- `create(payload) -> str` stores a dict and returns a UUID token.
+- `consume(token) -> dict | None` retrieves and deletes in one step (single-use).
+- All mutations are serialized through an `asyncio.Lock`.
+- `_sweep_expired()` reclaims stale entries before capacity checks.
+
+This backs the preview-then-apply write flow: `record_write` (with `preview=True`) creates a token containing the validated payload; `record_apply` consumes that token and executes the write.
+
+## Choice and Dictionary Registries
+
+**ChoiceRegistry** maps human-readable labels to internal values for state-like fields. It ships 6 default table-field mappings (incident, change_request, problem, cmdb_ci, sc_request, sc_req_item) and lazily fetches instance-specific overrides from `sys_choice`. Labels are normalized to lowercase with spaces replaced by underscores. See [[Tool-Reference]] for the `resolve_choice` tool surface.
+
+**DictionaryRegistry** resolves which fields on a given table carry executable script or markup content. It walks the `sys_db_object.super_class` chain child-first (bounded at depth 8, cycle-guarded), classifies fields by `internal_type` and attribute heuristics, and caches per-table results for the server lifetime. See [[Tool-Reference]] for the `describe` tool's `list_script_fields` action.
+
+## Where Things Live
+
+| Path | Role |
+|---|---|
+| `src/servicenow_mcp/server.py` | Bootstrap, `main()`, `list_tool_packages` |
+| `src/servicenow_mcp/tools/` | Tool group modules (one per group) and underscore-prefixed helpers |
+| `src/servicenow_mcp/investigations/` | Investigation modules (7 files) |
+| `src/servicenow_mcp/policy.py` | Table access, field masking, query safety, write gating |
+| `src/servicenow_mcp/client.py` | `ServiceNowClient` async HTTP layer |
+| `src/servicenow_mcp/config.py` | `Settings` model (pydantic-settings) |
+| `src/servicenow_mcp/decorators.py` | `@tool_handler` and Sentry arg redaction |
+| `src/servicenow_mcp/errors.py` | Exception hierarchy |
+| `src/servicenow_mcp/state.py` | `PreviewTokenStore` |
+| `src/servicenow_mcp/utils.py` | `format_response`, `safe_tool_call`, `ServiceNowQuery`, validators |
+| `src/servicenow_mcp/sentry.py` | Opt-in Sentry SDK setup and helpers |
+
+---
+
+See also: [[Safety-and-Policy]] for guardrails and write gating, [[Telemetry]] for Sentry integration details, [[Tool-Packages]] for the full package registry.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -81,8 +81,8 @@ The `QueryTokenStore` from previous versions has been deleted as agents now pass
 The `@tool_handler` decorator (in `decorators.py`) wraps every tool invocation:
 
 1. **Correlation ID:** Generates a unique UUID4 for the request.
-2. **Sentry Context:** Attaches tool names and arguments to the Sentry scope.
-3. **Safe Execution:** Wraps the tool in `safe_tool_call()`, which catches all exceptions (including `ForbiddenError` and `PolicyError`) and returns them as `status: "error"` JSON envelopes.
+2. **Sentry Context:** Attaches tool names and redacted arguments to the Sentry scope (sensitive keys are replaced with `"***REDACTED***"` before transmission).
+3. **Safe Execution:** Wraps the tool in `safe_tool_call()`, which catches all exceptions and returns them as `status: "error"` JSON envelopes. Known exception types (`ACLError`, `ForbiddenError`, `ServiceNowMCPError`, `ValueError`) preserve verbose messages; unclassified exceptions return an opaque `"Internal error (correlation_id=...)"` envelope with full detail logged locally and captured to Sentry.
 
 ## Source Layout
 

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -48,7 +48,7 @@ When `SERVICENOW_ENV` is `"prod"` or `"production"`:
 
 ## Script Path Security
 
-To use the `script_path` feature in `record_write`, you **must** configure `SCRIPT_ALLOWED_ROOT` with an absolute path. The server will reject any `script_path` that resolves outside of this directory.
+To use the `script_path` feature in `record_write`, you **must** configure `SCRIPT_ALLOWED_ROOT` with an absolute path. The root directory is resolved and validated as existing before any user-supplied path is touched. All user-path rejections (missing file, not a regular file, outside root, symlink escape) return a single opaque error: `"script_path is not readable or is outside the allowed root"`.
 
 Example:
 `SCRIPT_ALLOWED_ROOT=/Users/dev/projects/servicenow-scripts`

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -1,65 +1,71 @@
 # Configuration
 
-All configuration is handled through environment variables, loaded via [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/).
+## Where settings come from
 
----
+The server loads configuration through pydantic-settings. Values are resolved from three sources in this order (last wins):
 
-## Environment Variables
+1. `.env` file in the working directory.
+2. `.env.local` file in the working directory.
+3. Process environment variables.
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `SERVICENOW_INSTANCE_URL` | Yes | - | Full URL (must start with `https://`) |
-| `SERVICENOW_USERNAME` | Yes | - | ServiceNow username |
-| `SERVICENOW_PASSWORD` | Yes | - | ServiceNow password |
-| `MCP_TOOL_PACKAGE` | No | `"full"` | Tool package (`full`, `readonly`, `core_readonly`, `none`) or comma-separated tools |
-| `SERVICENOW_ENV` | No | `"dev"` | Set to `"prod"` or `"production"` to block all write operations |
-| `MAX_ROW_LIMIT` | No | `100` | Max records per query (1-10000) |
-| `LARGE_TABLE_NAMES_CSV` | No | `syslog,...` | Tables requiring date-bounded queries |
-| `SCRIPT_ALLOWED_ROOT` | No | `""` | Root directory for `script_path` in `record_write` |
-| `SENTRY_DSN` | No | `""` | Sentry DSN for error tracking |
-| `SENTRY_ENVIRONMENT` | No | - | Grouping label for Sentry (defaults to `SERVICENOW_ENV`) |
+Use `.env.local` for credentials during development - it belongs in `.gitignore`.
 
----
+## Settings reference
 
-## Tool Package Configuration
+Every field in the `Settings` class maps to a single environment variable.
 
-The `MCP_TOOL_PACKAGE` variable controls the available tool surface.
+| Env var | Type | Default | Range | What it controls |
+|---------|------|---------|-------|------------------|
+| `SERVICENOW_INSTANCE_URL` | `str` | (required) | - | Full instance URL. Must be HTTPS. Trailing slash is stripped automatically. |
+| `SERVICENOW_USERNAME` | `str` | (required) | - | ServiceNow user for Basic Auth. |
+| `SERVICENOW_PASSWORD` | `SecretStr` | (required) | - | Password for the above user. Never logged or exposed in responses. |
+| `MCP_TOOL_PACKAGE` | `str` | `"full"` | - | Active tool package preset or comma-separated group list. See [[Tool-Packages]]. |
+| `SERVICENOW_ENV` | `str` | `"dev"` | - | Environment label. Controls production write-gating (see below). |
+| `MAX_ROW_LIMIT` | `int` | `100` | 1-10000 | Maximum rows any single `query` call may return. |
+| `HTTPX_TIMEOUT_SECONDS` | `float` | `30.0` | 1.0-600.0 | HTTP timeout for all ServiceNow API calls. |
+| `LARGE_TABLE_NAMES_CSV` | `str` | `"syslog,sys_audit,sys_log_transaction,sys_email_log"` | - | Comma-separated tables that require a date-bounded filter in queries. |
+| `SCRIPT_ALLOWED_ROOT` | `str` | `""` | - | Filesystem root for `script_path` in `record_write`. Empty disables script-file reads. |
+| `SENTRY_DSN` | `str` | `""` | - | Sentry DSN. Empty disables Sentry integration. |
+| `SENTRY_ENVIRONMENT` | `str` | `""` | - | Sentry environment tag (e.g. `"staging"`). |
 
-### Presets
-- `full`: All 12 unified tools (includes the `build_query` helper).
-- `readonly`: 8 tools (excludes `record_write`, `record_apply`, `service_catalog`, and `build_query`; includes `record_read`).
-- `core_readonly`: 5 tools (`query`, `describe`, `attachment`, `attachment_write`, `list_tool_packages`).
-- `none`: Only `list_tool_packages`.
+## Production mode (`is_production`)
 
-### Custom Packages
-You can list specific tools: `MCP_TOOL_PACKAGE="query,describe,investigate"`.
-*Note: `service_catalog` and `record_write` are now tool names. `record_write` should typically be paired with `record_apply` for the preview flow.*
+The `is_production` flag is a cached property derived from `SERVICENOW_ENV`. It evaluates to `true` when the value equals `prod` or `production`.
 
----
+When production mode is active, **all** write operations are blocked. This includes `record_write`, `record_apply`, `attachment_write` (upload and delete), and write-gated Service Catalog actions (`order_now`, `add_to_cart`, `cart_submit`, `cart_checkout`). Blocked calls return a policy-error envelope rather than executing.
 
-## Write Gating & Production Mode
+## `SCRIPT_ALLOWED_ROOT`
 
-When `SERVICENOW_ENV` is `"prod"` or `"production"`:
-- `record_write`, `record_apply`, and `attachment_write` operations are rejected.
-- `service_catalog` order/cart operations are rejected.
-- All read operations (`query`, `describe`, `attachment` list/get) remain functional.
+When `record_write` receives a `script_path` argument, the path is validated against this root:
 
----
+- The root directory is resolved first (before any user-supplied path). It must exist and be a directory.
+- The resolved script path must reside under the root. Symlink escapes are rejected.
+- Maximum file size is 1 MB.
+- All path-validation failures - file missing, not a regular file, outside root, symlink escape - produce a single opaque error: `"script_path is not readable or is outside the allowed root"`.
+- When the target field has `internal_type` of `xml`, the content is validated as well-formed XML before any platform call.
 
-## Script Path Security
+When the setting is empty (the default), any call supplying `script_path` fails immediately.
 
-To use the `script_path` feature in `record_write`, you **must** configure `SCRIPT_ALLOWED_ROOT` with an absolute path. The root directory is resolved and validated as existing before any user-supplied path is touched. All user-path rejections (missing file, not a regular file, outside root, symlink escape) return a single opaque error: `"script_path is not readable or is outside the allowed root"`.
+## Sentry settings
 
-Example:
-`SCRIPT_ALLOWED_ROOT=/Users/dev/projects/servicenow-scripts`
+Two environment variables control the optional Sentry integration:
 
----
+- `SENTRY_DSN` - the DSN string. When empty, the SDK is not initialized.
+- `SENTRY_ENVIRONMENT` - the environment tag attached to events.
 
-## File Loading
+For SDK defaults, argument redaction, and captured context details, see [[Telemetry]].
 
-The server automatically reads configuration from:
-1. `.env.local` (highest priority)
-2. `.env`
-3. Shell environment variables (override files)
+## Stale-config warnings
 
-Refer to `.env.example` for a template. **Never commit `.env.local` to version control.**
+The `.env.example` file shipped with the repository lists example preset names (`itil`, `developer`, `analyst`, `incident_management`, and others) that do not exist in the current package registry. Only `full`, `readonly`, `core_readonly`, and `none` are valid presets. Custom comma-separated group names are also accepted. See [[Tool-Packages]] for the current registry.
+
+## Example `.env.local`
+
+```bash
+SERVICENOW_INSTANCE_URL=https://myinstance.service-now.com
+SERVICENOW_USERNAME=admin
+SERVICENOW_PASSWORD=secret
+MCP_TOOL_PACKAGE=full
+SERVICENOW_ENV=dev
+SCRIPT_ALLOWED_ROOT=/home/user/scripts
+```

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,311 +1,263 @@
 # Development
 
-Comprehensive development guide for contributing to `servicenow-platform-mcp`.
+This guide is for contributors working on the MCP server itself - not for consumers integrating it into an AI client.
 
-See also: [[Architecture]] for technical internals, [[Telemetry]] for observability.
+Related pages: [[Architecture]], [[Telemetry]].
 
-## Getting Started
+---
 
-### Prerequisites
+## Repository Layout
 
-- **Python 3.12+** (tested on 3.12, 3.13, 3.14)
-- **uv** - Fast Python package manager (not pip/poetry)
-- A ServiceNow instance with admin or developer credentials
+The project uses a src-layout with hatchling as the build backend and **uv** as the package manager.
 
-### Setup
+```
+src/servicenow_mcp/         # Package root
+  server.py                 # Entry point (console script servicenow-platform-mcp)
+  client.py                 # ServiceNowClient - async HTTP
+  config.py                 # Settings (pydantic-settings)
+  packages.py               # Package registry and tool group mapping
+  tools/                    # One module per tool group
+  investigations/           # Investigation modules (7)
+tests/                      # Unit and integration tests
+  integration/              # Live-instance tests (require .env.local)
+.github/workflows/          # CI, CodeQL, release-please, stale
+pyproject.toml              # Metadata, dependencies, tool configuration
+```
+
+Entry point: `servicenow_mcp.server:main` (registered as the `servicenow-platform-mcp` console script).
+
+Build backend: `hatchling`. Package manager: `uv` (not pip, not poetry).
+
+---
+
+## Setup
 
 ```bash
-git clone https://github.com/Xerrion/servicenow-platform-mcp.git
-cd servicenow-platform-mcp
 uv sync --group dev
-cp .env.example .env.local  # Fill in ServiceNow credentials
+cp .env.example .env.local   # fill in ServiceNow credentials
 ```
 
-The `.env.local` file needs at minimum:
+No build step is needed for development. Run the server with `uv run servicenow-platform-mcp`.
+
+---
+
+## Development Loop
+
+### Tests
 
 ```bash
-SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
-SERVICENOW_USERNAME=admin
-SERVICENOW_PASSWORD=your-password
+uv run pytest                                           # all unit tests (integration excluded)
+uv run pytest tests/test_client.py                      # single file
+uv run pytest tests/test_client.py::TestClass::test_method  # single test
+uv run pytest -k "keyword"                              # keyword filter
+uv run pytest -m integration                            # integration tests (needs .env.local)
+uv run pytest --no-cov                                  # skip coverage for speed
 ```
 
-No build step is required for development. The server runs directly from source via `uv run servicenow-platform-mcp`.
+### Lint and Format
 
-## Development Commands
-
-| Command | Purpose |
-|---|---|
-| `uv run ruff check .` | Lint (all rules) |
-| `uv run ruff check --fix .` | Auto-fix lint issues |
-| `uv run ruff format .` | Format code |
-| `uv run ruff format --check .` | Verify formatting without changes |
-| `uv run mypy src/` | Type checking |
-| `uv run pytest` | Run all unit tests (integration excluded) |
-| `uv run pytest tests/test_client.py` | Run a single test file |
-| `uv run pytest tests/test_client.py::TestClass::test_method` | Run a single test |
-| `uv run pytest -k "keyword"` | Run tests matching a keyword |
-| `uv run pytest -m integration` | Run integration tests (requires `.env.local`) |
-| `uv run pytest --no-cov` | Skip coverage collection for speed |
-| `uv build` | Build distribution wheel |
-
-## Code Style
-
-### Formatter
-
-- **Ruff** is the sole formatter and linter
-- Line length: **120 characters**
-- Quote style: **double quotes**
-- Target: **Python 3.12**
-- Indent style: **spaces**
-
-### Lint Rules
-
-The project enables an extensive set of ruff lint rules:
-
-| Rule Set | Category |
-|---|---|
-| E | pycodestyle errors |
-| F | pyflakes |
-| W | pycodestyle warnings |
-| I | isort (import sorting) |
-| UP | pyupgrade |
-| B | flake8-bugbear |
-| SIM | flake8-simplify |
-| RUF | ruff-specific rules |
-| C4 | flake8-comprehensions |
-| DTZ | flake8-datetimez |
-| T20 | flake8-print (no print statements in production code) |
-| PTH | flake8-use-pathlib |
-| TC | flake8-type-checking |
-| RET | flake8-return |
-| PLW | pylint warnings |
-| PT | flake8-pytest-style |
-| A | flake8-builtins |
-| COM | flake8-commas |
-| PIE | flake8-pie |
-| ISC | flake8-implicit-str-concat |
-| G | flake8-logging-format |
-| INP | flake8-no-pep420 |
-| TID | flake8-tidy-imports |
-| ERA | eradicate (commented-out code) |
-
-Notable ignored rules:
-
-- **E501** - Line too long (the formatter handles wrapping at 120 chars)
-- **COM812** - Missing trailing comma (conflicts with formatter)
-- **ISC001** - Implicit string concatenation (conflicts with formatter)
-- **TC001/TC002/TC003** - Type checking imports (would break runtime type resolution)
-- **RET504/RET505** - Return-related simplifications (reduces debuggability)
-
-### Import Order
-
-Enforced by ruff/isort:
-
-1. Standard library (`import logging`, `import json`)
-2. Third-party packages (`import httpx`, `from pydantic import ...`)
-3. Local imports (`from servicenow_mcp.client import ServiceNowClient`)
-
-**Absolute imports only** - relative imports are not used.
-
-## Type Annotations
-
-All function signatures must have full type hints - enforced by mypy with `disallow_untyped_defs = true`.
-
-### Rules
-
-- Return types always explicit, including `-> None` for void functions
-- Modern union syntax: `str | None` (not `Optional[str]`)
-- Lowercase generic types (PEP 585): `dict[str, Any]`, `list[str]`, `set[str]`
-- Primary typing import: `from typing import Any`
-- Regex patterns typed as `re.Pattern[str]`
-
-### mypy Configuration
-
-```toml
-[tool.mypy]
-python_version = "3.12"
-warn_return_any = false
-warn_unused_configs = true
-disallow_untyped_defs = true
-ignore_missing_imports = true
+```bash
+uv run ruff check .            # lint
+uv run ruff check --fix .      # auto-fix
+uv run ruff format .           # format
+uv run ruff format --check .   # verify without writing
 ```
 
-The `servicenow_mcp.server` module has `call-arg` error code disabled due to FastMCP's dynamic tool registration.
+### Type Check
 
-## Naming Conventions
+```bash
+uv run mypy src/
+```
 
-| Category | Convention | Examples |
-|---|---|---|
-| Functions/methods/variables | `snake_case` | `check_table_access`, `query_store` |
-| Classes | `PascalCase` | `ServiceNowClient`, `ChoiceRegistry` |
-| Constants | `UPPER_SNAKE_CASE` | `DENIED_TABLES`, `MASK_VALUE`, `PACKAGE_REGISTRY` |
-| Private | Single `_` prefix | `_table_url`, `_http_client`, `_ensure_client` |
-| Logger | Module-level | `logger = logging.getLogger(__name__)` |
-| Test classes | `Test` prefix + feature | `TestServiceNowClientGetRecord` |
-| Test methods | `test_` prefix + descriptive | `test_get_record_success` |
+---
 
-## Testing
+## Ruff Configuration
 
-### Framework
+Configured in `pyproject.toml`. Key settings:
 
-- **pytest** with **pytest-asyncio** (`asyncio_mode = "auto"` - no manual event loop configuration needed)
-- HTTP mocking: **respx** library with `@respx.mock` decorator on async test methods
-- Coverage: **pytest-cov**, reports to **Codecov**
-- Default addopts: `-m 'not integration' --cov=servicenow_mcp --cov-report=xml --cov-report=term-missing`
+| Setting | Value |
+|---------|-------|
+| Line length | 120 |
+| Quote style | double |
+| Target | `py312` |
+| Src dirs | `["src", "tests"]` |
 
-### Parsing Tool Output in Tests
+Selected rule families:
 
-All tool output is JSON. Parse with `json.loads()`:
+```
+E, F, W, I, UP, B, SIM, RUF, C4, DTZ, T20, PTH, TC, RET, PLW, PT, A, COM, PIE, ISC, G, INP, TID, ERA
+```
+
+Ignored rules:
+
+```
+E501, COM812, ISC001, TC001, TC002, TC003, RET504, RET505
+```
+
+Per-file ignores for `tests/**/*.py`: `T20, ERA001, PT019`.
+
+isort is configured with `known-first-party = ["servicenow_mcp"]`.
+
+---
+
+## Mypy Configuration
+
+| Setting | Value |
+|---------|-------|
+| `python_version` | `"3.12"` |
+| `disallow_untyped_defs` | `true` |
+| `ignore_missing_imports` | `true` |
+| `warn_return_any` | `false` |
+| `warn_unused_configs` | `true` |
+
+Module override: `servicenow_mcp.server` disables the `call-arg` error code. This accommodates FastMCP's dynamic tool registration signature.
+
+---
+
+## Pytest Configuration
+
+| Setting | Value |
+|---------|-------|
+| `asyncio_mode` | `"auto"` |
+| `testpaths` | `["tests"]` |
+| Default addopts | `-m 'not integration' --cov=servicenow_mcp --cov-report=xml --cov-report=term-missing` |
+
+The `integration` marker gates tests that run against a live ServiceNow instance. These require credentials in `.env.local` and are excluded by default.
+
+---
+
+## Adding a New Tool Group
+
+Every tool group module exports a `register_tools` function with the canonical 5-argument signature. The server loader calls every group with identical arguments regardless of whether the group needs them all.
 
 ```python
-import json
+def register_tools(
+    mcp: FastMCP,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    choices: ChoiceRegistry | None = None,
+    dictionary: DictionaryRegistry | None = None,
+) -> None:
+    del choices, dictionary  # unused; signature retained for loader parity
 
-raw = await tools["my_tool"](param="value")
+    @mcp.tool()
+    @tool_handler
+    async def my_tool(table: str, correlation_id: str = "") -> str:
+        """Brief description shown to the AI client.
+
+        Args:
+            table: The ServiceNow table name.
+        """
+        validate_identifier(table)
+        check_table_access(table)
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.some_method(table)
+
+        return format_response(data=result, correlation_id=correlation_id)
+```
+
+Rules:
+
+1. Decorator order is `@mcp.tool()` then `@tool_handler`.
+2. `correlation_id: str = ""` is always the last parameter. `@tool_handler` auto-injects it and hides it from the MCP schema.
+3. Never raise to the caller. `@tool_handler` wraps every call in `safe_tool_call()` which catches exceptions and returns serialized error envelopes.
+4. The docstring `Args:` section becomes the tool's parameter descriptions in MCP.
+5. Register your group in `_TOOL_GROUP_MODULES` and add it to the appropriate preset packages in `packages.py`.
+
+The one exception: `list_tool_packages` is registered inline in `server.py` without `@tool_handler`. It has no `correlation_id`, no error envelope, and returns `serialize(list_packages())` directly.
+
+---
+
+## Testing Patterns
+
+### HTTP Mocking with respx
+
+All unit tests mock HTTP via the **respx** library:
+
+```python
+@respx.mock
+async def test_query_success(self, settings, auth_provider):
+    respx.get("https://test.service-now.com/api/now/table/incident").mock(
+        return_value=httpx.Response(200, json={"result": [...]})
+    )
+    tools = _register_and_get_tools(settings, auth_provider)
+    raw = await tools["query"](table="incident", encoded_query="active=true")
+    result = json.loads(raw)
+    assert result["status"] == "success"
+```
+
+### Registering Tools in Tests
+
+Use the helper with the same 5-argument signature:
+
+```python
+def _register_and_get_tools(settings, auth_provider, choices=None, dictionary=None):
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider, choices=choices, dictionary=dictionary)
+    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
+```
+
+### Parsing Tool Output
+
+All tools return a serialized JSON string via `format_response`. Parse with `json.loads`:
+
+```python
+raw = await tools["my_tool"](table="incident")
 result = json.loads(raw)
 assert result["status"] == "success"
-assert result["data"]["field"] == "expected"
+assert result["correlation_id"]  # always present
 ```
-
-### Standard Test Helper Pattern
-
-```python
-def _register_and_get_tools(settings, auth_provider):
-    mcp = FastMCP("test")
-    register_tools(mcp, settings, auth_provider)
-    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-```
-
-Domain tools use the same pattern with an extra `choices` parameter:
-
-```python
-def _register_and_get_tools(settings, auth_provider, choices=None):
-    mcp = FastMCP("test")
-    register_tools(mcp, settings, auth_provider, choices=choices)
-    return {t.name: t.fn for t in mcp._tool_manager._tools.values()}
-```
-
-### Test Fixtures
-
-Defined in `tests/conftest.py`:
-
-| Fixture | Scope | Description |
-|---|---|---|
-| `_disable_sentry_capture` | autouse | Resets Sentry `_initialized` flag to prevent real captures during tests |
-| `settings` | per-test | Dev environment settings (`SERVICENOW_ENV=dev`) |
-| `prod_settings` | per-test | Production environment settings (`SERVICENOW_ENV=prod`) |
-| `prod_auth_provider` | per-test | `BasicAuthProvider` from production settings |
-
-All fixtures construct `Settings(_env_file=None)` with `patch.dict("os.environ", ...)` to avoid loading real env files.
 
 ### Integration Tests
 
 - Located in `tests/integration/`
 - Marked with `@pytest.mark.integration`
-- Excluded from default test runs (via `-m 'not integration'` addopts)
+- Excluded by default; run with `uv run pytest -m integration`
 - Require `.env.local` with real ServiceNow credentials
-- Run with: `uv run pytest -m integration`
+- Use session-scoped fixtures for the instance connection
 
-## CI Pipeline
+---
 
-The CI workflow (`.github/workflows/ci.yml`) runs on every push to `main` and every pull request targeting `main`.
+## CI
 
-### Concurrency
+Four workflows live in `.github/workflows/`:
 
-Uses GitHub's concurrency groups with `cancel-in-progress: true` - new pushes cancel in-flight runs for the same branch.
+### ci.yml
 
-### Jobs
+Triggers on push to `main` and PRs targeting `main`. Concurrency groups cancel in-progress runs.
 
-Three parallel jobs run on `ubuntu-latest`:
+Three parallel jobs on `ubuntu-latest`:
 
-**1. Lint**
-- Installs dependencies with `uv sync --group dev`
-- Runs `uv run ruff check .` (lint rules)
-- Runs `uv run ruff format --check .` (formatting verification)
+1. **lint** - `uv run ruff check .` and `uv run ruff format --check .`
+2. **type-check** - `uv run mypy src/`
+3. **test** - matrix over Python 3.12, 3.13, 3.14 (`fail-fast: false`). Coverage uploaded to Codecov on 3.12 only.
 
-**2. Type Check**
-- Installs dependencies with `uv sync --group dev`
-- Runs `uv run mypy src/`
+### codeql.yml
 
-**3. Test** (matrix: Python 3.12, 3.13, 3.14)
-- Installs the target Python version via `uv python install`
-- Installs dependencies with `uv sync --group dev --python ${{ matrix.python-version }}`
-- Runs `uv run --python ${{ matrix.python-version }} pytest`
-- Uploads coverage to Codecov on **Python 3.12 only**
+GitHub CodeQL static analysis for Python. Runs on push, PRs, and a weekly cron (Monday 06:00 UTC).
 
-All three jobs must pass before a PR can be merged.
+### release-please.yml
 
-## Release Process
+Automated releases driven by conventional commits. See Releases below.
 
-Automated via **release-please** (`.github/workflows/release-please.yml`).
+### stale.yml
 
-### How It Works
+Marks inactive issues and PRs as stale (daily cron).
 
-1. **Conventional commits** on `main` trigger release-please to create/update a release PR with a generated changelog
-2. **Merging the release PR** creates a GitHub Release with the new tag and version
-3. The **publish job** runs only when a release is created:
-   - Checks out the code
-   - Builds the package with `uv build`
-   - Publishes to PyPI with `uv publish --token ${{ secrets.PYPI_TOKEN }}`
+---
 
-### Required Secrets
+## Releases
 
-| Secret | Purpose |
-|---|---|
-| `RELEASE_PLEASE_TOKEN` | GitHub token for creating release PRs |
-| `PYPI_TOKEN` | PyPI API token for package publishing |
-| `CODECOV_TOKEN` | Codecov upload token |
+The project uses **release-please** (`googleapis/release-please-action@v5`) with conventional commits.
 
-### Commit Convention
+Workflow:
 
-Release-please uses conventional commits to determine version bumps:
+1. Land changes on `main` using conventional commit messages (`feat:`, `fix:`, `docs:`, etc.).
+2. release-please opens or updates a release PR with a generated changelog.
+3. Merging that PR creates a GitHub Release and git tag.
+4. A conditional **publish** job runs `uv build` then `uv publish` to PyPI.
 
-| Prefix | Version Bump | Example |
-|---|---|---|
-| `feat:` | Minor | `feat: add attachment upload tool` |
-| `fix:` | Patch | `fix: handle empty query results` |
-| `docs:` | None | `docs: update README` |
-| `chore:` | None | `chore: update dependencies` |
-| `refactor:` | None | `refactor: extract query builder` |
-| `test:` | None | `test: add client error handling tests` |
-| `feat!:` or `BREAKING CHANGE:` | Major | `feat!: remove deprecated API` |
+Version is managed in `pyproject.toml`. release-please handles the bump automatically.
 
-## Git Workflow
-
-- **Never** work directly on `main` - always use feature branches
-- **Conventional commits** required (enforced by release-please)
-- **Small, atomic commits** - each commit should do one thing
-- **Use `gh` CLI** for GitHub operations (PRs, issues, etc.)
-- **Never** commit code that breaks existing tests
-
-## Project Dependencies
-
-### Core Dependencies
-
-| Package | Purpose |
-|---|---|
-| `mcp` (>=1.0.0) | MCP server framework |
-| `httpx` (>=0.27.0) | Async HTTP client |
-| `pydantic` (>=2.0.0) | Data validation |
-| `pydantic-settings` (>=2.0.0) | Environment-based configuration |
-| `python-dotenv` (>=1.0.0) | `.env` file loading |
-| `uvicorn` (>=0.30.0) | ASGI server (SSE transport) |
-| `starlette` (>=0.38.0) | ASGI framework (SSE transport) |
-| `sentry-sdk` (>=2.55.0) | Error tracking |
-
-### Dev Dependencies
-
-| Package | Purpose |
-|---|---|
-| `pytest` (>=8.0.0) | Test framework |
-| `pytest-asyncio` (>=0.24.0) | Async test support |
-| `respx` (>=0.21.0) | httpx mocking |
-| `ruff` (>=0.9.0) | Linter and formatter |
-| `mypy` (>=1.14.0) | Type checker |
-| `pytest-cov` (>=6.0.0) | Coverage reporting |
-| `basedpyright` (>=1.29.0) | Alternative type checker |
-
-### Build System
-
-- **Build backend**: hatchling
-- **Wheel packages**: `src/servicenow_mcp` (src-layout)
-- **Entry point**: `servicenow-platform-mcp = servicenow_mcp.server:main`
+Required repository secrets: `RELEASE_PLEASE_TOKEN`, `PYPI_TOKEN`, `CODECOV_TOKEN`.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,193 +1,157 @@
 # Getting Started
 
-This guide walks you through installing and configuring the ServiceNow Platform MCP server for use with your AI client.
-
----
+This tutorial walks you through a first session with the servicenow-platform-mcp server. You have it installed and connected to an MCP client; now you want to do useful things. Each step builds on the last - by the end you will have queried records, inspected schema, written safely, resolved choice labels, and run an investigation.
 
 ## Prerequisites
 
-- **Python 3.12 or later** - The server requires Python 3.12+ (3.12, 3.13, and 3.14 are supported)
-- **A ServiceNow instance** - Developer, test, or production (note: write operations are blocked on production instances)
-- **ServiceNow credentials** - A user account with appropriate roles. Admin is recommended for full access to all tools
-- **An MCP-compatible AI client** - [OpenCode](https://opencode.ai), [Claude Desktop](https://claude.ai/download), [VS Code Copilot](https://code.visualstudio.com/), [Cursor](https://cursor.sh/), or any client supporting the [Model Context Protocol](https://modelcontextprotocol.io/)
+- Server installed and running (see INSTALL.md)
+- Credentials pointing at a dev or sandbox ServiceNow instance
+- `MCP_TOOL_PACKAGE` set to `full` (the default)
 
----
+## 1. Confirm the Server Is Up
 
-## Installation
+Call `list_tool_packages` with no arguments.
 
-### Recommended: Run with uvx (no install required)
+This tool is special: it bypasses `@tool_handler` entirely and returns raw JSON - no `status` field, no `correlation_id`, no error envelope. It is always registered regardless of your active package.
 
-```bash
-uvx servicenow-platform-mcp
-```
-
-This downloads and runs the server in an isolated environment. No permanent installation needed.
-
-### Alternative: Install with pip or uv
-
-```bash
-pip install servicenow-platform-mcp
-```
-
-```bash
-uv add servicenow-platform-mcp
-```
-
-> **Note:** The server communicates via stdio transport - it is launched by your MCP client as a subprocess, not run as a standalone service. You do not need to start it manually.
-
----
-
-## Environment Variables
-
-Three environment variables are required. These are passed to the server by your MCP client configuration.
-
-| Variable | Required | Description |
-|---|---|---|
-| `SERVICENOW_INSTANCE_URL` | Yes | Full instance URL, must start with `https://` |
-| `SERVICENOW_USERNAME` | Yes | ServiceNow username for Basic Auth |
-| `SERVICENOW_PASSWORD` | Yes | ServiceNow password |
-| `MCP_TOOL_PACKAGE` | No | Tool package to load (default: `"full"`). See [[Tool-Packages]] |
-| `SERVICENOW_ENV` | No | Environment label (default: `"dev"`). Write ops blocked on `"prod"` / `"production"` |
-
-The server also loads variables from `.env` and `.env.local` files in the working directory (`.env.local` takes precedence).
-
-See [[Configuration]] for the full reference of all environment variables.
-
----
-
-## MCP Client Configuration
-
-Configure your MCP client to launch the server with the required environment variables. Below are configuration examples for popular clients.
-
-### OpenCode
-
-File: `~/.config/opencode/opencode.json`
+Expected output:
 
 ```json
 {
-  "mcp": {
-    "servicenow": {
-      "type": "local",
-      "command": ["uvx", "servicenow-platform-mcp"],
-      "environment": {
-        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
-        "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password"
-      }
-    }
-  }
+  "full": ["query", "build_query", "describe", "record_read", "record_write", "attachment", "investigate", "resolve_choice", "service_catalog", "audit", "flow"],
+  "readonly": ["query", "describe", "record_read", "attachment", "investigate", "resolve_choice", "audit", "flow"],
+  "core_readonly": ["query", "describe", "attachment"],
+  "none": []
 }
 ```
 
-### Claude Desktop
+If your MCP client shows only `list_tool_packages` and nothing else, your `MCP_TOOL_PACKAGE` value is `none` or does not match a valid preset or comma-separated group list.
 
-File: `claude_desktop_config.json`
+## 2. Inspect a Table
+
+Call `describe` with only `table`:
+
+```json
+{ "table": "incident" }
+```
+
+When `action` is omitted (or empty string), `describe` runs the default field-metadata flow: it queries `sys_dictionary` and returns each field's name, label, type, max_length, mandatory flag, read_only flag, reference_table, and choice_count.
+
+The `action` parameter accepts exactly one value: `"list_script_fields"`. Any other string - for example `action: "fields"` - returns the error:
+
+```
+Unknown describe action 'fields'. Valid actions: ['list_script_fields'].
+```
+
+Do not guess action names. Omit the parameter for field metadata; pass `"list_script_fields"` when you need the script-bearing fields on a table.
+
+## 3. Query Records
+
+Call `query` with:
+
+```json
+{ "table": "incident", "limit": 5 }
+```
+
+The response envelope includes `data` (the masked records), `pagination` with `offset`, `limit`, and `total`, plus a `correlation_id` for tracing.
+
+To filter, pass `encoded_query` using ServiceNow's encoded query syntax:
+
+```json
+{ "table": "incident", "limit": 5, "encoded_query": "active=true^priority=1" }
+```
+
+The server enforces query safety: limits are capped at `MAX_ROW_LIMIT` (default 100), and large tables (syslog, sys_audit, sys_log_transaction, sys_email_log) require a date-bounded filter.
+
+## 4. Read One Record
+
+Take a `sys_id` from the query results and call `record_read`:
+
+```json
+{ "table": "incident", "sys_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" }
+```
+
+The response includes the full masked record plus `script_fields` - the list of script-bearing fields detected on that table via the DictionaryRegistry.
+
+Exactly one of `sys_id` or `name` must be supplied. Passing both returns an error; passing neither also returns an error. When using `name`, if multiple records match the server returns an ambiguity error rather than guessing.
+
+## 5. Write Safely (Preview-Then-Apply)
+
+Writes use a two-step pattern by default.
+
+**Step 5a - Preview:**
 
 ```json
 {
-  "mcpServers": {
-    "servicenow": {
-      "command": "uvx",
-      "args": ["servicenow-platform-mcp"],
-      "env": {
-        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
-        "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password"
-      }
-    }
-  }
+  "table": "incident",
+  "action": "update",
+  "sys_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  "data": "{\"short_description\": \"Updated via MCP\"}"
 }
 ```
 
-### VS Code / Cursor
+Because `preview` defaults to `True`, the server does not touch ServiceNow. It fetches the current record, computes a diff, stores the payload in a single-use token store (TTL 5 minutes), and returns a `preview_token` along with the masked diff.
 
-File: `.vscode/mcp.json`
+**Step 5b - Apply:**
+
+```json
+{ "preview_token": "b7e4f9a2-1c3d-4e5f-8a9b-0c1d2e3f4a5b" }
+```
+
+Call `record_apply` with the `preview_token` parameter (not `token` - the parameter name is `preview_token`). The server consumes the token, re-validates write permissions, and executes the update. The token is single-use; replaying it returns `"Invalid or expired preview token"`.
+
+## 6. Resolve Choice Labels
+
+Human-readable labels like "In Progress" do not match the numeric values ServiceNow stores. Call `resolve_choice` to map them:
+
+```json
+{ "table": "incident", "field": "state" }
+```
+
+With no `label` parameter, this returns all known choices for that field (e.g. open=1, in_progress=2, on_hold=3, resolved=6, closed=7, canceled=8). Pass `label` to resolve a single value:
+
+```json
+{ "table": "incident", "field": "state", "label": "in_progress" }
+```
+
+Labels are normalized: lowercase, spaces replaced with underscores.
+
+## 7. Run an Investigation
+
+The `investigate` tool dispatches predefined analysis playbooks. Call it with:
 
 ```json
 {
-  "servers": {
-    "servicenow": {
-      "command": "uvx",
-      "args": ["servicenow-platform-mcp"],
-      "env": {
-        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
-        "SERVICENOW_USERNAME": "admin",
-        "SERVICENOW_PASSWORD": "your-password"
-      }
-    }
-  }
+  "action": "run",
+  "name": "stale_automations",
+  "params": "{\"stale_days\": 90}"
 }
 ```
 
-### Generic stdio
+The parameter is `name` (not `investigation`). The `params` value is a JSON string parsed server-side.
 
-For any client that supports stdio transport, launch the server with inline environment variables:
+Three actions are available:
 
-```bash
-SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com \
-SERVICENOW_USERNAME=admin \
-SERVICENOW_PASSWORD=your-password \
-uvx servicenow-platform-mcp
+- `run` - execute the investigation and return findings
+- `explain` - given an `element_id` (format `table:sys_id`), ask all registered investigations to explain that element
+- `describe` - list available investigations and their parameters (no platform I/O)
+
+Seven investigations are registered: `stale_automations`, `deprecated_apis`, `table_health`, `acl_conflicts`, `error_analysis`, `slow_transactions`, `performance_bottlenecks`.
+
+## 8. Production Safety
+
+When `SERVICENOW_ENV` is set to `prod` or `production`, ALL write operations are blocked regardless of table. The server returns a serialized error envelope with the message:
+
+```
+Write operations are blocked in production environments
 ```
 
----
+This applies to `record_write`, `record_apply`, `attachment_write`, and the write actions on `service_catalog` (ordering, cart operations). There is no override flag - the block is absolute for the environment.
 
-## First Steps
+Even outside production, 8 security-sensitive tables are permanently denied for writes (and reads): `sys_user_has_password`, `oauth_credential`, `oauth_entity`, `sys_certificate`, `sys_ssh_key`, `sys_credentials`, `discovery_credentials`, `sys_user_token`.
 
-Once configured, try these example prompts with your AI agent:
+## Where to Go Next
 
-- **"Describe the incident table schema"** - Explores table structure, field types, and metadata
-- **"List open incidents"** - Queries records using domain tools with choice label resolution
-- **"Show me what business rules run on the incident table"** - Inspects platform artifacts
-- **"Trace the debug log for incident INC0010001"** - Builds an event timeline from system logs
-- **"What update sets were created this week?"** - Change intelligence across your instance
-- **"Run a table health investigation on cmdb_ci"** - Automated analysis with findings and recommendations
-
----
-
-## AI Agent Setup
-
-For copy-paste installation instructions optimized for AI agents, see [INSTALL.md](https://github.com/Xerrion/servicenow-platform-mcp/blob/main/INSTALL.md) in the repository root. This file is designed to be fed directly to an AI agent for self-configuration.
-
----
-
-## Troubleshooting
-
-### Connection refused or timeout
-
-- Verify `SERVICENOW_INSTANCE_URL` starts with `https://` (HTTP is not supported)
-- Check that your ServiceNow instance is reachable from your network
-- Trailing slashes are stripped automatically - `https://dev12345.service-now.com/` works fine
-
-### Authentication errors
-
-- Confirm `SERVICENOW_USERNAME` and `SERVICENOW_PASSWORD` are correct
-- The user account needs appropriate ServiceNow roles. Admin is recommended for full tool access
-- Check if your instance requires MFA or SSO - Basic Auth must be enabled for the user
-
-### No tools appearing in your AI client
-
-- Verify `MCP_TOOL_PACKAGE` is set to a valid package name (default is `"full"`)
-- Use the `list_tool_packages` tool (always available) to see what packages and groups exist
-- Check your MCP client logs for startup errors
-
-### Write operations blocked
-
-- Write operations are blocked when `SERVICENOW_ENV` is set to `"prod"` or `"production"`
-- This is a safety guardrail with no override - use a sub-production instance for write operations
-- Read operations work normally regardless of environment setting
-
-### Server not starting
-
-- Ensure Python 3.12 or later is installed: `python --version`
-- Try running directly: `uvx servicenow-platform-mcp` to see error output
-- Check that `uvx` is installed: `uv --version` (install from [astral.sh/uv](https://astral.sh/uv))
-
----
-
-## Next Steps
-
-- [[Configuration]] - Full environment variable reference and validation rules
-- [[Tool-Reference]] - Complete list of available tools with descriptions
-- [[Tool-Packages]] - Choose the right tool package for your use case
-- [[Safety-and-Policy]] - Understand the security guardrails
+- [[Tool-Reference]] - complete parameter and response documentation for every tool
+- [[Investigations]] - the 7 registered playbooks, their parameters, and element_id format
+- [[Safety-and-Policy]] - denied tables, field masking, query safety, and write gating in detail

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,72 +1,53 @@
 # ServiceNow Platform MCP Server
 
-A comprehensive MCP server for ServiceNow - platform introspection, change intelligence, debugging, investigations, and documentation generation.
+`servicenow-platform-mcp` is an async Python 3.12+ MCP server that gives AI assistants structured access to a ServiceNow instance. It communicates over stdio, exposes a composable tool surface for schema discovery, record operations, Flow Designer inspection, audit-trail queries, investigation playbooks, and Service Catalog ordering - all governed by built-in safety controls that deny sensitive tables, mask credentials in responses, enforce query-safety limits on large tables, and gate writes in production environments.
 
 ---
 
-## What is this?
+## Wiki Directory
 
-**servicenow-platform-mcp** is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI agents direct access to your ServiceNow instance. It exposes a comprehensive suite of tools covering schema exploration, record management, debugging, change intelligence, ITSM processes, and more - all through a standardized MCP interface.
+Go to the page that matches what you need:
 
-The server runs locally via stdio transport and is launched by your MCP-compatible AI client (OpenCode, Claude Desktop, VS Code Copilot, Cursor, etc.). Your AI agent gains the ability to query tables, inspect records, trace debug logs, generate documentation, manage incidents, and much more - without you needing to navigate the ServiceNow UI.
-
----
-
-## Key Capabilities
-
-- **Schema and table introspection** - Describe table schemas, query records, compute aggregates, and build structured queries
-- **Record CRUD** - Create, read, update, and delete records with a preview-then-apply confirmation pattern
-- **Attachment operations** - List, download, upload, and delete attachments with base64 content transfer
-- **Change intelligence** - Inspect update sets, diff artifact versions, view audit trails, and generate release notes
-- **Debug and trace** - Build event timelines, trace field mutations, inspect flow executions, check integration health
-- **Investigations** - Run automated analyses: stale automations, deprecated APIs, table health, ACL conflicts, error patterns, slow transactions
-- **Documentation generation** - Generate automation maps, artifact summaries, test scenarios, and code review notes
-- **Workflow and Flow Designer analysis** - Map workflow structures, inspect executions, analyze migration readiness
-- **ITSM domain tools** - Full lifecycle management for Incidents, Changes, Problems, Requests, Knowledge, CMDB, and Service Catalog
-- **Artifact write** - Create and update platform artifacts (business rules, script includes, client scripts, etc.) with optional local script file injection
+| Page | Go here if you need to... |
+|------|---------------------------|
+| [[Getting-Started]] | Install the server, configure credentials, and run your first query. |
+| [[Configuration]] | Understand every environment variable and its effect on runtime behavior. |
+| [[Tool-Packages]] | Choose a preset package or build a custom tool surface from individual groups. |
+| [[Tool-Reference]] | Look up a specific tool's actions, parameters, required arguments, or response shape. |
+| [[Investigations]] | Run or author investigation playbooks (stale automations, deprecated APIs, ACL conflicts, and more). |
+| [[Architecture]] | Understand the server bootstrap sequence, tool registration pattern, client lifecycle, and error hierarchy. |
+| [[Safety-and-Policy]] | Learn which tables are denied, how fields are masked, how query safety works, and how write gating protects production. |
+| [[Telemetry]] | Configure Sentry integration and understand argument redaction before data leaves the process. |
+| [[Development]] | Run the test suite, lint, type-check, and contribute changes. |
 
 ---
 
-## Quick Navigation
+## Installation
 
-| Page | Description |
-|---|---|
-| [[Getting-Started]] | Installation, MCP client configuration, first steps |
-| [[Configuration]] | Environment variables, settings reference |
-| [[Tool-Reference]] | Complete tool reference with descriptions |
-| [[Tool-Packages]] | Preset and custom tool packages |
-| [[Safety-and-Policy]] | Security guardrails, table deny list, write gating |
-| [[Development]] | Contributing, testing, CI pipeline |
-| [[Architecture]] | Server internals, patterns, data flow |
-| [[Telemetry]] | Sentry error tracking setup |
+For install instructions, dependency setup, and first-run guidance, see the repository [README](https://github.com/AstreaTech/servicenow-platform-mcp#readme).
 
 ---
 
-## Quick Start
+## Quick Facts
 
-**1. Run the server**
+- **Version**: 0.10.0
+- **License**: MIT
+- **Python**: 3.12, 3.13, 3.14
+- **Transport**: stdio (MCP SDK)
+- **Build system**: hatchling
+- **Package manager**: uv
 
-```bash
-uvx servicenow-platform-mcp
+---
+
+## Project Layout
+
 ```
-
-**2. Set environment variables**
-
-```bash
-SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com
-SERVICENOW_USERNAME=admin
-SERVICENOW_PASSWORD=your-password
+src/servicenow_mcp/
+  server.py          # Bootstrap and entry point
+  config.py          # Settings (pydantic-settings)
+  client.py          # Async HTTP client for ServiceNow REST API
+  policy.py          # Table deny-list, field masking, query safety, write gating
+  errors.py          # Exception hierarchy
+  tools/             # One module per tool group
+  investigations/    # Investigation playbook modules
 ```
-
-**3. Configure your MCP client** to launch the server with those environment variables.
-
-See [[Getting-Started]] for full setup instructions with configuration examples for OpenCode, Claude Desktop, VS Code, Cursor, and more.
-
----
-
-## Links
-
-- [PyPI](https://pypi.org/project/servicenow-platform-mcp/)
-- [GitHub Repository](https://github.com/Xerrion/servicenow-platform-mcp)
-- [Issues](https://github.com/Xerrion/servicenow-platform-mcp/issues)
-- [License (MIT)](https://github.com/Xerrion/servicenow-platform-mcp/blob/main/LICENSE)

--- a/docs/wiki/Investigations.md
+++ b/docs/wiki/Investigations.md
@@ -1,0 +1,327 @@
+# Investigations
+
+The `investigate` tool dispatches structured, read-only analysis modules against a ServiceNow instance. It accepts three actions - `run`, `explain`, and `describe` - and routes by the `name` parameter (not `investigation`).
+
+## Actions
+
+### describe
+
+Returns the registry without platform I/O.
+
+```json
+{"action": "describe"}
+```
+
+Response: `{"investigations": ["acl_conflicts", "deprecated_apis", ...]}` (sorted).
+
+Pass `name` to get a single module's parameter schema:
+
+```json
+{"action": "describe", "name": "error_analysis"}
+```
+
+Response includes `name`, `description` (first line of the module docstring), and `params`.
+
+### run
+
+Execute an investigation by name.
+
+```json
+{"action": "run", "name": "stale_automations", "params": "{\"stale_days\": 14}"}
+```
+
+`params` is a JSON string. When the params dict contains a `table` key, the dispatcher validates the identifier and checks table access before calling the module.
+
+### explain
+
+Provide rich context for a finding's `element_id`. The format is `"table:sys_id"`.
+
+```json
+{"action": "explain", "element_id": "sys_script:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"}
+```
+
+The dispatcher trial-runs every registered module's `explain` function. Modules decline by returning `{"error": "..."}` (single key). The first non-decline wins. If all decline: `{"error": "No registered investigation can explain element_id '...'"}`.
+
+Bare-table forms are not supported.
+
+---
+
+## stale_automations
+
+Find stuck flows, disabled scripts, and stale scheduled jobs.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `stale_days` | int | 30 | Days of inactivity to qualify as stale. Minimum 1. |
+| `limit` | int | 20 | Max findings per category. |
+
+### Tables queried
+
+- `sys_flow_context` - flows stuck in IN_PROGRESS, created more than `stale_days` ago.
+- `sys_script` - business rules with `active=false`.
+- `sys_script_include` - script includes with `active=false`.
+- `sys_trigger` - repeating triggers not updated in `stale_days`.
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `params`.
+
+Finding categories: `stuck_flow`, `disabled_business_rule`, `disabled_script_include`, `stale_scheduled_job`. Each finding carries `category`, `element_id` (`table:sys_id`), `name`, `detail`.
+
+### When to reach for it
+
+Platform hygiene reviews. Identify automations that are abandoned, stuck, or consuming resources without value.
+
+### Caveats
+
+- Disabled business rules are not inherently stale - some are intentionally deactivated during maintenance windows.
+- `sys_trigger` uses `sys_updated_on` as a staleness proxy; a trigger could be stale even if recently touched by a metadata update.
+
+---
+
+## deprecated_apis
+
+Scan scripts for deprecated API usage patterns via the Code Search API.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | int | 20 | Max findings per pattern. |
+
+### Tables queried
+
+Uses `client.code_search()`. Results may come from: `sys_script_include`, `sys_script`, `sys_ws_operation`, `sys_ui_script`, `sys_processor`, `sp_widget`.
+
+Patterns searched: `Packages.`, `gs.include(`, `current.setWorkflow(false)`, `GlideRecordSecure(`, `g_form.flash(`.
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `params`, `patterns_searched`.
+
+Each finding: `pattern`, `element_id`, `name`, `table`, `detail`.
+
+### When to reach for it
+
+Pre-upgrade readiness checks. Surface scripts using APIs that may be removed or behave differently in newer ServiceNow releases.
+
+### Caveats
+
+- Depends on the Code Search API being enabled on the instance. Unavailable patterns are silently skipped.
+- Pattern matching is substring-based; false positives are possible (e.g., `Packages.` in a comment).
+- The pattern list is hardcoded and does not cover all deprecated APIs.
+
+---
+
+## table_health
+
+Comprehensive health report for a single table: record count, automation density, and recent errors.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `table` | str | (required) | Table name to analyze. |
+| `hours` | int or None | None | Lookback window in hours. Omit to query all history. |
+
+### Tables queried
+
+Runs 6 queries in parallel:
+
+- Target table (via Stats API) - total record count.
+- `sys_script` - active business rules where `collection` matches.
+- `sys_script_client` - active client scripts where `table` matches.
+- `sys_security_acl` - ACLs where name equals or starts with the table.
+- `sys_ui_policy` - active UI policies for the table.
+- `syslog` - error-level entries (`level=0`) with `source LIKE table`, limited to 20.
+
+Automation queries capped at `INTERNAL_QUERY_LIMIT` (1000).
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `table`, `hours`, `record_count`, `automation`, `recent_errors`, `health_indicators`.
+
+`automation` contains `business_rules` (count + records), `client_scripts` (count + records), `acl_count`, `ui_policies` (count + records). Health indicator thresholds: >10 business rules, >20 ACLs, any recent syslog errors.
+
+### When to reach for it
+
+Before modifying a table's automation stack. Understand the density of rules, scripts, and policies before adding more.
+
+### Caveats
+
+- The `hours` filter applies to all automation queries (via `sys_updated_on`) and syslog (via `sys_created_on`). Omitting it queries full history, which may be slow on large instances.
+- Syslog `source LIKE table` is a heuristic; it may match unrelated sources containing the table name as a substring.
+
+---
+
+## acl_conflicts
+
+Detect overlapping ACL rules for a table - multiple ACLs sharing the same name and operation.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `table` | str | (required) | Table name to check. |
+
+### Tables queried
+
+- `sys_security_acl` - all ACLs where `name` equals the table or starts with `table.` (field-level ACLs). Fetches `sys_id`, `name`, `operation`, `condition`, `script`, `active`. Capped at `INTERNAL_QUERY_LIMIT` (1000).
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `table`, `total_acls_checked`.
+
+Each finding: `category` (`acl_conflict`), `name`, `operation`, `count`, `acls` (list of overlapping ACL details), `detail`.
+
+A conflict is reported when 2+ ACLs share the same `name|operation` key.
+
+### When to reach for it
+
+Debugging unexpected access control behavior. When users report inconsistent permissions on a table, this surfaces duplicate ACL rules that may evaluate contradictory conditions.
+
+### Caveats
+
+- Reports any duplication as a conflict, even when both ACLs have identical conditions (harmless but wasteful).
+- Does not evaluate ACL conditions or scripts for semantic contradiction - only structural overlap (same name and operation).
+- The investigation does not distinguish active from inactive ACLs when grouping; an inactive duplicate is still flagged.
+
+---
+
+## error_analysis
+
+Analyze and cluster syslog errors by source.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hours` | int | 24 | Lookback window in hours. Minimum 1. |
+| `source` | str or None | None | Optional source-name filter (LIKE match). |
+| `limit` | int | 100 | Max log entries to fetch. |
+
+### Tables queried
+
+- `syslog` - error-level entries (`level=0`) within the lookback window. Ordered by `sys_created_on` descending.
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `params`, `total_errors`.
+
+Each finding: `category` (`error_cluster`), `source`, `frequency`, `first_seen`, `last_seen`, `sample_messages` (up to 3), `element_id`.
+
+### When to reach for it
+
+Initial triage of error spikes. Quickly see which sources are producing the most errors and get sample messages without paging through syslog manually.
+
+### Caveats
+
+- Clustering is by source field only - no message deduplication or similarity grouping.
+- The `limit` cap applies to total fetched rows, not per-source. A noisy source may consume most of the budget.
+- `syslog` is a large table; wide lookback windows on busy instances may time out.
+
+---
+
+## slow_transactions
+
+Find slow transactions via ServiceNow performance pattern tables.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hours` | int | 24 | Lookback window in hours. Minimum 1. |
+| `limit` | int | 20 | Max findings per table. |
+| `categories` | csv or None | None | Comma-separated category filter (e.g., `"slow_query,mutex_contention"`). |
+
+### Tables queried
+
+| Table | Category |
+|-------|----------|
+| `sys_query_pattern` | `slow_query` |
+| `sys_transaction_pattern` | `slow_transaction` |
+| `sys_script_pattern` | `slow_script` |
+| `sys_mutex_pattern` | `mutex_contention` |
+| `sysevent_pattern` | `event_pattern` |
+| `sys_interaction_pattern` | `slow_interaction` |
+| `syslog_cancellation` | `cancelled_transaction` |
+
+Pattern tables are queried with `window_endISEMPTY^window_startISEMPTY` plus a time filter. `syslog_cancellation` uses only the time filter.
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `params`, `tables_queried`.
+
+Each finding: `category`, `table`, `element_id`, `name`, `count`, `detail`, `sys_created_on`.
+
+### When to reach for it
+
+Performance troubleshooting. Identify which query patterns, scripts, or mutex waits are currently active on the instance.
+
+### Caveats
+
+- Not all instances have all 7 pattern tables populated. Missing or inaccessible tables are silently skipped - you will not see an error, just fewer results.
+- Pattern tables are ServiceNow internal performance tracking; their availability and schema may vary across platform versions.
+- No fields are specified in the query (all fields returned), which may produce large payloads.
+
+---
+
+## performance_bottlenecks
+
+Find performance bottlenecks - tables with excessive automation, frequently-running jobs, and long-running flows.
+
+### Inputs
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hours` | int or None | None | Lookback window in hours. Omit to query all history. |
+| `limit` | int | 20 | Max findings per category. |
+
+### Tables queried
+
+- `sys_script` - active business rules, grouped by `collection` (table). Reports tables exceeding a threshold of 10 active BRs. Capped at `INTERNAL_QUERY_LIMIT` (1000).
+- `sysauto_script` - active scheduled scripts (scripted jobs).
+- `sys_flow_context` - flows still in IN_PROGRESS state.
+
+### Return shape
+
+`investigation`, `finding_count`, `findings`, `params`.
+
+Finding categories: `heavy_automation`, `frequent_job`, `long_running_flow`. Each finding carries `category`, `element_id`, `name`, `detail`, and category-specific fields (`br_count`, `run_type`).
+
+### When to reach for it
+
+Instance-wide performance posture. Unlike `slow_transactions` (which reads platform-internal pattern tables), this checks automation density and job scheduling - things you can directly act on.
+
+### Caveats
+
+- The heavy automation check counts all active BRs, not just problematic ones. A table with 15 well-optimized BRs will be flagged.
+- Scheduled jobs are reported regardless of frequency; a daily job and a per-minute job get equal weight.
+- `element_id` for `heavy_automation` findings is just the table name (not `table:sys_id` format), which affects how `explain` dispatches for these findings.
+
+---
+
+## Runtime Discovery
+
+You do not need to memorize this page. The `investigate` tool itself exposes the registry:
+
+```json
+{"action": "describe"}
+```
+
+Returns the sorted list of all registered investigation names.
+
+```json
+{"action": "describe", "name": "slow_transactions"}
+```
+
+Returns that module's parameter schema (types, defaults, descriptions) - the same information documented above, available at runtime without platform I/O.
+
+---
+
+## See Also
+
+- [[Tool-Reference]] - the `investigate` tool entry
+- [[Safety-and-Policy]] - field masking applies to all investigation results via `mask_sensitive_fields`

--- a/docs/wiki/Safety-and-Policy.md
+++ b/docs/wiki/Safety-and-Policy.md
@@ -71,22 +71,40 @@ All write operations are blocked when `SERVICENOW_ENV` is set to `"prod"` or `"p
 ### Preview Pattern
 The system uses a mandatory preview/apply flow mediated by the `PreviewTokenStore`. You must first call `record_write` with `preview=true` (the default) to stage the change and receive a `preview_token`. The change is only committed when this token is passed to `record_apply`.
 
+### Payload Size Cap
+The `data` parameter on `record_write` (used for both `create.data` and `update.changes`) is capped at `MAX_PAYLOAD_BYTES = 1 MiB`. The check runs in `_validate_action_args` before payload parsing, before preview-token creation - oversized payloads are rejected immediately. As defence in depth, `parse_payload_json` enforces a stricter 256 KiB inner cap downstream; the 1 MiB outer cap is the documented entry-point contract.
+
 ---
 
 ## Script Security
 
 When writing platform artifacts (e.g., Business Rules, Widgets, UI Pages, ACLs) using the `script_path` parameter in `record_write`:
 
-- **Root Constraint:** Paths must resolve within the directory defined by `SCRIPT_ALLOWED_ROOT`.
-- **Resolution:** Paths are resolved strictly to prevent symlink or traversal attacks.
+- **Root Validation First:** `script_allowed_root` is resolved and validated as an existing directory before any user-controlled path is touched.
+- **Opaque Errors:** All user-path rejections - file does not exist, not a regular file, outside root, symlink escape - return a single opaque message: `"script_path is not readable or is outside the allowed root"`. This closes the differential-error filesystem-enumeration channel.
+- **Verbose Configuration Errors:** Operator-facing errors (`script_allowed_root` unset or not a directory) and the >1 MiB file-size error remain verbose because the user does not control them.
 - **Limits:** Files are capped at 1 MB and must be UTF-8 encoded.
 - **Mapping:** Content is automatically routed to the first script-bearing field returned by `DictionaryRegistry.get_script_fields(table)` (resolved at runtime from `sys_dictionary`). Tables with multiple script fields (e.g. `sys_ui_policy.script_true`/`script_false`, `sp_widget.client_script`/`template`/`css`, `sys_ui_page.html`/`processing_script`) accept an optional `script_field` parameter to override the default target.
 - **XML Validation:** When the resolved field has `internal_type == 'xml'` (e.g. `sys_ui_macro.xml`), the file contents are parsed with `xml.etree.ElementTree.fromstring` before any platform call; malformed XML is rejected with a structured error.
 
 ---
 
+## Decompression Caps
+
+The Flow Designer `decode_values` action decompresses gzip+base64+JSON blobs. To prevent zip-bomb and resource-exhaustion attacks:
+
+- **Wire cap:** `MAX_COMPRESSED_BYTES = 1 MiB` - checked before allocating the decompressor.
+- **Output cap:** `MAX_DECOMPRESSED_BYTES = 4 MiB` - enforced during streaming decompression.
+- Truncated streams (incomplete gzip) and trailing garbage after the gzip footer are rejected.
+- All rejections raise `ValueError`, which `safe_tool_call` surfaces as a verbose error (see Error Handling below).
+
+---
+
 ## Error Handling
 
-All safety violations result in a JSON error envelope. The `@tool_handler` decorator ensures that `PolicyError`, `QuerySafetyError`, and `ForbiddenError` (ACL denials) are caught and returned gracefully with a descriptive message.
+The `@tool_handler` decorator ensures that exceptions are caught and returned as JSON error envelopes. The handler distinguishes verbose and opaque arms:
+
+- **Verbose arms:** `ACLError`, `ForbiddenError`, `ServiceNowMCPError`, and `ValueError` preserve their curated, caller-actionable messages in the error envelope. `ValueError` is the rejected-user-input signal raised by validators like `validate_identifier` and the decompression caps above.
+- **Opaque arm:** All other exceptions return `"Internal error (correlation_id=<uuid>)"`. Full exception detail is logged locally via `logger.exception` and captured to Sentry. The `correlation_id` in the envelope lets operators pivot to the detailed record.
 
 For more details on the implementation of these policies, see [[Architecture]].

--- a/docs/wiki/Safety-and-Policy.md
+++ b/docs/wiki/Safety-and-Policy.md
@@ -1,110 +1,128 @@
 # Safety and Policy
 
-The server enforces multiple layers of safety guardrails to prevent accidental data exposure, unbounded queries, and unintended modifications. These policies are applied automatically by the platform layer.
+## Threat Model
 
----
+The policy layer defends against four classes of accident: writes to dangerous tables that store credentials or key material, leakage of secret-shaped field values through read responses, runaway queries against large platform tables, and untrusted script paths escaping their allowed root. It does NOT defend against a malicious ServiceNow admin who has already configured their instance to expose sensitive data through normal APIs, nor against a malicious operator who holds `SERVICENOW_ENV=dev` credentials and deliberately points them at a production instance.
 
-## Overview
+## Denied Tables
 
-| Layer | Purpose |
+Eight tables are unconditionally blocked from all access - read or write:
+
+| Table | Rationale |
 |---|---|
-| Table access control | Blocks access to security-sensitive tables (e.g., `sys_credentials`) |
-| Sensitive field masking | Masks passwords, tokens, and secrets in responses |
-| Query safety | Enforces row limits and date-bounded filters on large tables |
-| Write gating | Blocks all mutations in production environments |
-| Input validation | Validates identifiers and sys_ids to prevent injection |
-| Script security | Constrains local script file reads for artifact writes |
+| `sys_user_has_password` | Password hashes |
+| `oauth_credential` | OAuth tokens |
+| `oauth_entity` | OAuth configuration secrets |
+| `sys_certificate` | TLS certificates and private keys |
+| `sys_ssh_key` | SSH key material |
+| `sys_credentials` | Stored credentials |
+| `discovery_credentials` | Discovery/scan credentials |
+| `sys_user_token` | API tokens |
 
----
-
-## Table Access Control
-
-The following security-sensitive tables are permanently blocked. Any attempt to use them via `query`, `describe`, or `record_write` will raise a `PolicyError`.
-
-- `sys_user_has_password`
-- `oauth_credential`
-- `oauth_entity`
-- `sys_certificate`
-- `sys_ssh_key`
-- `sys_credentials`
-- `discovery_credentials`
-- `sys_user_token`
-
----
+`check_table_access(table)` raises `PolicyError` when `table.lower()` appears in this set.
 
 ## Sensitive Field Masking
 
-The `mask_record` (used by `query`) and `mask_sensitive_fields` (used by `record_write`) functions automatically replace sensitive values with `***MASKED***`.
+Six case-insensitive regex patterns (matched via `re.search` against field names) identify sensitive fields:
 
-### Masked Patterns
-Any field name matching these regex patterns is masked:
-- `password`, `token`, `secret`, `credential`, `api_key`, `private_key`.
+```
+password
+token
+secret
+credential
+api_key
+private_key
+```
 
----
+Matched values are replaced with the constant `MASK_VALUE = "***MASKED***"`.
+
+Two masking paths exist:
+
+- `mask_record(table, record)` dispatches on table name. For most tables it calls `mask_sensitive_fields`, which recurses into nested dicts and lists replacing values whose keys match a sensitive pattern.
+- For `sys_audit` rows, `mask_audit_entry(entry)` handles the indirect structure: the sensitive field name lives in the `fieldname`/`field` key, while actual data lives in `oldvalue`/`newvalue`/`old_value`/`new_value`. Standard field masking would miss these because the dict keys are generic.
 
 ## Query Safety
 
-Query safety prevents performance degradation on the ServiceNow instance.
+`enforce_query_safety(table, query, limit, settings)` applies three constraints in order:
 
-### Row Limits
-- All queries are capped at `MAX_ROW_LIMIT` (default 100, max 10000).
-- If no limit is provided, the default is applied automatically.
+1. Denied-table check via `check_table_access`.
+2. Limit capping - the effective limit is floored at 1 and capped at `settings.max_row_limit` (default 100, configurable 1-10000).
+3. Large-table guard - tables in `large_table_names` (default: `syslog`, `sys_audit`, `sys_log_transaction`, `sys_email_log`) must carry a date-bounded filter on a recognized date field. Without one, `QuerySafetyError` is raised.
 
-### Large Table Protection
-The following tables require a date-bounded filter (e.g., `sys_created_on>=javascript:gs.daysAgo(1)`):
-- `syslog`, `sys_audit`, `sys_log_transaction`, `sys_email_log`.
+Returns `{"limit": effective_limit}`.
 
-Failure to provide a date filter on these tables results in a `QuerySafetyError`.
+`INTERNAL_QUERY_LIMIT = 1000` caps internal metadata fetches (schema lookups, choice loading) that are not user-facing.
 
----
+## Identifier Validation
+
+`validate_identifier(name)` enforces:
+
+```
+^[a-z0-9_]+(\.[a-z0-9_]+)*$
+```
+
+This permits dot-walked references like `change_request.number` while rejecting SQL injection fragments, encoded-query operators smuggled as names, path traversal, and uppercase characters. Every table and field name passes through this validator before reaching the HTTP client.
 
 ## Write Gating
 
-Mutations are controlled by the `write_gate` function.
+Write control is function-based. There is no `WriteGatingError` exception class.
 
-### Production Blocking
-All write operations are blocked when `SERVICENOW_ENV` is set to `"prod"` or `"production"`. This affects:
-- `record_write` and `record_apply`
-- `attachment_write` (upload and delete)
-- `service_catalog` (order and cart mutations)
+Four public functions:
 
-### Preview Pattern
-The system uses a mandatory preview/apply flow mediated by the `PreviewTokenStore`. You must first call `record_write` with `preview=true` (the default) to stage the change and receive a `preview_token`. The change is only committed when this token is passed to `record_apply`.
+- `write_blocked_reason(table, settings) -> str | None` - checks in order: (1) denied table, (2) `settings.is_production`. Returns a human-readable reason or `None`.
+- `can_write(table, settings, override=False) -> bool` - `override=True` bypasses all checks; otherwise returns `write_blocked_reason(...) is None`.
+- `write_gate(table, settings, correlation_id) -> str | None` - calls `write_blocked_reason`; returns a serialized error envelope if blocked, `None` if allowed.
+- `production_write_blocked(settings, correlation_id) -> str | None` - environment-level gate for operations where the target table is unknown pre-fetch (e.g. attachment deletion must fetch metadata to learn the owning table).
 
-### Payload Size Cap
-The `data` parameter on `record_write` (used for both `create.data` and `update.changes`) is capped at `MAX_PAYLOAD_BYTES = 1 MiB`. The check runs in `_validate_action_args` before payload parsing, before preview-token creation - oversized payloads are rejected immediately. As defence in depth, `parse_payload_json` enforces a stricter 256 KiB inner cap downstream; the 1 MiB outer cap is the documented entry-point contract.
+The combined entry point `gate_write(table, settings, correlation_id)` chains `validate_identifier` then `check_table_access` then `write_gate` and never raises - it returns an error envelope string on any failure.
+
+**In production (`servicenow_env` equals `prod` or `production`), ALL writes are blocked regardless of table.** The `write_blocked_reason` function returns `"Write operations are blocked in production environments"` whenever `settings.is_production` is true, and this check fires after the denied-table check but applies universally.
+
+## Script-Path Hardening
+
+When `record_write` accepts a local file via `script_path`:
+
+1. `script_allowed_root` is resolved and confirmed as a directory before any user path is touched.
+2. The user path is resolved and must satisfy four conditions: it exists, it is a regular file, it resides within the allowed root, and it does not escape via symlinks.
+3. All four user-path rejections collapse to one opaque error: `"script_path is not readable or is outside the allowed root"`. This prevents path-existence probing.
+4. Configuration errors (root unset, root not accessible, root not a directory) and the size error remain verbose.
+5. Maximum file size: `MAX_SCRIPT_FILE_BYTES = 1_048_576` (1 MB).
+6. The outer payload cap `MAX_PAYLOAD_BYTES = 1 MiB` is enforced on the `data` parameter in `_validate_action_args` before any token creation; `parse_payload_json` enforces a tighter 256 KiB cap downstream as defence in depth.
+7. When the resolved target field has `internal_type == "xml"`, content is validated as well-formed XML via `xml.etree.ElementTree.fromstring` before the platform call. Malformed content yields a structured error.
+
+## Script-Field Discovery
+
+`DictionaryRegistry` resolves which fields on a table carry executable script or markup content. The algorithm:
+
+1. Walks `sys_db_object.super_class` child-first, bounded at depth 8, with a cycle guard.
+2. Fetches active `sys_dictionary` rows for each table in the chain.
+3. Admits a field when its `internal_type` is in `UNAMBIGUOUS_SCRIPT_TYPES`:
+
+```
+script, script_plain, script_server, script_client,
+email_script, html_script, html_template, css
+```
+
+4. For ambiguous types (`html`, `xml`), admits the field only when `_parse_attributes` yields an exact token-boundary match for `tinymce_allow_all=true` or `html_sanitize=false`. The parser splits on commas, partitions on the first `=`, and lowercases both sides. Substring matches like `my_tinymce_allow_all=true` do not admit.
+
+5. Drops anything in `EXCLUDED_ELEMENTS`:
+
+```
+translated_html, template_value, glide_var, json, conditions,
+condition_string, glide_action_list, variable_conditions,
+snapshot_template_value, variable_template_value
+```
+
+Exclusion takes precedence over type check.
+
+## What the Policy Layer Does NOT Do
+
+- It does not emulate ServiceNow's ACL engine. If the platform returns a field to the configured user, the server shows it (unless the field name matches a sensitive pattern).
+- It does not perform row-level filtering beyond denied tables. The platform's own ACLs remain the final authority on record visibility.
+- It does not inspect field values for secrets - masking operates on field names only (except the `sys_audit` value-masking path where the field name is stored indirectly).
+- It does not rate-limit requests. A caller can issue many queries in rapid succession.
+- It does not validate that the ServiceNow instance URL actually points to the environment declared in `SERVICENOW_ENV`. An operator who sets `dev` while targeting a production instance bypasses the production write gate.
 
 ---
 
-## Script Security
-
-When writing platform artifacts (e.g., Business Rules, Widgets, UI Pages, ACLs) using the `script_path` parameter in `record_write`:
-
-- **Root Validation First:** `script_allowed_root` is resolved and validated as an existing directory before any user-controlled path is touched.
-- **Opaque Errors:** All user-path rejections - file does not exist, not a regular file, outside root, symlink escape - return a single opaque message: `"script_path is not readable or is outside the allowed root"`. This closes the differential-error filesystem-enumeration channel.
-- **Verbose Configuration Errors:** Operator-facing errors (`script_allowed_root` unset or not a directory) and the >1 MiB file-size error remain verbose because the user does not control them.
-- **Limits:** Files are capped at 1 MB and must be UTF-8 encoded.
-- **Mapping:** Content is automatically routed to the first script-bearing field returned by `DictionaryRegistry.get_script_fields(table)` (resolved at runtime from `sys_dictionary`). Tables with multiple script fields (e.g. `sys_ui_policy.script_true`/`script_false`, `sp_widget.client_script`/`template`/`css`, `sys_ui_page.html`/`processing_script`) accept an optional `script_field` parameter to override the default target.
-- **XML Validation:** When the resolved field has `internal_type == 'xml'` (e.g. `sys_ui_macro.xml`), the file contents are parsed with `xml.etree.ElementTree.fromstring` before any platform call; malformed XML is rejected with a structured error.
-
----
-
-## Decompression Caps
-
-The Flow Designer `decode_values` action decompresses gzip+base64+JSON blobs. To prevent zip-bomb and resource-exhaustion attacks:
-
-- **Wire cap:** `MAX_COMPRESSED_BYTES = 1 MiB` - checked before allocating the decompressor.
-- **Output cap:** `MAX_DECOMPRESSED_BYTES = 4 MiB` - enforced during streaming decompression.
-- Truncated streams (incomplete gzip) and trailing garbage after the gzip footer are rejected.
-- All rejections raise `ValueError`, which `safe_tool_call` surfaces as a verbose error (see Error Handling below).
-
----
-
-## Error Handling
-
-The `@tool_handler` decorator ensures that exceptions are caught and returned as JSON error envelopes. The handler distinguishes verbose and opaque arms:
-
-- **Verbose arms:** `ACLError`, `ForbiddenError`, `ServiceNowMCPError`, and `ValueError` preserve their curated, caller-actionable messages in the error envelope. `ValueError` is the rejected-user-input signal raised by validators like `validate_identifier` and the decompression caps above.
-- **Opaque arm:** All other exceptions return `"Internal error (correlation_id=<uuid>)"`. Full exception detail is logged locally via `logger.exception` and captured to Sentry. The `correlation_id` in the envelope lets operators pivot to the detailed record.
-
-For more details on the implementation of these policies, see [[Architecture]].
+See also: [[Architecture]] for where policy checks fire in the request flow, [[Tool-Reference]] for per-tool write-gate behavior.

--- a/docs/wiki/Telemetry.md
+++ b/docs/wiki/Telemetry.md
@@ -1,206 +1,78 @@
 # Telemetry
 
-Observability documentation for the `servicenow-platform-mcp` server. Currently, **Sentry** is the sole observability integration.
+## What is instrumented - and what is not
 
-See also: [[Architecture]] for server internals, [[Development]] for setup.
+Sentry is the only telemetry channel. The server does not expose a metrics endpoint, does not emit Prometheus scrape targets, and does not integrate OpenTelemetry. When Sentry is not configured, every telemetry function is a no-op and nothing leaves the process.
 
-## Overview
+## Enabling Sentry
 
-MCP servers run as child processes of AI agents via stdio transport - the user never sees stdout or stderr. This makes traditional logging insufficient for error visibility. Sentry provides structured error capture, contextual data, and alerting for production deployments.
+Set the `SENTRY_DSN` environment variable to a valid Sentry project DSN. Optionally set `SENTRY_ENVIRONMENT` to override the environment tag (falls back to `SERVICENOW_ENV`). Leave `SENTRY_DSN` empty - the default - to disable entirely.
 
-> **Note:** OpenTelemetry was previously available but has been removed from the project. See [Historical Note](#historical-note) at the end of this page.
+When disabled the server logs `"Sentry disabled (no DSN configured)"` at debug level. If the `sentry-sdk` package is missing at runtime it logs `"Sentry disabled (sentry-sdk not installed)"` instead.
 
-## Sentry Integration
+See [[Configuration]] for the full settings table.
 
-The Sentry integration lives in `sentry.py` and follows a graceful-degradation pattern - all public functions are safe to call regardless of whether Sentry is active.
+## SDK defaults
 
-### Activation Requirements
-
-`sentry-sdk` is a **core dependency** (always installed, not an optional extra). However, Sentry only activates when the `SENTRY_DSN` environment variable is set to a non-empty value. There is no separate `SENTRY_ENABLED` flag - the DSN presence is the gate.
-
-## Configuration
-
-| Variable | Default | Purpose |
+| Setting | Value | Notes |
 |---|---|---|
-| `SENTRY_DSN` | `""` (disabled) | Sentry Data Source Name - activates error tracking when set |
-| `SENTRY_ENVIRONMENT` | Falls back to `SERVICENOW_ENV` | Environment label shown in Sentry UI |
+| `send_default_pii` | `False` | No cookies, IPs, or user data in breadcrumbs |
+| `traces_sample_rate` | `0.1` | 10% of transactions sampled for performance tracing |
 
-Both values are defined in the `Settings` class (`config.py`) and loaded from environment variables or `.env`/`.env.local` files.
+Both values are operator-tunable via standard Sentry SDK environment variables (e.g. `SENTRY_TRACES_SAMPLE_RATE`). The server does not override SDK-level env var configuration.
 
-## Import Guard Pattern
+## What gets captured
 
-The module uses a two-level import guard to handle environments where `sentry-sdk` might not be installed and SDK versions that may or may not include the MCP integration:
+Exceptions are captured by the opaque generic `Exception` arm of `safe_tool_call`. This arm fires for unclassified failures - `RuntimeError`, `OSError`, httpx transport errors, and anything else not covered by the four verbose arms. When it fires, the caller receives only `"Internal error (correlation_id=<uuid>)"`. The full detail is logged via `logger.exception` and sent to Sentry via `sentry_capture(e)`.
 
-```python
-# Primary guard
-HAS_SENTRY: bool
-try:
-    import sentry_sdk
-    HAS_SENTRY = True
-except ImportError:
-    HAS_SENTRY = False
+The four verbose arms (`ACLError`, `ForbiddenError`, `ServiceNowMCPError`, `ValueError`) also call `sentry_capture(e)` but return caller-actionable messages in the error envelope rather than an opaque string.
 
-# Secondary guard for newer SDK versions
-_HAS_MCP_INTEGRATION = False
-if HAS_SENTRY:
-    try:
-        from sentry_sdk.integrations.mcp import MCPIntegration
-        _HAS_MCP_INTEGRATION = True
-    except ImportError:
-        pass
+## Argument redaction
+
+Before attaching tool arguments to Sentry context, `@tool_handler` replaces values for keys in `_SENSITIVE_ARG_KEYS` with `"***REDACTED***"`. The full set (case-insensitive, exact-name match):
+
+```
+data, content_base64, value, script_path, encoded_query, params,
+password, token, secret, api_key, authorization, variables, conditions, text
 ```
 
-When `HAS_SENTRY` is `False`, all public functions no-op immediately - zero overhead. The secondary guard allows the optional `MCPIntegration` to be used when available in newer SDK versions without breaking on older ones.
+`correlation_id` is dropped from the args dict entirely - it is already promoted to a top-level context field.
 
-## SDK Configuration
+Redaction is shallow. JSON-shaped string arguments are replaced as a whole, not parsed and field-redacted. A `data` parameter containing a serialized record is replaced wholesale; nested keys inside that JSON are never inspected by this pass.
 
-When activated, Sentry is initialized with conservative defaults:
+## Tags and context
 
-```python
-sentry_sdk.init(
-    dsn=dsn,
-    environment=environment,
-    release=_RELEASE,            # e.g. "servicenow-platform-mcp@0.10.0"
-    send_default_pii=False,      # No PII in breadcrumbs, request bodies, etc.
-    integrations=integrations,   # Includes MCPIntegration when available
-    traces_sample_rate=0.1,      # 10% of transactions sampled
-    profiles_sample_rate=None,   # Profiling disabled
-)
-```
+Each tool invocation sets:
 
-`send_default_pii` is `False` so the SDK does not attach usernames, IP addresses, or request bodies to events. `traces_sample_rate` defaults to `0.1` (10%) to limit trace volume. Both values are operator-tunable via the standard Sentry SDK environment variables (`SENTRY_SEND_DEFAULT_PII`, `SENTRY_TRACES_SAMPLE_RATE`) without code changes.
+- **Tags**: `tool.name`, `tool.correlation_id` - indexed and searchable in Sentry.
+- **Structured context** (`tool`): `{name, correlation_id, args}` where `args` has sensitive keys redacted per the rules above.
 
-The release string is dynamically derived from package metadata using `importlib.metadata.version()`:
+Additionally:
 
-```python
-try:
-    _RELEASE = f"servicenow-platform-mcp@{pkg_version('servicenow-platform-mcp')}"
-except Exception:
-    _RELEASE = "servicenow-platform-mcp@unknown"
-```
+- **HTTP context** (set by `_raise_for_status` on error): `{status_code, method, url}` with query parameters stripped from the URL.
+- **Server context** (set once at boot): `{instance_url (hostname only), environment, is_production, tool_package}`.
 
-## Instrumentation Points
+## MCPIntegration conditional load
 
-Sentry context and exception capture is woven through the codebase at key points:
+If the installed Sentry SDK exposes `sentry_sdk.integrations.mcp.MCPIntegration`, it is included in the integrations list passed to `sentry_sdk.init`. Otherwise the integrations list is empty. No error is raised when the integration is absent - newer SDK versions add it; older ones skip it silently.
 
-### `@tool_handler` (decorators.py)
+## Operational concerns
 
-Every tool invocation sets:
+**Flush on shutdown.** `shutdown_sentry()` is called in the `finally` block of `main()`. It flushes pending events with a 2-second timeout and closes the client with a second 2-second timeout. Safe to call multiple times.
 
-- **Tags** (indexed, searchable):
-  - `tool.name` - The tool function name (e.g., `"query"`)
-  - `tool.correlation_id` - UUID4 for request tracing
-- **Context** (structured data):
-  - `"tool"` context with `name`, `correlation_id`, and `args`
-  - `correlation_id` is excluded from the `args` dict (it is already a top-level tag and context field)
+**Sampling tuning.** The default `traces_sample_rate=0.1` means 90% of performance transactions are dropped. For high-volume deployments this is appropriate. For low-volume development instances, set `SENTRY_TRACES_SAMPLE_RATE=1.0` to capture everything.
 
-### Argument Redaction
+**Idempotent init.** `setup_sentry` is idempotent - only the first call initializes the SDK. Subsequent calls return immediately.
 
-Before the `args` dict is attached to Sentry context, `_redact_args()` replaces the values of sensitive keys with the sentinel `_REDACTED` (`"***REDACTED***"`). Redaction is **shallow** - if a value is a JSON-shaped string, it is replaced as a whole rather than parsed and field-redacted.
+**Graceful degradation.** All public functions in `sentry.py` are safe to call when `sentry-sdk` is not importable. The module sets `HAS_SENTRY = False` and every function becomes a no-op.
 
-The 13 keys in `_SENSITIVE_ARG_KEYS` (matched case-insensitively by exact name):
+## What is NOT sent
 
-`data`, `content_base64`, `value`, `script_path`, `encoded_query`, `params`, `password`, `token`, `secret`, `api_key`, `authorization`, `variables`, `conditions`, `text`.
+- **Secrets.** `_SENSITIVE_ARG_KEYS` redaction removes tool arguments that could carry credentials before any Sentry context is attached.
+- **Denied-table values.** Policy enforcement (`check_table_access`) raises before any data is fetched from restricted tables; there is no path where denied-table content reaches a logging or telemetry call.
+- **Sensitive-field values.** Response masking (`mask_sensitive_fields`, `mask_audit_entry`) replaces field values with `***MASKED***` before the response envelope is built. Even if the envelope were inadvertently logged, masked values are all that remain.
+- **Default PII.** `send_default_pii=False` instructs the Sentry SDK to omit cookies, IP addresses, and user identifiers from breadcrumbs and event payloads.
 
-This ensures cleartext payloads, query strings, and credentials are never transmitted to a third-party observability service. Operators who need the full argument values can inspect the local server logs, where arguments are not redacted.
+---
 
-### `safe_tool_call()` (utils.py)
-
-The error boundary that wraps all tool executions. It distinguishes **verbose** arms - whose curated, caller-actionable messages are returned to the agent - from an **opaque** arm for unclassified failures:
-
-| Arm | What the agent sees |
-|---|---|
-| `ACLError` | Verbose: curated ACL denial message |
-| `ForbiddenError` | Verbose: curated forbidden message |
-| `ServiceNowMCPError` | Verbose: curated platform error message |
-| `ValueError` | Verbose: the rejected-input message from validators like `validate_identifier` |
-| Generic `Exception` | **Opaque:** `"Internal error (correlation_id=<uuid>)"` |
-
-For the generic arm, full exception detail is logged locally via `logger.exception` and captured to Sentry via `capture_exception(e)`. The agent receives only the opaque envelope and the `correlation_id`, which operators can use to pivot to logs or Sentry events.
-
-All arms call `capture_exception(e)` before returning the serialized error response.
-
-### `serialize()` (utils.py)
-
-Captures JSON serialization failures to Sentry before returning a JSON error envelope.
-
-### `_raise_for_status()` (client.py)
-
-Before raising HTTP-related exceptions, sets `"http"` Sentry context with:
-
-- `status_code` - The HTTP status code
-- `method` - The HTTP method (GET, POST, etc.)
-- `url` - The request URL
-
-### `ChoiceRegistry` (choices.py)
-
-Captures persistent `sys_choice` fetch failures when the registry cannot load choice data from the ServiceNow instance.
-
-### Server Bootstrap (server.py)
-
-- Sets `"server"` Sentry context with instance hostname (extracted from URL), environment, `is_production` flag, and tool package name
-- Captures `ImportError` exceptions when tool group modules fail to load
-
-## Public API
-
-| Function | Signature | Purpose |
-|---|---|---|
-| `setup_sentry` | `(settings: Settings) -> None` | Initialize SDK with DSN gating. No-ops on re-call. |
-| `capture_exception` | `(exc: BaseException \| None) -> None` | Capture exception (or current `sys.exc_info()` if `None`) |
-| `set_sentry_tag` | `(key: str, value: str) -> None` | Set indexed tag on current isolation scope |
-| `set_sentry_context` | `(key: str, data: dict[str, Any]) -> None` | Set structured context dict on current isolation scope |
-| `shutdown_sentry` | `() -> None` | Flush pending events (2s timeout) and close client (2s timeout) |
-
-All functions no-op when either `HAS_SENTRY` is `False` or `_initialized` is `False`.
-
-## Lifecycle
-
-### Startup
-
-`setup_sentry(settings)` is called early in `create_mcp_server()`, before tool registration. The function uses a triple gate to prevent double-initialization:
-
-1. **`_initialized` check** - Short-circuits if already called
-2. **`HAS_SENTRY` check** - Short-circuits if `sentry-sdk` is not installed (sets `_initialized = True`)
-3. **DSN check** - Short-circuits if `sentry_dsn` is empty (sets `_initialized = True`)
-
-In all three cases, `_initialized` is set to `True` so future calls no-op immediately.
-
-### Shutdown
-
-`shutdown_sentry()` is called in the `finally` block of `main()`:
-
-```python
-def main() -> None:
-    mcp = create_mcp_server()
-    try:
-        mcp.run(transport="stdio")
-    finally:
-        shutdown_sentry()
-```
-
-The shutdown sequence:
-
-1. Checks `HAS_SENTRY and _initialized`
-2. Gets the active Sentry client
-3. If the client is active: flushes pending events (2s timeout), then closes the client (2s timeout)
-4. Resets `_initialized = False`
-5. Wraps everything in try/except to prevent shutdown errors from propagating
-
-### Testing
-
-Tests use an autouse fixture (`_disable_sentry_capture` in `tests/conftest.py`) that resets `_initialized = False` before and after each test, preventing real Sentry SDK calls during test runs:
-
-```python
-@pytest.fixture(autouse=True)
-def _disable_sentry_capture():
-    import servicenow_mcp.sentry as _sentry_mod
-    _sentry_mod._initialized = False
-    yield
-    _sentry_mod._initialized = False
-```
-
-## Historical Note
-
-OpenTelemetry was previously integrated via a `telemetry.py` module that provided distributed tracing with spans for tool invocations and HTTP requests. It supported OTLP and console exporters, W3C `traceparent` header injection, and trace context in response envelopes.
-
-The OTel integration was **removed in v0.9.0** (commit `b72cee3`, PR [#68](https://github.com/Xerrion/servicenow-platform-mcp/pull/68)) to resolve SonarCloud issues and simplify the observability stack. The `.env.example` file may still contain stale OTel-related variables (`OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) - these are ignored by the server and have no effect.
+See also: [[Configuration]] for the env var table, [[Safety-and-Policy]] for field masking and denied-table policies, [[Architecture]] for the full request flow and `@tool_handler` contract.

--- a/docs/wiki/Telemetry.md
+++ b/docs/wiki/Telemetry.md
@@ -54,19 +54,21 @@ When `HAS_SENTRY` is `False`, all public functions no-op immediately - zero over
 
 ## SDK Configuration
 
-When activated, Sentry is initialized with these settings:
+When activated, Sentry is initialized with conservative defaults:
 
 ```python
 sentry_sdk.init(
     dsn=dsn,
     environment=environment,
-    release=_RELEASE,            # e.g. "servicenow-platform-mcp@0.9.0"
-    send_default_pii=True,
+    release=_RELEASE,            # e.g. "servicenow-platform-mcp@0.10.0"
+    send_default_pii=False,      # No PII in breadcrumbs, request bodies, etc.
     integrations=integrations,   # Includes MCPIntegration when available
-    traces_sample_rate=1.0,      # All transactions sampled
+    traces_sample_rate=0.1,      # 10% of transactions sampled
     profiles_sample_rate=None,   # Profiling disabled
 )
 ```
+
+`send_default_pii` is `False` so the SDK does not attach usernames, IP addresses, or request bodies to events. `traces_sample_rate` defaults to `0.1` (10%) to limit trace volume. Both values are operator-tunable via the standard Sentry SDK environment variables (`SENTRY_SEND_DEFAULT_PII`, `SENTRY_TRACES_SAMPLE_RATE`) without code changes.
 
 The release string is dynamically derived from package metadata using `importlib.metadata.version()`:
 
@@ -86,19 +88,37 @@ Sentry context and exception capture is woven through the codebase at key points
 Every tool invocation sets:
 
 - **Tags** (indexed, searchable):
-  - `tool.name` - The tool function name (e.g., `"record_list"`)
+  - `tool.name` - The tool function name (e.g., `"query"`)
   - `tool.correlation_id` - UUID4 for request tracing
 - **Context** (structured data):
-  - `"tool"` context with `name`, `correlation_id`, and `args` (with `correlation_id` excluded from the args dict)
+  - `"tool"` context with `name`, `correlation_id`, and `args`
+  - `correlation_id` is excluded from the `args` dict (it is already a top-level tag and context field)
+
+### Argument Redaction
+
+Before the `args` dict is attached to Sentry context, `_redact_args()` replaces the values of sensitive keys with the sentinel `_REDACTED` (`"***REDACTED***"`). Redaction is **shallow** - if a value is a JSON-shaped string, it is replaced as a whole rather than parsed and field-redacted.
+
+The 13 keys in `_SENSITIVE_ARG_KEYS` (matched case-insensitively by exact name):
+
+`data`, `content_base64`, `value`, `script_path`, `encoded_query`, `params`, `password`, `token`, `secret`, `api_key`, `authorization`, `variables`, `conditions`, `text`.
+
+This ensures cleartext payloads, query strings, and credentials are never transmitted to a third-party observability service. Operators who need the full argument values can inspect the local server logs, where arguments are not redacted.
 
 ### `safe_tool_call()` (utils.py)
 
-The error boundary that wraps all tool executions:
+The error boundary that wraps all tool executions. It distinguishes **verbose** arms - whose curated, caller-actionable messages are returned to the agent - from an **opaque** arm for unclassified failures:
 
-- Catches `ForbiddenError` - captures to Sentry, returns ACL denial error envelope
-- Catches generic `Exception` - captures to Sentry, returns generic error envelope
+| Arm | What the agent sees |
+|---|---|
+| `ACLError` | Verbose: curated ACL denial message |
+| `ForbiddenError` | Verbose: curated forbidden message |
+| `ServiceNowMCPError` | Verbose: curated platform error message |
+| `ValueError` | Verbose: the rejected-input message from validators like `validate_identifier` |
+| Generic `Exception` | **Opaque:** `"Internal error (correlation_id=<uuid>)"` |
 
-Both paths call `capture_exception(e)` before returning the serialized error response.
+For the generic arm, full exception detail is logged locally via `logger.exception` and captured to Sentry via `capture_exception(e)`. The agent receives only the opaque envelope and the `correlation_id`, which operators can use to pivot to logs or Sentry events.
+
+All arms call `capture_exception(e)` before returning the serialized error response.
 
 ### `serialize()` (utils.py)
 

--- a/docs/wiki/Tool-Packages.md
+++ b/docs/wiki/Tool-Packages.md
@@ -1,68 +1,87 @@
 # Tool Packages
 
-Tool packages control which tools are loaded when the server starts. Configure the active package via the `MCP_TOOL_PACKAGE` environment variable.
+`MCP_TOOL_PACKAGE` controls which tools the server exposes at startup. It defaults to `full`. The server must restart for changes to take effect.
 
-The server has been consolidated from 14 packages down to 4 focused presets. For a complete reference of every tool, see [[Tool-Reference]]. For security guardrails that apply across all packages, see [[Safety-and-Policy]].
+For the complete tool reference see [[Tool-Reference]]. For all environment variables see [[Configuration]].
 
----
+## Tool Counting Convention
+
+Every tool count in this document includes the always-on `list_tool_packages` tool. This tool is registered unconditionally - it is not part of any package - and returns the package registry so callers can discover the active surface without out-of-band knowledge.
 
 ## Preset Packages
 
-| Package | Tools | Description |
-|---|---|---|
-| `full` (default) | 13 | All unified tools, including `audit`, `flow`, and the `build_query` helper |
-| `readonly` | 9 | Includes `record_read`, `audit`, `flow`, and `attachment_write` (runtime write gating blocks in prod) |
-| `core_readonly` | 5 | Minimal read-only core: `query`, `describe`, `attachment`, `attachment_write`, `list_tool_packages` |
-| `none` | 1 | No tools loaded - only `list_tool_packages` is available |
+| Package | Groups | Tools | Description |
+|---------|--------|-------|-------------|
+| `full` | 11 | 14 | Complete read/write surface for development instances |
+| `readonly` | 8 | 10 | Read-focused; no `record_write`, `record_apply`, `build_query`, or `service_catalog` |
+| `core_readonly` | 3 | 5 | Minimal - query, describe, attachments |
+| `none` | 0 | 1 | Only `list_tool_packages`; useful for connectivity checks |
 
----
+## Full Tool List Per Preset
 
-## Package Contents
+### `full` - 14 tools
 
-The `list_tool_packages` tool is always available and returns the active registry at runtime. The `full` and `readonly` counts below refer to the package tool surface, not the always-on introspection tool.
+`list_tool_packages`, `query`, `build_query`, `describe`, `record_read`, `record_write`, `record_apply`, `attachment`, `attachment_write`, `investigate`, `resolve_choice`, `service_catalog`, `audit`, `flow`
 
-### `full` (13 tools)
+### `readonly` - 10 tools
 
-`query`, `build_query`, `describe`, `record_read`, `record_write`, `record_apply`, `attachment`, `attachment_write`, `investigate`, `resolve_choice`, `service_catalog`, `audit`, `flow`.
+`list_tool_packages`, `query`, `describe`, `record_read`, `attachment`, `attachment_write`, `investigate`, `resolve_choice`, `audit`, `flow`
 
-*Note: `build_query` is a stateless helper that returns an encoded query string for the caller to pass straight to `query`. It is the only tool that is exclusive to the `full` package - the read-only presets pass encoded queries to `query` directly.*
+### `core_readonly` - 5 tools
 
-### `readonly` (9 tools)
+`list_tool_packages`, `query`, `describe`, `attachment`, `attachment_write`
 
-`query`, `describe`, `record_read`, `attachment`, `attachment_write`, `investigate`, `resolve_choice`, `audit`, `flow`.
+### `none` - 1 tool
 
-*Note: While `attachment_write` is included at the MCP layer, the underlying `write_gate` check will block deletions and uploads if `SERVICENOW_ENV` is set to production.*
+`list_tool_packages`
 
-### `core_readonly` (5 tools)
+## Runtime-Gated Writes
 
-`query`, `describe`, `attachment`, `attachment_write`, `list_tool_packages`.
-
-*Note: `attachment_write` is included for symmetry; mutations are blocked in production via write gating.*
-
----
+The `readonly` and `core_readonly` presets load `attachment_write` because the `attachment` group registers both its read and write tools as a pair. Write operations (`upload`, `delete`) are blocked at runtime by `write_gate` when the environment is production or the target table is denied. In non-production environments, `attachment_write` remains functional even under the readonly presets.
 
 ## Custom Packages
 
-You can create a custom package by setting `MCP_TOOL_PACKAGE` to a comma-separated list of tool names:
+Set `MCP_TOOL_PACKAGE` to a comma-separated list of group names to compose a bespoke surface:
 
 ```bash
-MCP_TOOL_PACKAGE="query,describe,attachment"
+MCP_TOOL_PACKAGE=query,describe,audit
 ```
 
-### Migration from v0.9.x
+A single group name also works - `MCP_TOOL_PACKAGE=service_catalog` loads only that group (plus `list_tool_packages`).
 
-The previous specialized packages (`itil`, `developer`, `incident_management`, `change_management`, `cmdb`, `problem_management`, `request_management`, `knowledge_management`, `service_catalog`, `analyst`) have been removed.
+Valid group names: `query`, `build_query`, `describe`, `record_read`, `record_write`, `attachment`, `investigate`, `resolve_choice`, `service_catalog`, `audit`, `flow`.
 
-- If you were using **incident_management** or **itil**, use `full` or `readonly`.
-- If you were using **developer**, use `full`.
-- If you were using **service_catalog**, note that `service_catalog` is now a single tool name. You can load it specifically: `MCP_TOOL_PACKAGE="query,describe,service_catalog"`.
+If a token in the comma-separated list does not match a known group name, the server logs an `ImportError` and captures it via Sentry; the remaining groups still load.
 
-The unified tools (`query`, `record_write`) are more powerful than the previous domain-specific tools and can handle all ITSM and CMDB workflows when combined with `resolve_choice`.
+## Tool-Group to Tool Mapping
 
----
+Most groups register a single MCP tool with the same name as the group. Two groups register a pair:
 
-## Next Steps
+| Group | Tools registered |
+|-------|-----------------|
+| `query` | `query` |
+| `build_query` | `build_query` |
+| `describe` | `describe` |
+| `record_read` | `record_read` |
+| `record_write` | `record_write`, `record_apply` |
+| `attachment` | `attachment`, `attachment_write` |
+| `investigate` | `investigate` |
+| `resolve_choice` | `resolve_choice` |
+| `service_catalog` | `service_catalog` |
+| `audit` | `audit` |
+| `flow` | `flow` |
 
-- [[Tool-Reference]] - Complete tool reference with descriptions and parameters
-- [[Safety-and-Policy]] - Security guardrails and write gating
-- [Agent Recipes](../../docs/agent-recipes.md) - Learn how to compose these tools for complex workflows
+## Runtime Introspection
+
+Call `list_tool_packages` to see the registry. It returns group names per preset:
+
+```json
+{
+  "full": ["query", "build_query", "describe", "record_read", "record_write", "attachment", "investigate", "resolve_choice", "service_catalog", "audit", "flow"],
+  "readonly": ["query", "describe", "record_read", "attachment", "investigate", "resolve_choice", "audit", "flow"],
+  "core_readonly": ["query", "describe", "attachment"],
+  "none": []
+}
+```
+
+Use the group-to-tool mapping above to determine individual tool names from these group lists.

--- a/docs/wiki/Tool-Reference.md
+++ b/docs/wiki/Tool-Reference.md
@@ -1,271 +1,533 @@
 # Tool Reference
 
-Complete reference for all tools provided by the ServiceNow Platform MCP server. The surface has been unified into 13 core tools that use dispatcher patterns and ServiceNow encoded queries.
-
-All tools return responses as JSON strings with a standardized envelope containing `correlation_id`, `status`, `data`, and optionally `pagination` and `warnings`. See [[Architecture]] for details on the response format.
-
-For security guardrails that apply across all tools, see [[Safety-and-Policy]]. For worked examples of complex queries and multi-tool workflows, see [Agent Recipes](../../docs/agent-recipes.md).
+Canonical per-tool reference for all 14 MCP tools registered by the ServiceNow Platform MCP server. For package selection see [[Tool-Packages]]. For safety policy and write gating see [[Safety-and-Policy]].
 
 ---
 
-## Always-On Tool
+## Response Envelope
 
-The `list_tool_packages` tool is always available, regardless of which tool package is configured.
+All tools except `list_tool_packages` return a JSON string produced by `format_response`. The envelope shape:
 
-| Tool | Description | Key Parameters |
-|---|---|---|
-| `list_tool_packages` | List available tool packages and their contents | - |
+```json
+{
+  "correlation_id": "<uuid4>",
+  "status": "success" | "error",
+  "data": <any>,
+  "error": {"message": "<str>"},
+  "pagination": {"offset": 0, "limit": 20, "total": 42},
+  "warnings": ["..."]
+}
+```
 
----
+- `correlation_id` is injected by the `@tool_handler` decorator. It is not a caller parameter - do not pass it.
+- `error` is present only when `status` is `"error"`. A string error is wrapped as `{"message": "<str>"}`.
+- `pagination` and `warnings` are present only when applicable.
 
-## Introspection Tools
-
-### `query`
-Search and retrieve records from any table using ServiceNow encoded query strings.
-
-- **Purpose:** Primary tool for finding records, auditing history (`sys_audit`), or checking logs (`syslog`).
-- **Key Parameters:**
-  - `table`: Target table name (e.g., `incident`).
-  - `encoded_query`: ServiceNow query string (e.g., `active=true^priority=1`).
-  - `fields`: Comma-separated field names to return.
-  - `resolve_labels`: Optional label-to-value resolution (e.g., `state=open`).
-  - `display_values`: If `true`, returns human-readable labels in a `_display` object.
-  - `limit`, `offset`, `order_by`: Pagination and sorting.
-- **Example:**
-  ```python
-  await query(table="incident", encoded_query="active=true^priority=1", fields="number,short_description")
-  ```
-
-### `build_query`
-Stateless helper that compiles a JSON array of condition objects into a ServiceNow encoded query string. The result is returned in `data.query` for the caller to forward to `query`.
-
-- **Purpose:** Let agents express filters as structured JSON without learning the encoded-query mini-language. The tool touches no ServiceNow APIs; it is a pure transform.
-- **Availability:** `full` package only - readonly presets pass encoded queries to `query` directly.
-- **Key Parameters:**
-  - `conditions`: JSON-encoded array of condition objects. Each object carries an `operator`, a `field` (omitted for `new_query`), and operator-specific keys (`value`, `start`/`end`, `other_field`, `part`/`dp_operator`/`dp_value`, `related_table`/`related_field`/`rl_operator`, `descending`).
-- **Operator groups:**
-  - **Comparison:** `equals`, `not_equals`, `greater_than`, `greater_or_equal`, `less_than`, `less_or_equal`
-  - **String:** `contains`, `starts_with`, `like`, `ends_with`, `not_like`, `does_not_contain`
-  - **Null / special:** `is_empty`, `is_not_empty`, `anything`, `empty_string`
-  - **Time:** `hours_ago`, `minutes_ago`, `days_ago`, `older_than_days`
-  - **Date:** `on`, `not_on`, `relative_gt`, `relative_lt`, `more_than`
-  - **Date part:** `datepart`
-  - **Range:** `between`
-  - **Field comparison:** `gt_field`, `lt_field`, `gt_or_equals_field`, `lt_or_equals_field`, `same_as`, `not_same_as`
-  - **Reference:** `dynamic`, `in_hierarchy`
-  - **Change detection:** `val_changes`, `changes_from`, `changes_to`
-  - **Logical:** `new_query` (inserts `^NQ` separator)
-  - **Related list:** `rl_query`
-  - **List:** `in_list`, `not_in_list` (value is a list of strings)
-  - **OR:** `or_equals`, `or_starts_with`
-  - **Ordering:** `order_by` (optional `descending: true`)
-- **Example:**
-  ```python
-  built = await build_query(conditions=json.dumps([
-      {"operator": "equals",     "field": "active",         "value": "true"},
-      {"operator": "less_or_equal", "field": "priority",    "value": "2"},
-      {"operator": "hours_ago",  "field": "sys_created_on", "value": 24},
-      {"operator": "order_by",   "field": "sys_created_on", "descending": True},
-  ]))
-  # built["data"]["query"] -> "active=true^priority<=2^sys_created_on>=javascript:gs.hoursAgoStart(24)^ORDERBYDESCsys_created_on"
-  await query(table="incident", encoded_query=built["data"]["query"], fields="number,priority")
-  ```
-
-### `describe`
-Retrieve schema and metadata for a table, or enumerate its script-bearing fields.
-
-- **Purpose:** Understand a table's structure before querying or writing; discover dictionary-driven script fields at runtime.
-- **Key Parameters:**
-  - `action`: Optional. `describe_table` (default) or `list_script_fields`. When `list_script_fields`, returns the resolved super_class `chain` and the script-bearing fields (`name`, `internal_type`, `inherited_from`, `via_heuristic`) for the supplied `table`.
-  - `table`: Target table name (required for both actions).
-  - `verbose`: If `true`, returns all platform metadata (otherwise returns a slim 8-key summary per field).
-- **Example:**
-  ```python
-  await describe(table="incident")
-  await describe(action="list_script_fields", table="sys_script")
-  ```
+**Exception:** `list_tool_packages` is the only tool not wrapped by `@tool_handler`. It has no envelope, no `correlation_id`, and no error safety net.
 
 ---
 
-## Record Management
+## `list_tool_packages`
 
-The system uses a two-stage preview/apply flow for all record mutations.
+List all registered packages and the tool groups in each.
 
-### `record_write`
-Unified tool for staging `create`, `update`, or `delete` actions.
+**Packages:** always loaded (regardless of `MCP_TOOL_PACKAGE`).
 
-- **Purpose:** Perform mutations with built-in safety checks and preview flow.
-- **Key Parameters:**
-  - `action`: One of `create`, `update`, or `delete`.
-  - `table`: Target table name.
-  - `sys_id`: Required for `update` and `delete`.
-  - `data`: JSON string of field-value pairs for `create`/`update`. Capped at `MAX_PAYLOAD_BYTES = 1 MiB` (checked before parsing or token creation).
-  - `script_path`: Local path to a script file. Allowed on any table that has at least one script-bearing field (resolved via `DictionaryRegistry` from `sys_dictionary`). The `script_allowed_root` setting is resolved and validated as a directory before the user path is touched; all user-path rejections return a single opaque message: `"script_path is not readable or is outside the allowed root"`. Files are capped at 1 MB and must be UTF-8.
-  - `script_field`: Optional. Target a specific script-bearing field on tables with more than one (e.g. `sys_ui_policy.script_true`/`script_false`, `sp_widget.client_script`/`template`/`css`, `sys_ui_page.html`/`processing_script`). Defaults to the first field returned by `DictionaryRegistry.get_script_fields(table)`. Setting `script_field` without `script_path` is rejected.
-  - `preview`: If `true` (default), stores the change in `PreviewTokenStore` and returns a `preview_token`.
-- **Notes:** When the resolved script field has `internal_type == 'xml'` (e.g. `sys_ui_macro.xml`), `record_write` validates the rendered XML (`xml.etree.ElementTree.fromstring`) before any platform call; malformed content is rejected with a structured error.
-- **Example:**
-  ```python
-  # Stage a create
-  preview = await record_write(action="create", table="incident", data='{"short_description": "New issue"}')
-  # Returns: {"data": {"preview_token": "uuid-token-here", ...}}
-  ```
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| _(none)_ | - | - | - | Takes no parameters |
 
-### `record_read`
-Read-only counterpart to `record_write` for any table.
+Returns a raw JSON dump of the package registry - not the standard envelope.
 
-- **Purpose:** Inspect an existing record (and learn its script-bearing fields) before composing a multi-field update via `record_write` + `script_field`.
-- **Key Parameters:**
-  - `table`: Target table name.
-  - `sys_id` **or** `name`: Exactly one must be supplied. Ambiguous names (more than one match) and missing records return a structured error.
-- **Response:** Masked record fields plus the `script_fields` list resolved from `sys_dictionary` for the table.
-- **Availability:** Included in both the `full` and `readonly` packages.
-- **Example:**
-  ```python
-  await record_read(table="sys_script", name="Validate priority on insert")
-  ```
-
-### `record_apply`
-Commits a write operation previously staged with `record_write(preview=true)`.
-
-- **Purpose:** Finalize a mutation after inspecting the preview.
-- **Key Parameters:**
-  - `preview_token`: The token returned by `record_write`.
-- **Example:**
-  ```python
-  await record_apply(preview_token="uuid-token-here")
-  ```
+```json
+{"full": ["query","build_query","describe","record_read","record_write","attachment","investigate","resolve_choice","service_catalog","audit","flow"], "readonly": [...], "core_readonly": [...], "none": []}
+```
 
 ---
 
-## Specialized Dispatchers
+## `query`
 
-### `attachment`
-Unified dispatcher for reading and downloading record attachments.
+Read records, run aggregates, or fetch a single record from any ServiceNow table.
 
-- **Actions:**
-  - `list`: List metadata for all attachments on a record.
-  - `get`: Fetch metadata for a specific attachment by sys_id.
-  - `download`: Download attachment content as base64.
-- **Example:**
-  ```python
-  await attachment(action="list", table_name="incident", table_sys_id="...")
-  ```
+**Packages:** `full`, `readonly`, `core_readonly`.
 
-### `attachment_write`
-Dispatcher for attachment mutations. Included in all packages; blocked in production via write gating.
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `table` | str | yes | - | Table name |
+| `sys_id` | str | no | - | Fetch one record by sys_id |
+| `encoded_query` | str | no | - | ServiceNow encoded query string |
+| `fields` | str | no | - | Comma-separated field projection |
+| `limit` | int | no | `20` | Max rows (capped by `MAX_ROW_LIMIT`) |
+| `offset` | int | no | `0` | Pagination offset |
+| `order_by` | str | no | - | Field name; prefix `-` for descending |
+| `display_values` | bool | no | `False` | Return display values for reference/choice fields |
+| `aggregate` | str | no | - | Aggregation spec (e.g. `count,avg:duration`) |
+| `group_by` | str | no | - | Group aggregate results by field |
+| `resolve_labels` | str | no | - | `field=label` pairs resolved via ChoiceRegistry |
 
-- **Actions:**
-  - `upload`: Upload a base64-encoded file.
-  - `delete`: Delete an attachment by sys_id.
+**Modes:** Three mutually exclusive modes resolved before table validation:
 
-### `investigate`
-Runs pre-defined diagnostic and health check modules.
+1. **sys_id mode** - `sys_id` set: single-record fetch.
+2. **Aggregate mode** - `aggregate` set (with optional `group_by`): Stats API.
+3. **Query mode** - neither: paginated record list.
 
-- **Actions:**
-  - `run`: Execute a module (e.g., `stale_automations`, `table_health`).
-  - `explain`: Interpret a specific finding from a previous run.
-- **Modules:** `stale_automations`, `deprecated_apis`, `table_health`, `acl_conflicts`, `error_analysis`, `slow_transactions`, `performance_bottlenecks`.
+**Mutex rules** (each returns a validation error):
 
-### `audit`
+- `sys_id` + `aggregate`: `"Cannot combine sys_id with aggregate; sys_id mode fetches a single record."`
+- `sys_id` + `group_by`: `"Cannot combine sys_id with group_by; sys_id mode fetches a single record."`
+- `group_by` without `aggregate`: `"group_by requires aggregate to be set (aggregate mode only)."`
 
-Inspect ServiceNow field-level auditing posture and masked history.
+**Example:**
 
-- **Purpose:** Resolve whether a `(table, field)` pair is actually audited (walking `super_class` and `sys_dictionary`), survey a table's audit posture, and fetch a masked, date-bounded audit trail for one record.
-- **Availability:** Included in the `full` and `readonly` packages.
-- **Actions:**
-  - `check_field`: Resolve the combined audit verdict for one `(table, field)` pair. Returns the chain-walked dictionary flag, the `no_audit` attribute veto, the table-level flag, and a positive-control count from `sys_audit` within `window_days`.
-  - `check_fields`: Batch variant of `check_field`. Accepts `fields_csv` (max 50) and returns one verdict per field plus a single shared `table_change_count`.
-  - `check_table`: Table-level posture - the table default plus the list of fields whose resolved audit flag differs from that default.
-  - `history`: Masked, date-bounded audit trail for one record. Queries `sys_audit` by `tablename` + `documentkey` and masks sensitive fields via `mask_audit_entry`.
-  - `describe`: Return the action registry without platform I/O.
-- **Key Parameters:**
-  - `action`: One of `check_field`, `check_fields`, `check_table`, `history`, or `describe`.
-  - `table`: Target table name (required for all actions except `describe`).
-  - `field`: Field name (required for `check_field`).
-  - `fields_csv`: Comma-separated field names, max 50 (required for `check_fields`).
-  - `sys_id`: Document sys_id for `history`.
-  - `window_days`: Override the default 90-day window for `sys_audit` queries. Wider windows risk timeouts.
-  - `since`: Explicit ISO date floor for `history` (overrides `window_days`).
-- **Notes:** `sys_audit` is one of the largest tables on the platform; every action that touches it applies a default 90-day window. Responses include the `window_days` actually used and a `window_note` describing it. `no_audit=true` in the `attributes` blob vetoes the boolean `audit` column; the match is token-boundary-aware (comma-delimited) and tolerates trailing whitespace before end-of-string. The positive-control count distinguishes "no field activity in window" (`audited_but_inactive`) from "audit not configured" (`inconclusive`).
-- **Example:**
-
-  ```python
-  await audit(action="check_field", table="incident", field="state")
-  await audit(action="check_fields", table="incident", fields_csv="state,priority,assigned_to")
-  await audit(action="check_table", table="incident")
-  await audit(action="history", table="incident", sys_id="<sys_id>", window_days=30)
-  ```
-
-### `flow`
-
-Inspect ServiceNow Flow Designer artifacts from documented Table API records.
-
-- **Purpose:** Read Flow Designer flows and subflows, including triggers, declared inputs/outputs/variables, decoded V2 action and logic configuration, canvas structure, and published snapshot drift.
-- **Availability:** Included in the `full` and `readonly` packages. Custom packages can include it with `MCP_TOOL_PACKAGE=flow,query,describe`.
-- **Actions:**
-  - `inspect`: Assemble one flow/subflow. Requires exactly one of `sys_id` or `name`.
-  - `find_by_table`: Find flows with a record trigger on `table`.
-  - `decode_values`: Decode a gzip+base64+JSON `values` blob from a `sys_hub_*_v2` row. Requires `value`. Compressed input is capped at `MAX_COMPRESSED_BYTES = 1 MiB`; decompressed output is capped at `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected.
-  - `list_triggers`: List record triggers across flows. Optional filters: `table`, `trigger_type`, `active` (`true`/`false`), `limit`.
-  - `describe`: Return the action registry with names, descriptions, and parameters.
-- **Key Parameters:**
-  - `action`: One of `inspect`, `find_by_table`, `decode_values`, `list_triggers`, or `describe`.
-  - `sys_id`: 32-character flow sys_id for `inspect`; mutually exclusive with `name`.
-  - `name`: Flow name or `internal_name` for `inspect`; must resolve to exactly one flow.
-  - `table`: Target record table for `find_by_table`; optional filter for `list_triggers`.
-  - `trigger_type`: Optional trigger filter for `list_triggers`, such as `record_update`.
-  - `active`: Optional `true`/`false` filter for `list_triggers`.
-  - `value`: Raw compressed `values` field content for `decode_values`. Must not exceed 1 MiB compressed.
-  - `limit`: Optional page size for `list_triggers`; defaults to 100 when omitted or `0`.
-- **Examples:**
-  ```python
-  await flow(action="inspect", sys_id="9e858befc3340f105cf89fcd2b01317d")
-  await flow(action="inspect", name="My Flow")
-  await flow(action="find_by_table", table="incident")
-  await flow(action="decode_values", value="H4sIA...")
-  await flow(action="list_triggers", trigger_type="record_update", active="true", limit=50)
-  await flow(action="describe")
-  ```
-- **`inspect` response highlights:** `data` contains `header`, `triggers`, `inputs`, `outputs`, `variables`, `canvas`, `published_state`, `v1_count`, `v2_count`, `v1_logic_count`, and `v1_variable_values`.
-  - `header`: Flow metadata (`sys_id`, `name`, `internal_name`, `type`, `active`, `description`, `sys_scope`).
-  - `published_state`: `{master_snapshot, latest_snapshot, drift}`. `drift` is `true` when the published snapshot differs from the latest authored snapshot.
-  - `canvas`: Nested V2 tree. Root nodes have an empty `parent_ui_id`; children are sorted by `order`. Each node includes `kind` (`action` or `logic`), `ui_id`, `parent_ui_id`, `order`, `decoded_values`, and recursive `children`.
-  - `warnings`: Returned in the standard response envelope for mixed V1/V2 flows, snapshot drift, IntegrationHub spoke heuristics, or V1 logic that cannot be woven into the V2 canvas tree.
-- **Notes:** The tool reads both V1 (`sys_hub_action_instance`, `sys_hub_flow_logic`, `sys_hub_trigger_instance`) and V2 (`sys_hub_action_instance_v2`, `sys_hub_flow_logic_instance_v2`, `sys_hub_trigger_instance_v2`) records. Record-trigger conditions are joined through `sys_flow_record_trigger`. It does not use the undocumented `/api/now/processflow/flow/{sys_id}` endpoint or the opaque `sys_hub_flow_snapshot` compiled cache. A bad per-node `values` blob adds `decode_error` to that node; the rest of `inspect` still succeeds. Decompression is bounded at 1 MiB compressed / 4 MiB decompressed; truncated streams and trailing garbage are rejected with a `ValueError`.
-
-### `resolve_choice`
-Resolves human-readable labels to underlying ServiceNow values using the `sys_choice` table.
-
-- **Key Parameters:**
-  - `table`: Table name.
-  - `field`: Field name.
-  - `label`: Human label (e.g., "In Progress"). If omitted, returns all choices for the field.
-- **Example:**
-  ```python
-  await resolve_choice(table="incident", field="state", label="New")
-  ```
-
-### `service_catalog`
-Unified dispatcher for Service Catalog operations.
-
-- **Actions:** `list_catalogs`, `get_catalog`, `list_categories`, `get_category`, `list_items`, `get_item`, `get_variables`, `order_now`, `add_to_cart`, `get_cart`, `submit_cart`, `checkout`.
-- **Example:**
-  ```python
-  await service_catalog(action="list_items", text="laptop")
-  ```
+```json
+{"table": "incident", "encoded_query": "priority=1^state=2", "limit": 5, "order_by": "-sys_created_on"}
+```
 
 ---
 
-## Migration Note
+## `describe`
 
-The following specialized tool families from v0.9.x have been **deleted** and replaced by the unified tools above:
-- ATF tools (Deleted entirely)
-- Specialized domain tools (`incident_*`, `change_*`, etc. — Use `query`, `record_write`, and `resolve_choice`)
-- Change Intelligence and Debug families (`changes_*`, `debug_*` — Use `query` against system tables like `sys_update_xml` or `syslog`)
-- Documentation and Workflow families (`docs_*`, `workflow_*`, legacy `flow_*` - Use `flow` for Flow Designer inspection, or `query`/`describe` against platform tables)
-- `artifact_create`/`artifact_update` (Folded into `record_write`)
+Return field metadata for a table, or list its script-bearing fields.
 
-`build_query` is retained from v0.9.x but reshaped to be stateless and scoped to the `full` package. The `QueryTokenStore` is gone - `build_query` returns the encoded query string directly in `data.query` for the caller to forward to `query`. Agents may also bypass `build_query` entirely and pass encoded queries to `query` directly.
+**Packages:** `full`, `readonly`, `core_readonly`.
 
-For detailed mapping of old workflows to new tools, see [Agent Recipes](../../docs/agent-recipes.md).
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `table` | str | yes | - | Table name |
+| `fields` | str | no | - | Comma-separated field filter (bare mode only) |
+| `verbose` | bool | no | `False` | Full sys_dictionary rows minus noise fields |
+| `include_docs` | bool | no | `False` | Attach sys_documentation entries |
+| `action` | str | no | `""` | Only valid value: `"list_script_fields"` |
+
+**Bare mode** (default, `action` omitted or empty) is the standard field-metadata flow. It requires `table`. Returns `data.fields` (slim field metadata list), `data.field_count`, and optional `data.documentation`. Error when `table` is missing: `"table is required when action is not set."`.
+
+**`action="list_script_fields"`** walks the `super_class` chain and returns script-bearing fields with inheritance info. Returns `data.script_fields` and `data.chain`.
+
+**Unknown action error:** `"Unknown describe action '<value>'. Valid actions: ['list_script_fields']."`
+
+Common mistake: callers pass `action="fields"` or `action="table"` expecting field metadata. Both are wrong. To get field metadata, omit `action` entirely.
+
+**Example:**
+
+```json
+{"table": "sys_script", "action": "list_script_fields"}
+```
+
+---
+
+## `record_read`
+
+Fetch a single record by sys_id or name, with script-field discovery.
+
+**Packages:** `full`, `readonly`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `table` | str | yes | - | Table name |
+| `sys_id` | str | no | - | Record sys_id |
+| `name` | str | no | - | Resolve via `name=<value>` query |
+
+**Cross-parameter constraints:** Exactly one of `sys_id` or `name` must be supplied.
+
+- Both: `"Provide exactly one of sys_id or name, not both."`
+- Neither: `"Provide exactly one of sys_id or name."`
+- Ambiguous name: `"Ambiguous name='<value>' on table '<table>': multiple records match."`
+- Not found: `"No record found with name='<value>' on table '<table>'."`
+
+**Returns:** `data.record` (masked), `data.script_fields` (list from DictionaryRegistry).
+
+**Example:**
+
+```json
+{"table": "sys_script_include", "name": "TableUtils"}
+```
+
+---
+
+## `record_write`
+
+Create, update, or delete a record. **Default is `preview=True`** - the call validates and stores the payload, returning a single-use token. Direct commit requires `preview=False`.
+
+**Packages:** `full`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | `create`, `update`, or `delete` |
+| `table` | str | yes | - | Target table |
+| `sys_id` | str | update/delete | - | Record sys_id |
+| `data` | str | create/update | - | JSON string of field values (max 1 MiB) |
+| `script_path` | str | no | - | Absolute path to a local script file (max 1 MB, UTF-8) |
+| `script_field` | str | no | - | Override target field for script_path content |
+| `preview` | bool | no | `True` | When true, returns a preview token instead of committing |
+
+**Per-action requirements:**
+
+| Action | Required | Forbidden |
+|--------|----------|-----------|
+| `create` | `table`, `data` | `sys_id` |
+| `update` | `table`, `sys_id`, `data` | - |
+| `delete` | `table`, `sys_id` | `data` |
+
+**Cross-parameter constraints:**
+
+- `script_field` without `script_path`: `"script_field requires script_path to be set."`
+- `data` exceeds 1 MiB: `"payload exceeds maximum allowed size of 1 MiB"`
+- Unknown action: `"Unknown action '<value>'. Valid actions: ['create', 'delete', 'update']."`
+
+**Preview flow:** Response includes `data.preview_token` (TTL 300s, single-use). Pass it to `record_apply` to commit. Updates include a diff of old vs. new values.
+
+**Script path errors:**
+
+- Opaque rejection (not found, outside root, symlink, not regular file): `"script_path is not readable or is outside the allowed root"`
+- Config missing: `"script_allowed_root must be configured when using script_path"`
+- XML validation failure: `"XML content is not well-formed: <detail>"`
+
+**Example:**
+
+```json
+{"action": "update", "table": "sys_script_include", "sys_id": "abc123...", "data": "{\"active\": \"true\"}", "preview": false}
+```
+
+---
+
+## `record_apply`
+
+Commit a previously previewed write operation.
+
+**Packages:** `full`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `preview_token` | str | yes | - | Token from `record_write` preview response |
+
+The parameter is `preview_token`, not `token`.
+
+**Notable errors:**
+
+- Invalid or expired: `"Invalid or expired preview token"`
+- Unknown payload action: `"Unknown preview action: '<action>'"`
+
+Re-runs `check_table_access` and `write_gate` as defense in depth before committing.
+
+**Example:**
+
+```json
+{"preview_token": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
+```
+
+---
+
+## `attachment`
+
+Read attachment metadata and content. This is the read-only half; writes use `attachment_write`.
+
+**Packages:** `full`, `readonly`, `core_readonly`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | `list`, `get`, `download`, or `download_by_name` |
+| `sys_id` | str | get/download | - | Attachment sys_id |
+| `table` | str | list/download_by_name | - | Parent table name |
+| `table_sys_id` | str | list/download_by_name | - | Parent record sys_id |
+| `file_name` | str | download_by_name | - | Attachment file name |
+
+**Per-action requirements:**
+
+| Action | Required params | Purpose |
+|--------|----------------|---------|
+| `list` | `table`, `table_sys_id` | List attachments for a parent record |
+| `get` | `sys_id` | Get metadata for one attachment |
+| `download` | `sys_id` | Download content (base64 in `data.content_base64`) |
+| `download_by_name` | `table`, `table_sys_id`, `file_name` | Resolve by name then download |
+
+**Notable errors:**
+
+- Unknown action: `"Unknown action '<value>'. Valid actions: ['download', 'download_by_name', 'get', 'list']."`
+- Not found (download_by_name): `"Attachment '<file_name>' was not found for table '<table>' and record '<table_sys_id>'"`
+
+**Example:**
+
+```json
+{"action": "download", "sys_id": "abc123def456..."}
+```
+
+---
+
+## `attachment_write`
+
+Upload or delete attachments. Disjoint action enum from `attachment` (read). Write-gated in production.
+
+**Packages:** `full`, `readonly`, `core_readonly` (write actions blocked at runtime by `write_gate` in production).
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | `upload` or `delete` |
+| `table` | str | upload | - | Parent table name |
+| `table_sys_id` | str | upload | - | Parent record sys_id |
+| `file_name` | str | upload | - | File name for the attachment |
+| `content_base64` | str | upload | - | Base64-encoded file content |
+| `content_type` | str | no | `"application/octet-stream"` | MIME type |
+| `sys_id` | str | delete | - | Attachment sys_id to delete |
+
+**Per-action requirements:**
+
+| Action | Required params | Purpose |
+|--------|----------------|---------|
+| `upload` | `table`, `table_sys_id`, `file_name`, `content_base64` | Attach file to a record (max 10 MB decoded) |
+| `delete` | `sys_id` | Delete an attachment |
+
+**Notable errors:**
+
+- Size exceeded: `"Attachment <operation> size <N> bytes exceeds the maximum supported size of 10485760 bytes"`
+- Bad base64: `"Invalid base64 content"`
+
+**Example:**
+
+```json
+{"action": "upload", "table": "incident", "table_sys_id": "abc123...", "file_name": "notes.txt", "content_base64": "SGVsbG8gV29ybGQ="}
+```
+
+---
+
+## `investigate`
+
+Run predefined investigation playbooks, explain findings, or discover available investigations.
+
+**Packages:** `full`, `readonly`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | `run`, `explain`, or `describe` |
+| `name` | str | run/describe | - | Investigation name |
+| `params` | str | no | `"{}"` | JSON string of run parameters |
+| `element_id` | str | explain | - | `table:sys_id` identifier of a finding |
+
+The investigation identifier parameter is `name`, not `investigation`.
+
+**Per-action requirements:**
+
+| Action | Required params | Purpose |
+|--------|----------------|---------|
+| `run` | `name` | Execute a named investigation |
+| `explain` | `element_id` | Explain a finding (trial-dispatches across all modules) |
+| `describe` | _(optional `name`)_ | List all investigations, or describe one by name |
+
+**Available investigations:** `acl_conflicts`, `deprecated_apis`, `error_analysis`, `performance_bottlenecks`, `slow_transactions`, `stale_automations`, `table_health`.
+
+**Notable errors:**
+
+- Unknown action: `"Unknown action '<value>'. Expected one of: ['describe', 'explain', 'run']."`
+- Unknown investigation: `"Unknown investigation '<name>'. Available: <comma-separated list>"`
+- Bad element_id: `"element_id must be in 'table:sys_id' format"`
+
+**Example:**
+
+```json
+{"action": "run", "name": "stale_automations", "params": "{\"stale_days\": 60, \"limit\": 10}"}
+```
+
+---
+
+## `resolve_choice`
+
+Map a human-readable choice label to its platform value, or list all choices for a field.
+
+**Packages:** `full`, `readonly`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `table` | str | yes | - | Table name |
+| `field` | str | yes | - | Field name |
+| `label` | str | no | `""` | Label to resolve; empty returns the full mapping |
+
+When `label` is empty, returns `data.choices` (full `{label: value}` map). When set, returns `data.value`.
+
+**Notable errors:**
+
+- Registry unavailable: `"ChoiceRegistry not configured."`
+- Unresolved warning: `"resolve_choice: '<field>=<label>' did not resolve via ChoiceRegistry; returning the label verbatim as the value."`
+
+**Example:**
+
+```json
+{"table": "incident", "field": "state", "label": "in_progress"}
+```
+
+---
+
+## `service_catalog`
+
+Service Catalog operations - browse catalogs, items, and place orders.
+
+**Packages:** `full`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | See action table below |
+| `sys_id` | str | varies | - | Catalog/category/item sys_id |
+| `item_sys_id` | str | order_now/add_to_cart | - | Item to order |
+| `catalog_sys_id` | str | categories_list | - | Parent catalog |
+| `catalog` | str | no | - | Filter items_list by catalog |
+| `category` | str | no | - | Filter items_list by category |
+| `text` | str | no | - | Search text |
+| `variables` | str | no | - | JSON object of form variables |
+| `limit` | int | no | `20` | Max results |
+| `offset` | int | no | `0` | Pagination offset |
+| `top_level_only` | bool | no | `False` | Top-level categories only |
+
+**Actions:**
+
+| Action | Required params | Write-gated |
+|--------|----------------|-------------|
+| `catalogs_list` | - | no |
+| `catalog_get` | `sys_id` | no |
+| `categories_list` | `catalog_sys_id` | no |
+| `category_get` | `sys_id` | no |
+| `items_list` | - | no |
+| `item_get` | `sys_id` | no |
+| `item_variables` | `sys_id` | no |
+| `order_now` | `item_sys_id` | yes (`sc_req_item`) |
+| `add_to_cart` | `item_sys_id` | yes (`sc_cart_item`) |
+| `cart_get` | - | no |
+| `cart_submit` | - | yes (`sc_request`) |
+| `cart_checkout` | - | yes (`sc_request`) |
+
+**Notable errors:**
+
+- Unknown action: `"Unknown action '<value>'. Valid actions: [<sorted list>]."`
+
+**Example:**
+
+```json
+{"action": "item_get", "sys_id": "abc123def456..."}
+```
+
+---
+
+## `build_query`
+
+Stateless helper that builds a ServiceNow encoded query string from structured conditions. Pass the result to `query`.
+
+**Packages:** `full` only.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `conditions` | str | yes | - | JSON array of condition objects (max 256 KiB) |
+
+Each condition object requires `operator` (str) and `field` (str, except for `new_query`). Additional keys vary by operator family.
+
+**Operator families:**
+
+- Unary: `is_empty`, `is_not_empty`, `anything`, `empty_string`, `val_changes`
+- Binary: `equals`, `not_equals`, `greater_than`, `contains`, `starts_with`, `like`, etc.
+- Time: `hours_ago`, `minutes_ago`, `days_ago`, `older_than_days`
+- List: `in_list`, `not_in_list`
+- Field comparison: `gt_field`, `lt_field`, `same_as`, `not_same_as`, etc.
+- OR: `or_equals`, `or_starts_with`
+- Special: `between`, `datepart`, `new_query`, `rl_query`, `order_by`
+
+**Notable errors:**
+
+- Size exceeded: `"conditions exceeds maximum size of 262144 bytes"`
+- Bad JSON: `"Invalid JSON: <detail>"`
+- Not array: `"conditions must be a JSON array"`
+- Bad element: `"conditions[<idx>] must be a JSON object, got <type>"`
+
+**Returns:** `data.query` - the encoded query string.
+
+**Example:**
+
+```json
+{"conditions": "[{\"operator\": \"equals\", \"field\": \"priority\", \"value\": \"1\"}, {\"operator\": \"order_by\", \"field\": \"sys_created_on\", \"descending\": true}]"}
+```
+
+---
+
+## `audit`
+
+Inspect audit configuration and retrieve audit trail history. Read-only.
+
+**Packages:** `full`, `readonly`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | `check_field`, `check_fields`, `check_table`, `history`, or `describe` |
+| `table` | str | most actions | - | Table name |
+| `field` | str | check_field | - | Field name |
+| `fields_csv` | str | check_fields | - | Comma-separated fields (max 50) |
+| `sys_id` | str | history | - | Record sys_id |
+| `since` | str | no | - | `YYYY-MM-DD` cutoff (overrides window_days) |
+| `window_days` | int | no | `0` (uses default 90) | Audit window in days |
+| `limit` | int | no | `0` (uses max_row_limit) | Row cap for history |
+
+**Per-action requirements:**
+
+| Action | Required params | Purpose |
+|--------|----------------|---------|
+| `check_field` | `table`, `field` | Resolve audit verdict for one (table, field) pair |
+| `check_fields` | `table`, `fields_csv` | Batch verdict (max 50 fields per call) |
+| `check_table` | `table` | Table-level posture + field overrides |
+| `history` | `table`, `sys_id` | Masked audit trail (date-bounded) |
+| `describe` | - | Return action registry |
+
+**Verdict values:** `audited`, `not_audited_field_flag`, `not_audited_table_flag`, `audited_but_inactive`, `inconclusive`.
+
+**Notable errors:**
+
+- Empty fields_csv: `"fields_csv must list at least one field."`
+- Too many fields: `"At most 50 fields per check_fields call (got <N>)."`
+
+`sys_audit` is one of the largest platform tables. The default 90-day window exists for performance - widen with care.
+
+**Example:**
+
+```json
+{"action": "check_field", "table": "incident", "field": "state"}
+```
+
+---
+
+## `flow`
+
+Read-only Flow Designer inspection.
+
+**Packages:** `full`, `readonly`.
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | str | yes | - | `inspect`, `find_by_table`, `decode_values`, `list_triggers`, or `describe` |
+| `sys_id` | str | inspect | - | Flow sys_id (mutually exclusive with `name`) |
+| `name` | str | inspect | - | Flow name (mutually exclusive with `sys_id`) |
+| `value` | str | decode_values | - | gzip+base64+JSON blob to decode |
+| `table` | str | find_by_table | - | Target table |
+| `trigger_type` | str | no | - | Filter for list_triggers |
+| `active` | str | no | - | Must be `""`, `"true"`, or `"false"` |
+| `limit` | int | no | `0` (default 100) | Row cap for list_triggers |
+
+**Per-action requirements:**
+
+| Action | Required params | Purpose |
+|--------|----------------|---------|
+| `inspect` | exactly one of `sys_id` or `name` | Full flow assembly: header, triggers, I/O, canvas tree, snapshot drift |
+| `find_by_table` | `table` | Find flows with record triggers on a table |
+| `decode_values` | `value` | Stateless decode of a V2 values blob |
+| `list_triggers` | _(all optional)_ | List V1+V2 triggers with optional filters |
+| `describe` | - | Return action registry |
+
+**`active` parameter constraint:** Must be `""`, `"true"`, or `"false"`. Any other value: `"'active' must be 'true', 'false', or '' (got '<value>')."`
+
+**Notable errors (inspect):**
+
+- Both sys_id and name: `"Provide exactly one of sys_id or name (not both)."`
+- Neither: `"Either sys_id or name is required."`
+- Name ambiguous: `"Name '<name>' is ambiguous (<N> flows match); pass sys_id instead."`
+- Not found by name: `"No flow found with name '<name>'."`
+- Not found by sys_id: `"Flow <sys_id> not found."`
+
+**Deliberately excluded:** `/api/now/processflow/*` endpoints (undocumented) and `sys_hub_flow_snapshot` (opaque compiled cache).
+
+**Example:**
+
+```json
+{"action": "inspect", "name": "My Incident Flow"}
+```

--- a/docs/wiki/Tool-Reference.md
+++ b/docs/wiki/Tool-Reference.md
@@ -99,8 +99,8 @@ Unified tool for staging `create`, `update`, or `delete` actions.
   - `action`: One of `create`, `update`, or `delete`.
   - `table`: Target table name.
   - `sys_id`: Required for `update` and `delete`.
-  - `data`: JSON string of field-value pairs for `create`/`update`.
-  - `script_path`: Local path to a script file. Allowed on any table that has at least one script-bearing field (resolved via `DictionaryRegistry` from `sys_dictionary`). Resolved strictly under `SCRIPT_ALLOWED_ROOT`; capped at 1 MB; UTF-8.
+  - `data`: JSON string of field-value pairs for `create`/`update`. Capped at `MAX_PAYLOAD_BYTES = 1 MiB` (checked before parsing or token creation).
+  - `script_path`: Local path to a script file. Allowed on any table that has at least one script-bearing field (resolved via `DictionaryRegistry` from `sys_dictionary`). The `script_allowed_root` setting is resolved and validated as a directory before the user path is touched; all user-path rejections return a single opaque message: `"script_path is not readable or is outside the allowed root"`. Files are capped at 1 MB and must be UTF-8.
   - `script_field`: Optional. Target a specific script-bearing field on tables with more than one (e.g. `sys_ui_policy.script_true`/`script_false`, `sp_widget.client_script`/`template`/`css`, `sys_ui_page.html`/`processing_script`). Defaults to the first field returned by `DictionaryRegistry.get_script_fields(table)`. Setting `script_field` without `script_path` is rejected.
   - `preview`: If `true` (default), stores the change in `PreviewTokenStore` and returns a `preview_token`.
 - **Notes:** When the resolved script field has `internal_type == 'xml'` (e.g. `sys_ui_macro.xml`), `record_write` validates the rendered XML (`xml.etree.ElementTree.fromstring`) before any platform call; malformed content is rejected with a structured error.
@@ -187,7 +187,7 @@ Inspect ServiceNow field-level auditing posture and masked history.
   - `sys_id`: Document sys_id for `history`.
   - `window_days`: Override the default 90-day window for `sys_audit` queries. Wider windows risk timeouts.
   - `since`: Explicit ISO date floor for `history` (overrides `window_days`).
-- **Notes:** `sys_audit` is one of the largest tables on the platform; every action that touches it applies a default 90-day window. Responses include the `window_days` actually used and a `window_note` describing it. `no_audit=true` in the `attributes` blob vetoes the boolean `audit` column. The positive-control count distinguishes "no field activity in window" (`audited_but_inactive`) from "audit not configured" (`inconclusive`).
+- **Notes:** `sys_audit` is one of the largest tables on the platform; every action that touches it applies a default 90-day window. Responses include the `window_days` actually used and a `window_note` describing it. `no_audit=true` in the `attributes` blob vetoes the boolean `audit` column; the match is token-boundary-aware (comma-delimited) and tolerates trailing whitespace before end-of-string. The positive-control count distinguishes "no field activity in window" (`audited_but_inactive`) from "audit not configured" (`inconclusive`).
 - **Example:**
 
   ```python
@@ -206,7 +206,7 @@ Inspect ServiceNow Flow Designer artifacts from documented Table API records.
 - **Actions:**
   - `inspect`: Assemble one flow/subflow. Requires exactly one of `sys_id` or `name`.
   - `find_by_table`: Find flows with a record trigger on `table`.
-  - `decode_values`: Decode a gzip+base64+JSON `values` blob from a `sys_hub_*_v2` row. Requires `value`.
+  - `decode_values`: Decode a gzip+base64+JSON `values` blob from a `sys_hub_*_v2` row. Requires `value`. Compressed input is capped at `MAX_COMPRESSED_BYTES = 1 MiB`; decompressed output is capped at `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected.
   - `list_triggers`: List record triggers across flows. Optional filters: `table`, `trigger_type`, `active` (`true`/`false`), `limit`.
   - `describe`: Return the action registry with names, descriptions, and parameters.
 - **Key Parameters:**
@@ -216,7 +216,7 @@ Inspect ServiceNow Flow Designer artifacts from documented Table API records.
   - `table`: Target record table for `find_by_table`; optional filter for `list_triggers`.
   - `trigger_type`: Optional trigger filter for `list_triggers`, such as `record_update`.
   - `active`: Optional `true`/`false` filter for `list_triggers`.
-  - `value`: Raw compressed `values` field content for `decode_values`.
+  - `value`: Raw compressed `values` field content for `decode_values`. Must not exceed 1 MiB compressed.
   - `limit`: Optional page size for `list_triggers`; defaults to 100 when omitted or `0`.
 - **Examples:**
   ```python
@@ -232,7 +232,7 @@ Inspect ServiceNow Flow Designer artifacts from documented Table API records.
   - `published_state`: `{master_snapshot, latest_snapshot, drift}`. `drift` is `true` when the published snapshot differs from the latest authored snapshot.
   - `canvas`: Nested V2 tree. Root nodes have an empty `parent_ui_id`; children are sorted by `order`. Each node includes `kind` (`action` or `logic`), `ui_id`, `parent_ui_id`, `order`, `decoded_values`, and recursive `children`.
   - `warnings`: Returned in the standard response envelope for mixed V1/V2 flows, snapshot drift, IntegrationHub spoke heuristics, or V1 logic that cannot be woven into the V2 canvas tree.
-- **Notes:** The tool reads both V1 (`sys_hub_action_instance`, `sys_hub_flow_logic`, `sys_hub_trigger_instance`) and V2 (`sys_hub_action_instance_v2`, `sys_hub_flow_logic_instance_v2`, `sys_hub_trigger_instance_v2`) records. Record-trigger conditions are joined through `sys_flow_record_trigger`. It does not use the undocumented `/api/now/processflow/flow/{sys_id}` endpoint or the opaque `sys_hub_flow_snapshot` compiled cache. A bad per-node `values` blob adds `decode_error` to that node; the rest of `inspect` still succeeds.
+- **Notes:** The tool reads both V1 (`sys_hub_action_instance`, `sys_hub_flow_logic`, `sys_hub_trigger_instance`) and V2 (`sys_hub_action_instance_v2`, `sys_hub_flow_logic_instance_v2`, `sys_hub_trigger_instance_v2`) records. Record-trigger conditions are joined through `sys_flow_record_trigger`. It does not use the undocumented `/api/now/processflow/flow/{sys_id}` endpoint or the opaque `sys_hub_flow_snapshot` compiled cache. A bad per-node `values` blob adds `decode_error` to that node; the rest of `inspect` still succeeds. Decompression is bounded at 1 MiB compressed / 4 MiB decompressed; truncated streams and trailing garbage are rejected with a `ValueError`.
 
 ### `resolve_choice`
 Resolves human-readable labels to underlying ServiceNow values using the `sys_choice` table.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,12 +115,6 @@ ignore = [
     "ERA001", # commented-out code OK in tests
     "PT019",  # underscore-prefixed fixtures are used for @patch and side-effect injection
 ]
-"src/servicenow_mcp/tools/domains/*.py" = [
-    "A002",   # shadowing built-in "type" used as ServiceNow parameter name
-]
-"src/servicenow_mcp/tools/changes.py" = [
-    "A002",   # same - "format" parameter from ServiceNow API
-]
 
 [tool.ruff.lint.isort]
 known-first-party = ["servicenow_mcp"]


### PR DESCRIPTION
PR #85 introduced/hardened 8 security behaviours; the docs have now been
updated to match. Canonical pages (Telemetry.md, Safety-and-Policy.md)
received coordinated rewrites; other docs got pinpoint edits. CHANGELOG
gained 8 entries under [Unreleased] > Security, each referencing #85.

Behaviours documented:
- Sentry defaults: send_default_pii=False, traces_sample_rate=0.1
- Sentry argument redaction (13 sensitive keys, shallow semantics)
- Opaque error envelope on unclassified exceptions
- script_path opaque error + root-validated-first ordering
- Flow Designer decode_values size caps (1 MiB compressed / 4 MiB out)
- record_write MAX_PAYLOAD_BYTES = 1 MiB entry-point cap
- Dictionary attribute token-boundary parsing
- Audit no_audit regex whitespace tolerance

No source changes. Follow-up to #85.

## Files touched

- `docs/wiki/Telemetry.md`: rewrote Sentry section — SDK defaults table, argument redaction frozenset, redaction semantics
- `docs/wiki/Safety-and-Policy.md`: added opaque-error-envelope, script_path opaque rejection, payload size cap, dictionary token-boundary, audit no_audit whitespace
- `docs/wiki/Architecture.md`: noted `safe_tool_call` opaque generic-Exception arm + Sentry capture path
- `docs/wiki/Tool-Reference.md`: updated `record_write` payload cap, `flow decode_values` size caps, dictionary parser note
- `docs/wiki/Configuration.md`: clarified Sentry env-var overrides for `send_default_pii` / `traces_sample_rate`
- `docs/agent-recipes.md`: minor wording sync with hardened error envelopes
- `INSTALL.md`: Sentry section aligned with new defaults
- `README.md`: one-line Sentry default reference
- `AGENTS.md`: Sentry Module section — defaults, redaction set, shallow semantics; audit/dictionary notes
- `CHANGELOG.md`: 8 new entries under `[Unreleased] > Security`, each citing #85
