### PR TITLE
feat: add code_search tool for searching scripts across ServiceNow tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,7 +352,7 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 - `sys_hub_flow_variable` is filtered by `model=<flow_sys_id>` (not `flow=`). The `flow` column does not exist on that table; using it makes ServiceNow silently ignore the filter and return every variable declared by every action_type on the platform (hundreds of unrelated rows).
 - Pure decoder lives in `tools/_flow_values.py` as `decode_values()` and `looks_compressed()`. Decompression is bounded: `MAX_COMPRESSED_BYTES = 1 MiB` (wire cap, checked before allocating the decompressor) and `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected with `ValueError`.
 - Deliberately does not use undocumented `/api/now/processflow/*` endpoints.
-- Deliberately skips `sys_hub_flow_snapshot` because it is an opaque compiled cache.
+- `sys_hub_flow_snapshot` itself is an opaque compiled cache and is not parsed - but its `label_cache` column is plain JSON and IS read for the `latest_snapshot` to recover last-known step labels for producers that have since been deleted from the canvas (used to enrich the `unresolved_datapill_ref` warning).
 - Per-node decode failures add `decode_error` to that node only; the enclosing `inspect` response still succeeds.
 
 ### Datapill resolution
@@ -370,7 +370,7 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 - `v1_v2_coexistence` - both V1 and V2 action/logic rows exist for the same flow.
 - `v1_logic_present` - V1 `sys_hub_flow_logic` rows exist (legacy logic on an otherwise-migrated flow).
 - `spoke_action_types_referenced` - the canvas references one or more spoke-provided action types.
-- `unresolved_datapill_ref` - one per unique `producer_ui_id` referenced in any decoded payload that does not exist on the canvas. The message names the producer UUID and an example consumer step.
+- `unresolved_datapill_ref` - one per unique `producer_ui_id` referenced in any decoded payload that does not exist on the canvas. The message aggregates every consumer (order, field) pair and, when the published snapshot's `label_cache` carries the producer, names the deleted step (`producer 'Step Label' (deleted; ui_id=...)`); otherwise falls back to the bare `producer_ui_id=...` form.
 - `step_decode_failure` - aggregate count of canvas nodes whose `values` blob failed to decode (a single warning, not one per node).
 
 ## 🛡 Audit Inspection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,11 +336,12 @@ Dispatched via the `investigate` tool with `action='run'`, `action='explain'`, o
 
 Dispatched via the read-only `flow` tool. Available in the `full` and `readonly` packages, or through custom packages such as `MCP_TOOL_PACKAGE=flow,query,describe`.
 
-### 5 Flow Actions
+### 6 Flow Actions
 
 | Action | Purpose |
 | ------ | ------- |
-| `inspect` | Assemble one flow/subflow by `sys_id` or `name`: header, triggers, inputs, outputs, variables, decoded V2 action/logic nodes, canvas tree, published snapshot drift, and warnings. |
+| `inspect` | Assemble one flow/subflow by `sys_id` or `name`: header, triggers, inputs, outputs, variables, decoded V2 action/logic nodes with resolved datapill refs, canvas tree, published snapshot drift, and warnings. |
+| `summary` | Compact projection of `inspect`: single flattened trigger, flat ordered `steps` (no `values_decoded`), structure-only `branches` tree, global `datapill_graph`, `counts`, and the same `warnings`. Same input contract as `inspect`. |
 | `find_by_table` | Find flows with record triggers on a given table. |
 | `decode_values` | Stateless decode for gzip+base64+JSON `values` blobs from `sys_hub_*_v2` rows. |
 | `list_triggers` | List V1 and V2 trigger rows with optional `table`, `trigger_type`, `active`, and `limit` filters. |
@@ -348,10 +349,30 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 
 - Reads both V1 (`sys_hub_action_instance`, `sys_hub_flow_logic`, `sys_hub_trigger_instance`) and V2 (`sys_hub_action_instance_v2`, `sys_hub_flow_logic_instance_v2`, `sys_hub_trigger_instance_v2`) Flow Designer tables.
 - Joins V2 record-trigger conditions through `sys_flow_record_trigger.sys_id == trigger_v2.remote_trigger_id`.
+- `sys_hub_flow_variable` is filtered by `model=<flow_sys_id>` (not `flow=`). The `flow` column does not exist on that table; using it makes ServiceNow silently ignore the filter and return every variable declared by every action_type on the platform (hundreds of unrelated rows).
 - Pure decoder lives in `tools/_flow_values.py` as `decode_values()` and `looks_compressed()`. Decompression is bounded: `MAX_COMPRESSED_BYTES = 1 MiB` (wire cap, checked before allocating the decompressor) and `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected with `ValueError`.
 - Deliberately does not use undocumented `/api/now/processflow/*` endpoints.
 - Deliberately skips `sys_hub_flow_snapshot` because it is an opaque compiled cache.
 - Per-node decode failures add `decode_error` to that node only; the enclosing `inspect` response still succeeds.
+
+### Datapill resolution
+
+`inspect` builds a `ui_uuid -> {sys_id, name, action_type_name}` map from the canvas, then scans every node's `values_decoded` payload for `{{<uuid>.<field>}}` references (regex `\{\{([0-9a-f-]{36})\.([^}]+)\}\}`). Resolved refs are attached as a `datapill_refs: [{ref, field, producer_ui_uuid, producer_sys_id, producer_name, resolved}]` sibling on each consuming node. `summary` reshapes the same data into a flat `datapill_graph` (one edge per consumer field), keyed by `consumer_step_sys_id`.
+
+### Payload trims (`inspect`)
+
+- The verbatim "Add your code here" `calculation` boilerplate Flow Designer drops into every new input/output/variable is stripped from `inputs[]`, `outputs[]`, and `variables[]`. Customised calculations survive untouched.
+- `v1_actions` and `v1_variable_values` are omitted from the response when the underlying lists are empty (the common case on modern V2-only flows).
+
+### Warnings (`inspect` and `summary`)
+
+In addition to the original four (snapshot drift, V1+V2 coexistence, V1-logic presence, spoke-action-type references), the warning list now emits:
+
+- `flow_active_with_inactive_trigger` - flow header is `active=true` but no V2 trigger is `active=true`.
+- `missing_record_trigger_condition` - a V2 trigger has a `remote_trigger_id` but the stitched `condition` is empty (the joined `sys_flow_record_trigger` row is missing or has no condition).
+- `canvas_order_gap` - some sibling group on the canvas has a non-uniform consecutive order delta (e.g. 100 -> 200 -> 400, or 9 -> 11 elsewhere).
+- `unresolved_datapill_ref` - one per unique `producer_ui_uuid` referenced in any decoded payload that does not exist on the canvas. The message names the producer UUID and an example consumer step.
+- `step_decode_failure` - aggregate count of canvas nodes whose `values` blob failed to decode (a single warning, not one per node).
 
 ## 🛡 Audit Inspection
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,7 +348,7 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 | `describe` | Return the action registry without platform I/O. |
 
 - Reads both V1 (`sys_hub_action_instance`, `sys_hub_flow_logic`, `sys_hub_trigger_instance`) and V2 (`sys_hub_action_instance_v2`, `sys_hub_flow_logic_instance_v2`, `sys_hub_trigger_instance_v2`) Flow Designer tables.
-- Joins V2 record-trigger conditions through `sys_flow_record_trigger.sys_id == trigger_v2.remote_trigger_id`.
+- V2 rows expose `ui_id` and `parent_ui_id` (no `name`/`label`/`active` columns). Node display labels are resolved through the referenced `sys_hub_action_type_base.name` (for actions) or `sys_hub_flow_logic_definition.name` (for logic). Trigger row parameters (`table`, `condition`, schedule fields) come from the decoded `trigger_inputs` gzip+base64+JSON blob - the V2 trigger row itself does not carry them as columns, and `sys_flow_record_trigger` is not joined.
 - `sys_hub_flow_variable` is filtered by `model=<flow_sys_id>` (not `flow=`). The `flow` column does not exist on that table; using it makes ServiceNow silently ignore the filter and return every variable declared by every action_type on the platform (hundreds of unrelated rows).
 - Pure decoder lives in `tools/_flow_values.py` as `decode_values()` and `looks_compressed()`. Decompression is bounded: `MAX_COMPRESSED_BYTES = 1 MiB` (wire cap, checked before allocating the decompressor) and `MAX_DECOMPRESSED_BYTES = 4 MiB`. Truncated streams and trailing garbage are rejected with `ValueError`.
 - Deliberately does not use undocumented `/api/now/processflow/*` endpoints.
@@ -357,7 +357,7 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 
 ### Datapill resolution
 
-`inspect` builds a `ui_uuid -> {sys_id, name, action_type_name}` map from the canvas, then scans every node's `values_decoded` payload for `{{<uuid>.<field>}}` references (regex `\{\{([0-9a-f-]{36})\.([^}]+)\}\}`). Resolved refs are attached as a `datapill_refs: [{ref, field, producer_ui_uuid, producer_sys_id, producer_name, resolved}]` sibling on each consuming node. `summary` reshapes the same data into a flat `datapill_graph` (one edge per consumer field), keyed by `consumer_step_sys_id`.
+`inspect` builds a `ui_id -> {sys_id, name, action_type_name}` map from the canvas, then scans every node's `values_decoded` payload for `{{<uuid>.<field>}}` references (regex `\{\{([0-9a-f-]{36})\.([^}]+)\}\}`). Resolved refs are attached as a `datapill_refs: [{ref, field, producer_ui_id, producer_sys_id, producer_name, resolved}]` sibling on each consuming node. `summary` reshapes the same data into a flat `datapill_graph` (one edge per consumer field), keyed by `consumer_step_sys_id`.
 
 ### Payload trims (`inspect`)
 
@@ -366,12 +366,11 @@ Dispatched via the read-only `flow` tool. Available in the `full` and `readonly`
 
 ### Warnings (`inspect` and `summary`)
 
-In addition to the original four (snapshot drift, V1+V2 coexistence, V1-logic presence, spoke-action-type references), the warning list now emits:
-
-- `flow_active_with_inactive_trigger` - flow header is `active=true` but no V2 trigger is `active=true`.
-- `missing_record_trigger_condition` - a V2 trigger has a `remote_trigger_id` but the stitched `condition` is empty (the joined `sys_flow_record_trigger` row is missing or has no condition).
-- `canvas_order_nonuniform` - some sibling group on the canvas has a non-uniform consecutive order delta (e.g. 100 -> 200 -> 400, or 9 -> 11 elsewhere).
-- `unresolved_datapill_ref` - one per unique `producer_ui_uuid` referenced in any decoded payload that does not exist on the canvas. The message names the producer UUID and an example consumer step.
+- `snapshot_drift` - the published snapshot's hash differs from the live flow definition.
+- `v1_v2_coexistence` - both V1 and V2 action/logic rows exist for the same flow.
+- `v1_logic_present` - V1 `sys_hub_flow_logic` rows exist (legacy logic on an otherwise-migrated flow).
+- `spoke_action_types_referenced` - the canvas references one or more spoke-provided action types.
+- `unresolved_datapill_ref` - one per unique `producer_ui_id` referenced in any decoded payload that does not exist on the canvas. The message names the producer UUID and an example consumer step.
 - `step_decode_failure` - aggregate count of canvas nodes whose `values` blob failed to decode (a single warning, not one per node).
 
 ## 🛡 Audit Inspection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,7 +370,7 @@ In addition to the original four (snapshot drift, V1+V2 coexistence, V1-logic pr
 
 - `flow_active_with_inactive_trigger` - flow header is `active=true` but no V2 trigger is `active=true`.
 - `missing_record_trigger_condition` - a V2 trigger has a `remote_trigger_id` but the stitched `condition` is empty (the joined `sys_flow_record_trigger` row is missing or has no condition).
-- `canvas_order_gap` - some sibling group on the canvas has a non-uniform consecutive order delta (e.g. 100 -> 200 -> 400, or 9 -> 11 elsewhere).
+- `canvas_order_nonuniform` - some sibling group on the canvas has a non-uniform consecutive order delta (e.g. 100 -> 200 -> 400, or 9 -> 11 elsewhere).
 - `unresolved_datapill_ref` - one per unique `producer_ui_uuid` referenced in any decoded payload that does not exist on the canvas. The message names the producer UUID and an example consumer step.
 - `step_decode_failure` - aggregate count of canvas nodes whose `values` blob failed to decode (a single warning, not one per node).
 

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -1,5 +1,6 @@
 """Async ServiceNow REST API client."""
 
+import json
 import logging
 import re
 import uuid
@@ -910,6 +911,59 @@ class ServiceNowClient:
         except NotFoundError:
             return None
         return self._extract_result(response.json())
+
+    async def get_flow_snapshot_label_cache(self, snapshot_sys_id: str) -> dict[str, str]:
+        """Map producer ``ui_id`` to its last-known step label from a published snapshot.
+
+        ``sys_hub_flow_snapshot.label_cache`` is a plain-JSON column (NOT
+        gzip+base64 like ``values`` / ``trigger_inputs``); decode with
+        ``json.loads``. Each entry is keyed ``"<ui_id>.<field>"`` and
+        carries a label of the form ``"<step label>\u279b<field>"``. We
+        strip the field suffix from both sides so the returned map can
+        resolve orphan datapill producers by ui_id alone. Returns ``{}``
+        when the snapshot or its ``label_cache`` is absent.
+        """
+        if not snapshot_sys_id:
+            return {}
+        http = self._ensure_client()
+        try:
+            response = await http.get(
+                self._table_url("sys_hub_flow_snapshot", snapshot_sys_id),
+                headers=await self._headers(),
+                params={"sysparm_fields": "label_cache"},
+            )
+            self._raise_for_status(response)
+        except NotFoundError:
+            return {}
+        record = self._extract_result(response.json())
+        raw = record.get("label_cache") if isinstance(record, dict) else None
+        if not raw or not isinstance(raw, str):
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        if not isinstance(parsed, list):
+            return {}
+
+        label_map: dict[str, str] = {}
+        for entry in parsed:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            label = entry.get("label")
+            if not isinstance(name, str) or not isinstance(label, str):
+                continue
+            uid, _, _ = name.partition(".")
+            uid = uid.strip().lower()
+            if not uid:
+                continue
+            step_label, _, _ = label.partition("\u279b")
+            step_label = step_label.strip()
+            if not step_label:
+                continue
+            label_map.setdefault(uid, step_label)
+        return label_map
 
     async def find_flows_by_name(self, name: str) -> list[dict[str, Any]]:
         """Find flows whose ``name`` or ``internal_name`` matches *name* (display values resolved)."""

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -956,13 +956,20 @@ class ServiceNowClient:
         return self._extract_result(response.json())
 
     async def list_flow_variables(self, flow_sys_id: str) -> list[dict[str, Any]]:
-        """List flow-scoped variables (``sys_hub_flow_variable``)."""
+        """List flow-scoped variables (``sys_hub_flow_variable``).
+
+        Filters on ``model`` (the owning flow/subflow/action_type sys_id),
+        not ``flow``. A ``flow`` column does not exist on
+        ``sys_hub_flow_variable``; using it makes ServiceNow silently
+        ignore the filter and return the entire table (every variable
+        declared by every action_type on the platform).
+        """
         http = self._ensure_client()
         response = await http.get(
             self._table_url("sys_hub_flow_variable"),
             headers=await self._headers(),
             params={
-                "sysparm_query": f"flow={flow_sys_id}^ORDERBYorder",
+                "sysparm_query": f"model={flow_sys_id}^ORDERBYorder",
                 "sysparm_display_value": "all",
             },
         )

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -921,7 +921,10 @@ class ServiceNowClient:
         carries a label of the form ``"<step label>\u279b<field>"``. We
         strip the field suffix from both sides so the returned map can
         resolve orphan datapill producers by ui_id alone. Returns ``{}``
-        when the snapshot or its ``label_cache`` is absent.
+        for any non-recoverable shape mismatch (missing snapshot_sys_id,
+        404, blank ``label_cache`` column, malformed JSON, non-list root,
+        non-dict entries, non-string ``name``/``label``, or empty parts
+        after partitioning on ``.`` / ``\u279b``).
         """
         if not snapshot_sys_id:
             return {}

--- a/src/servicenow_mcp/client.py
+++ b/src/servicenow_mcp/client.py
@@ -1064,27 +1064,14 @@ class ServiceNowClient:
         self._raise_for_status(response)
         return self._extract_result(response.json())
 
-    async def list_record_triggers(self, remote_trigger_ids: list[str]) -> list[dict[str, Any]]:
-        """Bulk-fetch ``sys_flow_record_trigger`` rows for V2 record-trigger conditions."""
-        if not remote_trigger_ids:
-            return []
-        http = self._ensure_client()
-        ids_csv = ",".join(remote_trigger_ids)
-        limit = min(len(remote_trigger_ids), INTERNAL_QUERY_LIMIT)
-        response = await http.get(
-            self._table_url("sys_flow_record_trigger"),
-            headers=await self._headers(),
-            params={
-                "sysparm_query": f"sys_idIN{ids_csv}",
-                "sysparm_display_value": "all",
-                "sysparm_limit": str(limit),
-            },
-        )
-        self._raise_for_status(response)
-        return self._extract_result(response.json())
-
     async def get_action_type_definitions(self, action_type_sys_ids: list[str]) -> list[dict[str, Any]]:
-        """Bulk-fetch action-type metadata from ``sys_hub_action_type_base``."""
+        """Bulk-fetch action-type metadata from ``sys_hub_action_type_base``.
+
+        The concrete action-type rows actually live in child class
+        ``sys_hub_action_type_snapshot``, but they extend ``_base``;
+        querying ``sys_hub_action_type_definition`` returns 404 on this
+        platform - that table does not exist.
+        """
         if not action_type_sys_ids:
             return []
         http = self._ensure_client()
@@ -1096,6 +1083,30 @@ class ServiceNowClient:
             params={
                 "sysparm_query": f"sys_idIN{ids_csv}",
                 "sysparm_fields": "sys_id,name,internal_name,sys_scope,category,sys_class_name",
+                "sysparm_display_value": "all",
+                "sysparm_limit": str(limit),
+            },
+        )
+        self._raise_for_status(response)
+        return self._extract_result(response.json())
+
+    async def get_logic_definitions(self, logic_definition_sys_ids: list[str]) -> list[dict[str, Any]]:
+        """Bulk-fetch logic-definition metadata from ``sys_hub_flow_logic_definition``.
+
+        Each row's ``name`` is the kind label (``If``, ``Else``, ``For Each``,
+        ``End``, ...) that the canvas surfaces as a logic node's label.
+        """
+        if not logic_definition_sys_ids:
+            return []
+        http = self._ensure_client()
+        ids_csv = ",".join(logic_definition_sys_ids)
+        limit = min(len(logic_definition_sys_ids), INTERNAL_QUERY_LIMIT)
+        response = await http.get(
+            self._table_url("sys_hub_flow_logic_definition"),
+            headers=await self._headers(),
+            params={
+                "sysparm_query": f"sys_idIN{ids_csv}",
+                "sysparm_fields": "sys_id,name,internal_name,sys_scope,category",
                 "sysparm_display_value": "all",
                 "sysparm_limit": str(limit),
             },

--- a/src/servicenow_mcp/packages.py
+++ b/src/servicenow_mcp/packages.py
@@ -1,9 +1,9 @@
 """Tool package registry and loader for the ServiceNow MCP server.
 
-The unified tool surface exposes 11 tool groups across 4 preset packages:
+The unified tool surface exposes 12 tool groups across 4 preset packages:
 
 Groups (registered modules under ``servicenow_mcp.tools``):
-    ``query``, ``describe``, ``record_write``, ``record_read``,
+    ``code_search``, ``query``, ``describe``, ``record_write``, ``record_read``,
     ``attachment``, ``investigate``, ``resolve_choice``,
     ``service_catalog``, ``build_query``, ``audit``, ``flow``.
     The ``build_query`` group is
@@ -18,8 +18,8 @@ separate ``attachment_write`` group - read and write live in one
 module and write paths are gated by ``write_gate``/``can_write``.
 
 Presets:
-    ``full``           - every group (full surface).
-    ``readonly``       - query + describe + record_read + attachment +
+    ``full``           - every group (full surface, includes code_search).
+    ``readonly``       - code_search + query + describe + record_read + attachment +
                        investigate + resolve_choice + audit + flow
                        (still loads attachment which carries write tools;
                        those are blocked at runtime in production by
@@ -37,6 +37,7 @@ tool only.
 """
 
 _TOOL_GROUP_MODULES: dict[str, str] = {
+    "code_search": "servicenow_mcp.tools.code_search",
     "query": "servicenow_mcp.tools.query",
     "describe": "servicenow_mcp.tools.describe",
     "record_write": "servicenow_mcp.tools.record_write",
@@ -60,6 +61,7 @@ _TOOL_GROUP_MODULES: dict[str, str] = {
 # to be split into separate read / write groups.
 PACKAGE_REGISTRY: dict[str, list[str]] = {
     "full": [
+        "code_search",
         "query",
         "describe",
         "record_write",
@@ -73,6 +75,7 @@ PACKAGE_REGISTRY: dict[str, list[str]] = {
         "flow",
     ],
     "readonly": [
+        "code_search",
         "query",
         "describe",
         "record_read",

--- a/src/servicenow_mcp/tools/code_search.py
+++ b/src/servicenow_mcp/tools/code_search.py
@@ -1,0 +1,175 @@
+"""Unified ``code_search`` tool: search script-bearing tables for code.
+
+Three actions dispatched on ``action``:
+
+* ``search``  - search for ``term`` across script-bearing tables.
+* ``tables``  - return the list of searchable tables.
+* ``describe`` - return tool action metadata without making API calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from mcp.server.fastmcp import FastMCP
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.choices import ChoiceRegistry
+from servicenow_mcp.client import ServiceNowClient
+from servicenow_mcp.config import Settings
+from servicenow_mcp.decorators import tool_handler
+from servicenow_mcp.tools._dictionary import DictionaryRegistry
+from servicenow_mcp.utils import format_response
+
+
+TOOL_NAMES: list[str] = ["code_search"]
+
+_VALID_ACTIONS: Final[frozenset[str]] = frozenset({"search", "tables", "describe"})
+
+_MAX_SEARCH_LIMIT: Final[int] = 500
+_MIN_SEARCH_LIMIT: Final[int] = 1
+
+_ACTION_REGISTRY: Final[dict[str, dict[str, Any]]] = {
+    "search": {
+        "description": "Search for code across script-bearing ServiceNow tables.",
+        "params": {
+            "term": "str (required) — search term",
+            "table": "str (optional) — limit search to a specific table",
+            "search_group": "str (optional) — name of a search group scope",
+            "limit": f"int (default 50, 1..{_MAX_SEARCH_LIMIT})",
+        },
+    },
+    "tables": {
+        "description": "Return the list of searchable tables for the Code Search API.",
+        "params": {},
+    },
+    "describe": {
+        "description": "Return this action registry without making any platform calls.",
+        "params": {},
+    },
+}
+
+
+def _error(correlation_id: str, message: str) -> str:
+    """Serialize a standard error envelope."""
+    return format_response(data=None, correlation_id=correlation_id, status="error", error=message)
+
+
+def _clamp_limit(limit: int) -> int:
+    """Clamp *limit* to ``[_MIN_SEARCH_LIMIT, _MAX_SEARCH_LIMIT]``."""
+    return max(_MIN_SEARCH_LIMIT, min(limit, _MAX_SEARCH_LIMIT))
+
+
+async def _action_search(
+    *,
+    term: str,
+    table: str,
+    search_group: str,
+    limit: int,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    correlation_id: str,
+) -> str:
+    """Execute a code search via the ServiceNow Code Search API."""
+    if not term:
+        return _error(correlation_id, "term is required for action='search'.")
+
+    effective_limit = _clamp_limit(limit)
+    table_param: str | None = table if table else None
+    search_group_param: str | None = search_group if search_group else None
+
+    async with ServiceNowClient(settings, auth_provider) as client:
+        result = await client.code_search(
+            term=term,
+            table=table_param,
+            search_group=search_group_param,
+            limit=effective_limit,
+        )
+
+    return format_response(data=result, correlation_id=correlation_id)
+
+
+async def _action_tables(
+    *,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    correlation_id: str,
+) -> str:
+    """Fetch the list of searchable tables via the Code Search API."""
+    async with ServiceNowClient(settings, auth_provider) as client:
+        result = await client.code_search_tables()
+
+    return format_response(data=result, correlation_id=correlation_id)
+
+
+def _action_describe(correlation_id: str) -> str:
+    """Return the action registry without making any platform calls."""
+    return format_response(
+        data={"actions": _ACTION_REGISTRY},
+        correlation_id=correlation_id,
+    )
+
+
+def register_tools(
+    mcp: FastMCP,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    choices: ChoiceRegistry | None = None,
+    dictionary: DictionaryRegistry | None = None,
+) -> None:
+    """Register the unified ``code_search`` tool on the MCP server.
+
+    ``choices`` and ``dictionary`` are accepted only to satisfy the
+    uniform loader contract in ``server.py``; this tool needs neither.
+    """
+    del choices, dictionary  # unused; signature retained for loader parity
+
+    @mcp.tool()
+    @tool_handler
+    async def code_search(
+        action: str = "search",
+        term: str = "",
+        table: str = "",
+        search_group: str = "",
+        limit: int = 50,
+        *,
+        correlation_id: str = "",
+    ) -> str:
+        """Search script-bearing ServiceNow tables for code matches.
+
+        Three modes: ``search`` (default) queries the Code Search API,
+        ``tables`` lists the searchable tables, and ``describe`` returns
+        metadata about this tool without making any platform calls.
+
+        Args:
+            action: 'search' | 'tables' | 'describe'. Defaults to 'search'.
+            term: Search term (required for action='search').
+            table: Table name to restrict the search (optional).
+            search_group: Name of a search group scope (optional).
+            limit: Maximum results for action='search' (1..500, default 50).
+        """
+        if action not in _VALID_ACTIONS:
+            return _error(
+                correlation_id,
+                f"Unknown action {action!r}. Expected one of: {sorted(_VALID_ACTIONS)}.",
+            )
+
+        if action == "describe":
+            return _action_describe(correlation_id)
+
+        if action == "tables":
+            return await _action_tables(
+                settings=settings,
+                auth_provider=auth_provider,
+                correlation_id=correlation_id,
+            )
+
+        return await _action_search(
+            term=term,
+            table=table,
+            search_group=search_group,
+            limit=limit,
+            settings=settings,
+            auth_provider=auth_provider,
+            correlation_id=correlation_id,
+        )

--- a/src/servicenow_mcp/tools/flow.py
+++ b/src/servicenow_mcp/tools/flow.py
@@ -45,7 +45,7 @@ _VALID_ACTIONS: Final[frozenset[str]] = frozenset(
 _DEFAULT_TRIGGER_LIMIT: Final[int] = 100
 
 # Datapills in Flow Designer ``values`` payloads are stored as
-# ``{{<ui_uuid>.<dotted.field.path>}}`` where ui_uuid is the producer step's
+# ``{{<ui_id>.<dotted.field.path>}}`` where ui_id is the producer step's
 # canvas UUID (lowercase hex with dashes, 36 chars). The field part may
 # contain dots, brackets, and underscores; we capture lazily up to the
 # closing braces.
@@ -184,23 +184,64 @@ def _walk_strings(value: Any) -> Iterator[str]:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_node_label(
+    row: dict[str, Any],
+    *,
+    kind: str,
+    action_type_lookup: dict[str, dict[str, Any]],
+    logic_definition_lookup: dict[str, dict[str, Any]],
+) -> str:
+    """Derive the user-visible label for a V2 canvas node.
+
+    Action nodes have no ``name``/``label`` column on the instance row; the
+    label lives on the referenced ``sys_hub_action_type_base`` row. Logic
+    nodes follow the same pattern via ``sys_hub_flow_logic_definition``.
+    Fall back to the inline display value of the ref column when the
+    lookup is empty (mostly a test/mock convenience).
+    """
+    if kind == "action":
+        atype_id = _v(row.get("action_type"))
+        meta = action_type_lookup.get(atype_id) if atype_id else None
+        if meta:
+            return _d(meta.get("name"))
+        return _d(row.get("action_type"))
+    if kind == "logic":
+        ldef_id = _v(row.get("logic_definition"))
+        meta = logic_definition_lookup.get(ldef_id) if ldef_id else None
+        if meta:
+            return _d(meta.get("name"))
+        return _d(row.get("logic_definition"))
+    return ""
+
+
 def _build_v2_node(
     row: dict[str, Any],
     *,
     kind: str,
-    action_type_lookup: dict[str, dict[str, Any]] | None = None,
+    action_type_lookup: dict[str, dict[str, Any]],
+    logic_definition_lookup: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build a canvas node for a V2 action or logic instance."""
+    """Build a canvas node for a V2 action or logic instance.
+
+    V2 instance rows expose ``ui_id``/``parent_ui_id``; they have no
+    ``name``/``label``/``active`` columns. The visible label is derived
+    from the referenced action-type or logic-definition row.
+    """
     decoded, decode_error = _maybe_decode(row.get("values"))
+    label = _resolve_node_label(
+        row,
+        kind=kind,
+        action_type_lookup=action_type_lookup,
+        logic_definition_lookup=logic_definition_lookup,
+    )
     node: dict[str, Any] = {
         "kind": kind,
         "version": "v2",
         "sys_id": _v(row.get("sys_id")),
-        "ui_uuid": _v(row.get("ui_uuid")),
-        "parent_ui_id": _v(row.get("parent_ui_uuid")),
+        "ui_id": _v(row.get("ui_id")),
+        "parent_ui_id": _v(row.get("parent_ui_id")),
         "order": _v(row.get("order")),
-        "label": _d(row.get("label")),
-        "name": _v(row.get("name")),
+        "label": label,
         "comment": _v(row.get("comment")),
         "values_decoded": decoded,
         "children": [],
@@ -209,10 +250,10 @@ def _build_v2_node(
         action_type_id = _v(row.get("action_type"))
         node["action_type"] = {
             "sys_id": action_type_id,
-            "name": _d(row.get("action_type")),
+            "name": label,
         }
-        if action_type_lookup and action_type_id in action_type_lookup:
-            meta = action_type_lookup[action_type_id]
+        meta = action_type_lookup.get(action_type_id)
+        if meta:
             node["action_type"].update(
                 {
                     "internal_name": _v(meta.get("internal_name")),
@@ -223,7 +264,7 @@ def _build_v2_node(
     if kind == "logic":
         node["logic_definition"] = {
             "sys_id": _v(row.get("logic_definition")),
-            "name": _d(row.get("logic_definition")),
+            "name": label,
         }
     if decode_error is not None:
         node["decode_error"] = decode_error
@@ -231,44 +272,99 @@ def _build_v2_node(
 
 
 def _assemble_canvas(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Build a nested canvas tree by linking each node to its parent_ui_uuid.
+    """Build a nested canvas tree by linking each node to its parent_ui_id.
 
     Roots (``parent_ui_id == ""``) are returned at the top level; children
     are attached to their parent's ``children`` list in the order they
     appear in *nodes* (already sorted by ``order`` upstream).
     """
-    by_uuid: dict[str, dict[str, Any]] = {}
+    by_id: dict[str, dict[str, Any]] = {}
     for node in nodes:
-        uuid = node["ui_uuid"]
-        if uuid:
-            by_uuid[uuid] = node
+        uid = node["ui_id"]
+        if uid:
+            by_id[uid] = node
 
     roots: list[dict[str, Any]] = []
     for node in nodes:
         parent = node["parent_ui_id"]
-        if parent and parent in by_uuid:
-            by_uuid[parent]["children"].append(node)
+        if parent and parent in by_id:
+            by_id[parent]["children"].append(node)
         else:
             roots.append(node)
     return roots
 
 
-def _v2_trigger_entry(
-    row: dict[str, Any],
-    *,
-    condition_lookup: dict[str, str],
-) -> dict[str, Any]:
-    """Build a trigger entry from a V2 ``sys_hub_trigger_instance_v2`` row."""
-    remote_id = _v(row.get("remote_trigger_id"))
-    decoded, decode_error = _maybe_decode(row.get("values"))
+# Schedule extraction is keyed by ``trigger_type``: each scheduled kind
+# stores its single relevant parameter under a fixed ``name`` in the
+# decoded ``trigger_inputs`` list. ``service_catalog`` and the record
+# triggers have no schedule field.
+_SCHEDULE_INPUT_BY_TRIGGER_TYPE: Final[dict[str, str]] = {
+    "daily": "time",
+    "repeat": "repeat",
+    "run_once": "run_in",
+}
+
+
+def _index_trigger_inputs(decoded: Any) -> dict[str, dict[str, Any]]:
+    """Index a decoded ``trigger_inputs`` list by each entry's ``name``."""
+    if not isinstance(decoded, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for entry in decoded:
+        if isinstance(entry, dict):
+            key = entry.get("name")
+            if isinstance(key, str) and key:
+                indexed[key] = entry
+    return indexed
+
+
+def _project_trigger_inputs(decoded: Any, trigger_type: str) -> dict[str, Any]:
+    """Extract structured trigger fields from a decoded ``trigger_inputs`` list.
+
+    The blob is a list of ``{name, value, displayValue, ...}`` dicts.
+    Record triggers carry ``table`` and ``condition`` entries; scheduled
+    triggers carry a single kind-specific schedule entry. Everything else
+    (``service_catalog``, undefined types) returns empty strings.
+    """
+    by_name = _index_trigger_inputs(decoded)
+    table_entry = by_name.get("table") or {}
+    condition_entry = by_name.get("condition") or {}
+
+    schedule: dict[str, str] = {}
+    schedule_field = _SCHEDULE_INPUT_BY_TRIGGER_TYPE.get(trigger_type)
+    if schedule_field:
+        schedule_entry = by_name.get(schedule_field) or {}
+        schedule_value = schedule_entry.get("value", "")
+        if schedule_value:
+            schedule[schedule_field] = str(schedule_value)
+
+    return {
+        "table": str(table_entry.get("value", "")),
+        "table_display": str(table_entry.get("displayValue", "")),
+        "condition": str(condition_entry.get("value", "")),
+        "schedule": schedule,
+    }
+
+
+def _v2_trigger_entry(row: dict[str, Any]) -> dict[str, Any]:
+    """Build a trigger entry from a V2 ``sys_hub_trigger_instance_v2`` row.
+
+    Trigger metadata (``table``, ``condition``, schedule) lives inside the
+    gzip+base64+JSON ``trigger_inputs`` blob - the V2 row does not expose
+    ``type``/``table``/``active``/``remote_trigger_id`` as columns.
+    """
+    decoded, decode_error = _maybe_decode(row.get("trigger_inputs"))
+    trigger_type = _v(row.get("trigger_type"))
+    projection = _project_trigger_inputs(decoded, trigger_type)
     entry: dict[str, Any] = {
         "version": "v2",
         "sys_id": _v(row.get("sys_id")),
-        "type": _v(row.get("type")),
-        "active": _v(row.get("active")) == "true",
-        "table": _v(row.get("table")),
-        "remote_trigger_id": remote_id,
-        "condition": condition_lookup.get(remote_id, ""),
+        "type": trigger_type,
+        "name": _v(row.get("name")),
+        "table": projection["table"],
+        "table_display": projection["table_display"],
+        "condition": projection["condition"],
+        "schedule": projection["schedule"],
         "values_decoded": decoded,
     }
     if decode_error is not None:
@@ -294,21 +390,22 @@ def _v1_trigger_entry(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _build_canvas_map(flat_nodes: list[dict[str, Any]]) -> dict[str, dict[str, str]]:
-    """Map each canvas node's ``ui_uuid`` to its identifying metadata.
+    """Map each canvas node's ``ui_id`` to its identifying metadata.
 
     Built from the flat node list (pre-nesting) so all nodes are included
-    regardless of branch depth.
+    regardless of branch depth. Keys are lowercased for case-insensitive
+    datapill resolution.
     """
     canvas_map: dict[str, dict[str, str]] = {}
     for node in flat_nodes:
-        uuid = node["ui_uuid"]
-        if not uuid:
+        uid = node["ui_id"]
+        if not uid:
             continue
         action_type = node.get("action_type")
         action_type_name = action_type.get("name", "") if isinstance(action_type, dict) else ""
-        canvas_map[uuid.lower()] = {
+        canvas_map[uid.lower()] = {
             "sys_id": node["sys_id"],
-            "name": node["label"] or node["name"],
+            "name": node["label"],
             "action_type_name": action_type_name,
         }
     return canvas_map
@@ -317,8 +414,8 @@ def _build_canvas_map(flat_nodes: list[dict[str, Any]]) -> dict[str, dict[str, s
 def _find_datapill_refs_in(decoded: Any) -> list[tuple[str, str, str]]:
     """Find every ``{{uuid.field}}`` ref in a decoded payload.
 
-    Returns ``[(raw_ref, producer_ui_uuid, field), ...]`` preserving order
-    of first appearance, deduplicated by ``(producer_ui_uuid, field)``.
+    Returns ``[(raw_ref, producer_ui_id, field), ...]`` preserving order
+    of first appearance, deduplicated by ``(producer_ui_id, field)``.
     """
     refs: list[tuple[str, str, str]] = []
     seen: set[tuple[str, str]] = set()
@@ -341,13 +438,13 @@ def _resolve_refs_for_node(
     if decoded is None:
         return []
     resolved: list[dict[str, Any]] = []
-    for raw, producer_uuid, field in _find_datapill_refs_in(decoded):
-        producer = canvas_map.get(producer_uuid.lower())
+    for raw, producer_uid, field in _find_datapill_refs_in(decoded):
+        producer = canvas_map.get(producer_uid.lower())
         resolved.append(
             {
                 "ref": raw,
                 "field": field,
-                "producer_ui_uuid": producer_uuid,
+                "producer_ui_id": producer_uid,
                 "producer_sys_id": producer["sys_id"] if producer else "",
                 "producer_name": producer["name"] if producer else "",
                 "resolved": producer is not None,
@@ -361,31 +458,8 @@ def _resolve_refs_for_node(
 # ---------------------------------------------------------------------------
 
 
-def _detect_order_gaps(roots: list[dict[str, Any]]) -> bool:
-    """Return True if any sibling group on the canvas has a discontinuous order sequence.
-
-    A "gap" is detected at any nesting level with at least three sibling
-    nodes when the consecutive order deltas are not uniform (max delta
-    exceeds min delta). This catches both classic Flow spacing skips
-    (100 -> 200 -> 400) and tight sequences (...9 -> 11...).
-    """
-    if not roots:
-        return False
-
-    def _level_has_gap(siblings: list[dict[str, Any]]) -> bool:
-        orders = sorted({_safe_int(n["order"]) for n in siblings})
-        if len(orders) >= 3:
-            deltas = [orders[i + 1] - orders[i] for i in range(len(orders) - 1)]
-            if min(deltas) > 0 and max(deltas) > min(deltas):
-                return True
-        return any(_level_has_gap(n.get("children", [])) for n in siblings)
-
-    return _level_has_gap(roots)
-
-
 def _build_warnings(
     *,
-    flow_active: bool,
     drift: bool,
     master: str,
     latest: str,
@@ -396,11 +470,10 @@ def _build_warnings(
     logic_v2: list[dict[str, Any]],
     triggers_v2_entries: list[dict[str, Any]],
     action_type_lookup: dict[str, dict[str, Any]],
-    canvas: list[dict[str, Any]],
     unresolved_refs: dict[str, str],
     decode_failure_count: int,
 ) -> list[str]:
-    """Assemble the full warning list shared by ``inspect`` and ``summary``."""
+    """Assemble the warning list shared by ``inspect`` and ``summary``."""
     warnings: list[str] = []
 
     if drift:
@@ -427,22 +500,9 @@ def _build_warnings(
             f"{len(spoke_actions)} spoke action type(s) referenced; their decoded values may depend on scoped types."
         )
 
-    if flow_active and triggers_v2_entries and not any(t["active"] for t in triggers_v2_entries):
-        warnings.append("flow_active_with_inactive_trigger: flow.active=true but no V2 trigger is active.")
-
-    for entry in triggers_v2_entries:
-        if entry["remote_trigger_id"] and not entry["condition"]:
-            warnings.append(
-                f"missing_record_trigger_condition: V2 trigger {entry['sys_id']!r} has remote_trigger_id "
-                f"{entry['remote_trigger_id']!r} but the stitched condition is empty."
-            )
-
-    if _detect_order_gaps(canvas):
-        warnings.append("canvas_order_nonuniform: sibling step orders are not uniformly spaced on at least one branch.")
-
-    for producer_uuid, consumer_sys_id in unresolved_refs.items():
+    for producer_uid, consumer_sys_id in unresolved_refs.items():
         warnings.append(
-            f"unresolved_datapill_ref: producer_ui_uuid={producer_uuid!r} is referenced by step "
+            f"unresolved_datapill_ref: producer_ui_id={producer_uid!r} is referenced by step "
             f"{consumer_sys_id!r} but is not present on the canvas."
         )
 
@@ -512,24 +572,36 @@ async def _load_flow_bundle(
     triggers_v2 = await client.list_trigger_instances_v2(resolved_sys_id)
     triggers_v1 = await client.list_trigger_instances_v1(resolved_sys_id)
 
-    remote_ids = sorted({_v(t.get("remote_trigger_id")) for t in triggers_v2 if _v(t.get("remote_trigger_id"))})
-    record_triggers = await client.list_record_triggers(remote_ids) if remote_ids else []
-
     action_type_ids = sorted({_v(a.get("action_type")) for a in actions_v2 if _v(a.get("action_type"))})
     action_type_rows = await client.get_action_type_definitions(action_type_ids) if action_type_ids else []
+
+    logic_definition_ids = sorted({_v(le.get("logic_definition")) for le in logic_v2 if _v(le.get("logic_definition"))})
+    logic_definition_rows = await client.get_logic_definitions(logic_definition_ids) if logic_definition_ids else []
 
     v1_action_ids = sorted({_v(a.get("sys_id")) for a in actions_v1 if _v(a.get("sys_id"))})
     v1_variable_values = await client.list_v1_variable_values(v1_action_ids) if v1_action_ids else []
 
     action_type_lookup = _index_by_sys_id(action_type_rows)
-    condition_lookup: dict[str, str] = {
-        _v(row.get("sys_id")): _v(row.get("condition")) for row in record_triggers if _v(row.get("sys_id"))
-    }
+    logic_definition_lookup = _index_by_sys_id(logic_definition_rows)
 
     flat_nodes: list[dict[str, Any]] = [
-        _build_v2_node(row, kind="action", action_type_lookup=action_type_lookup) for row in actions_v2
+        _build_v2_node(
+            row,
+            kind="action",
+            action_type_lookup=action_type_lookup,
+            logic_definition_lookup=logic_definition_lookup,
+        )
+        for row in actions_v2
     ]
-    flat_nodes.extend(_build_v2_node(row, kind="logic") for row in logic_v2)
+    flat_nodes.extend(
+        _build_v2_node(
+            row,
+            kind="logic",
+            action_type_lookup=action_type_lookup,
+            logic_definition_lookup=logic_definition_lookup,
+        )
+        for row in logic_v2
+    )
     flat_nodes.sort(key=lambda n: _safe_int(n["order"]))
 
     canvas_map = _build_canvas_map(flat_nodes)
@@ -545,14 +617,12 @@ async def _load_flow_bundle(
         if refs:
             node["datapill_refs"] = refs
             for ref in refs:
-                if not ref["resolved"] and ref["producer_ui_uuid"] not in unresolved_refs:
-                    unresolved_refs[ref["producer_ui_uuid"]] = node["sys_id"]
+                if not ref["resolved"] and ref["producer_ui_id"] not in unresolved_refs:
+                    unresolved_refs[ref["producer_ui_id"]] = node["sys_id"]
 
     canvas = _assemble_canvas(flat_nodes)
 
-    triggers_v2_entries: list[dict[str, Any]] = [
-        _v2_trigger_entry(row, condition_lookup=condition_lookup) for row in triggers_v2
-    ]
+    triggers_v2_entries: list[dict[str, Any]] = [_v2_trigger_entry(row) for row in triggers_v2]
     triggers_v1_entries: list[dict[str, Any]] = [_v1_trigger_entry(row) for row in triggers_v1]
 
     return {
@@ -568,6 +638,7 @@ async def _load_flow_bundle(
         "triggers_v2_rows": triggers_v2,
         "v1_variable_values": v1_variable_values,
         "action_type_lookup": action_type_lookup,
+        "logic_definition_lookup": logic_definition_lookup,
         "flat_nodes": flat_nodes,
         "canvas_map": canvas_map,
         "canvas": canvas,
@@ -629,7 +700,6 @@ async def _action_inspect(
     triggers.extend(bundle["triggers_v1_entries"])
 
     warnings = _build_warnings(
-        flow_active=flow_payload["active"],
         drift=drift,
         master=master,
         latest=latest,
@@ -640,7 +710,6 @@ async def _action_inspect(
         logic_v2=bundle["logic_v2"],
         triggers_v2_entries=bundle["triggers_v2_entries"],
         action_type_lookup=bundle["action_type_lookup"],
-        canvas=bundle["canvas"],
         unresolved_refs=bundle["unresolved_refs"],
         decode_failure_count=bundle["decode_failure_count"],
     )
@@ -680,16 +749,25 @@ def _summary_trigger(triggers_v2_entries: list[dict[str, Any]]) -> dict[str, Any
 
     Real flows have one trigger; the array shape on ``inspect`` exists to
     cover edge cases. ``summary`` always returns the same flat object,
-    using sentinel values when no V2 trigger exists.
+    using empty values when no V2 trigger exists.
     """
     if not triggers_v2_entries:
-        return {"type": "", "table": "", "active": False, "condition": ""}
+        return {
+            "type": "",
+            "name": "",
+            "table": "",
+            "table_display": "",
+            "condition": "",
+            "schedule": {},
+        }
     first = triggers_v2_entries[0]
     return {
         "type": first["type"],
+        "name": first["name"],
         "table": first["table"],
-        "active": first["active"],
+        "table_display": first["table_display"],
         "condition": first["condition"],
+        "schedule": first["schedule"],
     }
 
 
@@ -699,27 +777,24 @@ def _summary_steps(
 ) -> list[dict[str, Any]]:
     """Project the flat node list down to summary step rows.
 
-    Each step carries enough identity (``sys_id``, ``ui_uuid``, ``order``,
-    ``kind``, ``name``, ``label``, ``comment``) and branch context
-    (``branch_parent_ui_uuid``, ``branch_label``) to be useful on its own
+    Each step carries enough identity (``sys_id``, ``ui_id``, ``order``,
+    ``kind``, ``label``, ``comment``) and branch context
+    (``branch_parent_ui_id``, ``branch_label``) to be useful on its own
     without the heavy ``values_decoded`` payload.
     """
     steps: list[dict[str, Any]] = []
     for node in flat_nodes:
-        action_type = node.get("action_type") or {}
-        resolved_name = action_type.get("name", "") if isinstance(action_type, dict) else ""
         parent_id = node["parent_ui_id"]
         parent = parent_lookup.get(parent_id)
         steps.append(
             {
                 "order": _safe_int(node["order"]),
                 "sys_id": node["sys_id"],
-                "ui_uuid": node["ui_uuid"],
+                "ui_id": node["ui_id"],
                 "kind": node["kind"],
-                "name": resolved_name or node["name"],
                 "label": node["label"],
                 "comment": node["comment"],
-                "branch_parent_ui_uuid": parent_id,
+                "branch_parent_ui_id": parent_id,
                 "branch_label": parent["label"] if parent else "",
             }
         )
@@ -730,10 +805,10 @@ def _summary_branches(canvas: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Strip decoded values + datapill refs from the canvas tree, keep structure only."""
     return [
         {
-            "ui_uuid": node["ui_uuid"],
+            "ui_id": node["ui_id"],
             "sys_id": node["sys_id"],
             "order": _safe_int(node["order"]),
-            "name": node["label"] or node["name"],
+            "label": node["label"],
             "children": _summary_branches(node.get("children", [])),
         }
         for node in canvas
@@ -748,12 +823,12 @@ def _summary_datapill_graph(
     graph: list[dict[str, Any]] = []
     for node in flat_nodes:
         for ref in node.get("datapill_refs", []):
-            producer = canvas_map.get(ref["producer_ui_uuid"].lower())
+            producer = canvas_map.get(ref["producer_ui_id"].lower())
             graph.append(
                 {
                     "consumer_step_sys_id": node["sys_id"],
                     "consumer_field": ref["field"],
-                    "producer_ui_uuid": ref["producer_ui_uuid"],
+                    "producer_ui_id": ref["producer_ui_id"],
                     "producer_sys_id_if_resolved": producer["sys_id"] if producer else "",
                     "producer_name_if_resolved": producer["name"] if producer else "",
                     "raw_reference": ref["ref"],
@@ -791,14 +866,11 @@ async def _action_summary(
     drift = bool(master and latest and master != latest)
     flow_payload = _flow_header_payload(header)
 
-    parent_lookup: dict[str, dict[str, Any]] = {
-        node["ui_uuid"]: node for node in bundle["flat_nodes"] if node["ui_uuid"]
-    }
+    parent_lookup: dict[str, dict[str, Any]] = {node["ui_id"]: node for node in bundle["flat_nodes"] if node["ui_id"]}
 
     actions_v2 = bundle["actions_v2"]
     logic_v2 = bundle["logic_v2"]
     warnings = _build_warnings(
-        flow_active=flow_payload["active"],
         drift=drift,
         master=master,
         latest=latest,
@@ -809,7 +881,6 @@ async def _action_summary(
         logic_v2=logic_v2,
         triggers_v2_entries=bundle["triggers_v2_entries"],
         action_type_lookup=bundle["action_type_lookup"],
-        canvas=bundle["canvas"],
         unresolved_refs=bundle["unresolved_refs"],
         decode_failure_count=bundle["decode_failure_count"],
     )

--- a/src/servicenow_mcp/tools/flow.py
+++ b/src/servicenow_mcp/tools/flow.py
@@ -1,9 +1,12 @@
 """Unified ``flow`` tool: read-only Flow Designer inspection.
 
-Five actions:
+Six actions:
 
 * ``inspect``        - assemble one flow by sys_id or name: header, triggers,
-  inputs/outputs/variables, decoded V2 nodes, canvas tree, snapshot drift.
+  inputs/outputs/variables, decoded V2 nodes (with resolved datapill refs),
+  canvas tree, snapshot drift.
+* ``summary``        - compact projection of the same data: single trigger,
+  flat ordered steps, branch-only tree, global datapill graph, counts.
 * ``find_by_table``  - find flows with record triggers on a given table
   (merges V1 + V2).
 * ``decode_values``  - stateless decode of a gzip+base64+JSON ``values`` blob.
@@ -17,6 +20,8 @@ endpoints (undocumented) or ``sys_hub_flow_snapshot`` (opaque cache).
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterator
 from typing import Any, Final
 
 from mcp.server.fastmcp import FastMCP
@@ -34,14 +39,32 @@ from servicenow_mcp.utils import format_response, validate_identifier, validate_
 TOOL_NAMES: list[str] = ["flow"]
 
 _VALID_ACTIONS: Final[frozenset[str]] = frozenset(
-    {"inspect", "find_by_table", "decode_values", "list_triggers", "describe"}
+    {"inspect", "summary", "find_by_table", "decode_values", "list_triggers", "describe"}
 )
 
 _DEFAULT_TRIGGER_LIMIT: Final[int] = 100
 
+# Datapills in Flow Designer ``values`` payloads are stored as
+# ``{{<ui_uuid>.<dotted.field.path>}}`` where ui_uuid is the producer step's
+# canvas UUID (lowercase hex with dashes, 36 chars). The field part may
+# contain dots, brackets, and underscores; we capture lazily up to the
+# closing braces.
+_DATAPILL_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{\{([0-9a-f-]{36})\.([^}]+)\}\}")
+
+# Verbatim "Add your code here" stub Flow Designer drops into every new
+# calculated-field input/output/variable. Stripping it keeps real custom
+# calculations visible while removing pure boilerplate from payloads.
+_CALCULATION_BOILERPLATE: Final[str] = (
+    "(function calculatedFieldValue(current) {\n\n\t// Add your code here\n\treturn '';  // return the calculated value\n\n})(current);"
+)
+
 _ACTION_REGISTRY: Final[dict[str, dict[str, Any]]] = {
     "inspect": {
-        "description": "Assemble one flow by sys_id or name: header, triggers, inputs/outputs/variables, decoded V2 nodes, canvas tree, snapshot drift.",
+        "description": "Assemble one flow by sys_id or name: header, triggers, inputs/outputs/variables, decoded V2 nodes with resolved datapill refs, canvas tree, snapshot drift.",
+        "params": {"sys_id": "str (32-char)", "name": "str"},
+    },
+    "summary": {
+        "description": "Compact projection of inspect: single resolved trigger, flat ordered steps, branch-only tree, global datapill graph, and counts.",
         "params": {"sys_id": "str (32-char)", "name": "str"},
     },
     "find_by_table": {
@@ -128,8 +151,36 @@ def _index_by_sys_id(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return indexed
 
 
+def _safe_int(value: str) -> int:
+    """Best-effort int conversion for sorting; non-numeric sorts last."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 10**9
+
+
+def _flatten_record(row: dict[str, Any]) -> dict[str, Any]:
+    """Collapse a display_value=all row to its raw ``value`` per field, dropping boilerplate calculation."""
+    flat: dict[str, Any] = {key: _v(val) for key, val in row.items()}
+    if flat.get("calculation") == _CALCULATION_BOILERPLATE:
+        flat.pop("calculation", None)
+    return flat
+
+
+def _walk_strings(value: Any) -> Iterator[str]:
+    """Yield every string leaf in a nested dict/list/scalar."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _walk_strings(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _walk_strings(v)
+
+
 # ---------------------------------------------------------------------------
-# inspect
+# inspect / summary - canvas node and trigger builders
 # ---------------------------------------------------------------------------
 
 
@@ -237,13 +288,184 @@ def _v1_trigger_entry(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Datapill resolution
+# ---------------------------------------------------------------------------
+
+
+def _build_canvas_map(flat_nodes: list[dict[str, Any]]) -> dict[str, dict[str, str]]:
+    """Map each canvas node's ``ui_uuid`` to its identifying metadata.
+
+    Built from the flat node list (pre-nesting) so all nodes are included
+    regardless of branch depth.
+    """
+    canvas_map: dict[str, dict[str, str]] = {}
+    for node in flat_nodes:
+        uuid = node["ui_uuid"]
+        if not uuid:
+            continue
+        action_type = node.get("action_type")
+        action_type_name = action_type.get("name", "") if isinstance(action_type, dict) else ""
+        canvas_map[uuid] = {
+            "sys_id": node["sys_id"],
+            "name": node["label"] or node["name"],
+            "action_type_name": action_type_name,
+        }
+    return canvas_map
+
+
+def _find_datapill_refs_in(decoded: Any) -> list[tuple[str, str, str]]:
+    """Find every ``{{uuid.field}}`` ref in a decoded payload.
+
+    Returns ``[(raw_ref, producer_ui_uuid, field), ...]`` preserving order
+    of first appearance, deduplicated by ``(producer_ui_uuid, field)``.
+    """
+    refs: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for s in _walk_strings(decoded):
+        for match in _DATAPILL_PATTERN.finditer(s):
+            key = (match.group(1), match.group(2))
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append((match.group(0), match.group(1), match.group(2)))
+    return refs
+
+
+def _resolve_refs_for_node(
+    node: dict[str, Any],
+    canvas_map: dict[str, dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Annotate one node's datapill refs with producer metadata."""
+    decoded = node.get("values_decoded")
+    if decoded is None:
+        return []
+    resolved: list[dict[str, Any]] = []
+    for raw, producer_uuid, field in _find_datapill_refs_in(decoded):
+        producer = canvas_map.get(producer_uuid)
+        resolved.append(
+            {
+                "ref": raw,
+                "field": field,
+                "producer_ui_uuid": producer_uuid,
+                "producer_sys_id": producer["sys_id"] if producer else "",
+                "producer_name": producer["name"] if producer else "",
+                "resolved": producer is not None,
+            }
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Warnings
+# ---------------------------------------------------------------------------
+
+
+def _detect_order_gaps(roots: list[dict[str, Any]]) -> bool:
+    """Return True if any sibling group on the canvas has a discontinuous order sequence.
+
+    A "gap" is detected at any nesting level with at least three sibling
+    nodes when the consecutive order deltas are not uniform (max delta
+    exceeds min delta). This catches both classic Flow spacing skips
+    (100 -> 200 -> 400) and tight sequences (...9 -> 11...).
+    """
+    if not roots:
+        return False
+
+    def _level_has_gap(siblings: list[dict[str, Any]]) -> bool:
+        orders = sorted({_safe_int(n["order"]) for n in siblings})
+        if len(orders) >= 3:
+            deltas = [orders[i + 1] - orders[i] for i in range(len(orders) - 1)]
+            if min(deltas) > 0 and max(deltas) > min(deltas):
+                return True
+        return any(_level_has_gap(n.get("children", [])) for n in siblings)
+
+    return _level_has_gap(roots)
+
+
+def _build_warnings(
+    *,
+    flow_active: bool,
+    drift: bool,
+    master: str,
+    latest: str,
+    actions_v1: list[dict[str, Any]],
+    logic_v1: list[dict[str, Any]],
+    triggers_v1: list[dict[str, Any]],
+    actions_v2: list[dict[str, Any]],
+    logic_v2: list[dict[str, Any]],
+    triggers_v2_entries: list[dict[str, Any]],
+    action_type_lookup: dict[str, dict[str, Any]],
+    canvas: list[dict[str, Any]],
+    unresolved_refs: dict[str, str],
+    decode_failure_count: int,
+) -> list[str]:
+    """Assemble the full warning list shared by ``inspect`` and ``summary``."""
+    warnings: list[str] = []
+
+    if drift:
+        warnings.append(
+            f"snapshot drift: master_snapshot={master!r} differs from latest_snapshot={latest!r}; "
+            "the runtime engine and the latest design may not agree."
+        )
+
+    if (actions_v1 or logic_v1 or triggers_v1) and (actions_v2 or logic_v2 or triggers_v2_entries):
+        warnings.append("V1 and V2 Flow Designer artifacts coexist on this flow; canvas omits V1 nodes.")
+
+    if logic_v1:
+        warnings.append(
+            f"{len(logic_v1)} V1 logic instance(s) present; their semantics are not reflected in the canvas tree."
+        )
+
+    spoke_actions = [
+        meta
+        for meta in action_type_lookup.values()
+        if "spoke" in _v(meta.get("category")).lower() or "spoke" in _v(meta.get("sys_scope")).lower()
+    ]
+    if spoke_actions:
+        warnings.append(
+            f"{len(spoke_actions)} spoke action type(s) referenced; their decoded values may depend on scoped types."
+        )
+
+    if flow_active and triggers_v2_entries and not any(t["active"] for t in triggers_v2_entries):
+        warnings.append("flow_active_with_inactive_trigger: flow.active=true but no V2 trigger is active.")
+
+    for entry in triggers_v2_entries:
+        if entry["remote_trigger_id"] and not entry["condition"]:
+            warnings.append(
+                f"missing_record_trigger_condition: V2 trigger {entry['sys_id']!r} has remote_trigger_id "
+                f"{entry['remote_trigger_id']!r} but the stitched condition is empty."
+            )
+
+    if _detect_order_gaps(canvas):
+        warnings.append("canvas_order_gap: sibling step orders are not uniformly spaced on at least one branch.")
+
+    for producer_uuid, consumer_sys_id in unresolved_refs.items():
+        warnings.append(
+            f"unresolved_datapill_ref: producer_ui_uuid={producer_uuid!r} is referenced by step "
+            f"{consumer_sys_id!r} but is not present on the canvas."
+        )
+
+    if decode_failure_count:
+        warnings.append(
+            f"step_decode_failure: {decode_failure_count} canvas node(s) failed to decode their values blob."
+        )
+
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Bundle loader (shared by inspect and summary)
+# ---------------------------------------------------------------------------
+
+
 async def _resolve_inspect_sys_id(
     client: ServiceNowClient,
     sys_id: str,
     name: str,
     correlation_id: str,
 ) -> tuple[str, str | None]:
-    """Resolve the flow ``sys_id`` for ``inspect``.
+    """Resolve the flow ``sys_id`` for ``inspect``/``summary``.
 
     Returns ``(resolved_sys_id, error_envelope_or_none)``. When ``sys_id``
     is provided it is returned unchanged; otherwise ``name`` is looked up
@@ -266,42 +488,112 @@ async def _resolve_inspect_sys_id(
     return resolved, None
 
 
-def _build_inspect_warnings(
-    *,
-    drift: bool,
-    master: str,
-    latest: str,
-    actions_v1: list[dict[str, Any]],
-    logic_v1: list[dict[str, Any]],
-    triggers_v1: list[dict[str, Any]],
-    actions_v2: list[dict[str, Any]],
-    logic_v2: list[dict[str, Any]],
-    triggers_v2: list[dict[str, Any]],
-    action_type_lookup: dict[str, dict[str, Any]],
-) -> list[str]:
-    """Assemble the ``inspect`` warning list (drift, V1/V2 coexistence, spokes)."""
-    warnings: list[str] = []
-    if drift:
-        warnings.append(
-            f"snapshot drift: master_snapshot={master!r} differs from latest_snapshot={latest!r}; "
-            "the runtime engine and the latest design may not agree."
-        )
-    if (actions_v1 or logic_v1 or triggers_v1) and (actions_v2 or logic_v2 or triggers_v2):
-        warnings.append("V1 and V2 Flow Designer artifacts coexist on this flow; canvas omits V1 nodes.")
-    if logic_v1:
-        warnings.append(
-            f"{len(logic_v1)} V1 logic instance(s) present; their semantics are not reflected in the canvas tree."
-        )
-    spoke_actions = [
-        meta
-        for meta in action_type_lookup.values()
-        if "spoke" in _v(meta.get("category")).lower() or "spoke" in _v(meta.get("sys_scope")).lower()
+async def _load_flow_bundle(
+    client: ServiceNowClient,
+    resolved_sys_id: str,
+) -> dict[str, Any] | None:
+    """Fetch and assemble every artifact needed by ``inspect`` and ``summary``.
+
+    Returns a bundle with raw rows, the assembled canvas (with datapill
+    refs attached to every node), trigger entries, and lookup tables.
+    Returns ``None`` if the flow header is missing.
+    """
+    header = await client.get_flow_by_sys_id(resolved_sys_id)
+    if header is None:
+        return None
+
+    inputs = await client.list_flow_inputs(resolved_sys_id)
+    outputs = await client.list_flow_outputs(resolved_sys_id)
+    variables = await client.list_flow_variables(resolved_sys_id)
+    actions_v2 = await client.list_action_instances_v2(resolved_sys_id)
+    actions_v1 = await client.list_action_instances_v1(resolved_sys_id)
+    logic_v2 = await client.list_logic_instances_v2(resolved_sys_id)
+    logic_v1 = await client.list_logic_instances_v1(resolved_sys_id)
+    triggers_v2 = await client.list_trigger_instances_v2(resolved_sys_id)
+    triggers_v1 = await client.list_trigger_instances_v1(resolved_sys_id)
+
+    remote_ids = sorted({_v(t.get("remote_trigger_id")) for t in triggers_v2 if _v(t.get("remote_trigger_id"))})
+    record_triggers = await client.list_record_triggers(remote_ids) if remote_ids else []
+
+    action_type_ids = sorted({_v(a.get("action_type")) for a in actions_v2 if _v(a.get("action_type"))})
+    action_type_rows = await client.get_action_type_definitions(action_type_ids) if action_type_ids else []
+
+    v1_action_ids = sorted({_v(a.get("sys_id")) for a in actions_v1 if _v(a.get("sys_id"))})
+    v1_variable_values = await client.list_v1_variable_values(v1_action_ids) if v1_action_ids else []
+
+    action_type_lookup = _index_by_sys_id(action_type_rows)
+    condition_lookup: dict[str, str] = {
+        _v(row.get("sys_id")): _v(row.get("condition")) for row in record_triggers if _v(row.get("sys_id"))
+    }
+
+    flat_nodes: list[dict[str, Any]] = [
+        _build_v2_node(row, kind="action", action_type_lookup=action_type_lookup) for row in actions_v2
     ]
-    if spoke_actions:
-        warnings.append(
-            f"{len(spoke_actions)} spoke action type(s) referenced; their decoded values may depend on scoped types."
-        )
-    return warnings
+    flat_nodes.extend(_build_v2_node(row, kind="logic") for row in logic_v2)
+    flat_nodes.sort(key=lambda n: _safe_int(n["order"]))
+
+    canvas_map = _build_canvas_map(flat_nodes)
+
+    # Attach datapill refs before nesting so we can walk the flat list and
+    # collect the global unresolved-producer set in one pass.
+    unresolved_refs: dict[str, str] = {}
+    decode_failure_count = 0
+    for node in flat_nodes:
+        if "decode_error" in node:
+            decode_failure_count += 1
+        refs = _resolve_refs_for_node(node, canvas_map)
+        if refs:
+            node["datapill_refs"] = refs
+            for ref in refs:
+                if not ref["resolved"] and ref["producer_ui_uuid"] not in unresolved_refs:
+                    unresolved_refs[ref["producer_ui_uuid"]] = node["sys_id"]
+
+    canvas = _assemble_canvas(flat_nodes)
+
+    triggers_v2_entries: list[dict[str, Any]] = [
+        _v2_trigger_entry(row, condition_lookup=condition_lookup) for row in triggers_v2
+    ]
+    triggers_v1_entries: list[dict[str, Any]] = [_v1_trigger_entry(row) for row in triggers_v1]
+
+    return {
+        "header": header,
+        "inputs": inputs,
+        "outputs": outputs,
+        "variables": variables,
+        "actions_v1": actions_v1,
+        "actions_v2": actions_v2,
+        "logic_v1": logic_v1,
+        "logic_v2": logic_v2,
+        "triggers_v1_rows": triggers_v1,
+        "triggers_v2_rows": triggers_v2,
+        "v1_variable_values": v1_variable_values,
+        "action_type_lookup": action_type_lookup,
+        "flat_nodes": flat_nodes,
+        "canvas_map": canvas_map,
+        "canvas": canvas,
+        "triggers_v2_entries": triggers_v2_entries,
+        "triggers_v1_entries": triggers_v1_entries,
+        "unresolved_refs": unresolved_refs,
+        "decode_failure_count": decode_failure_count,
+    }
+
+
+def _flow_header_payload(header: dict[str, Any]) -> dict[str, Any]:
+    """Build the shared ``flow`` header sub-object used by inspect and summary."""
+    return {
+        "sys_id": _v(header.get("sys_id")),
+        "name": _d(header.get("name")),
+        "internal_name": _v(header.get("internal_name")),
+        "type": _v(header.get("type")),
+        "active": _v(header.get("active")) == "true",
+        "description": _v(header.get("description")),
+        "sys_scope": _d(header.get("sys_scope")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# inspect
+# ---------------------------------------------------------------------------
 
 
 async def _action_inspect(
@@ -323,103 +615,223 @@ async def _action_inspect(
         resolved_sys_id, err = await _resolve_inspect_sys_id(client, sys_id, name, correlation_id)
         if err is not None:
             return err
-
-        header = await client.get_flow_by_sys_id(resolved_sys_id)
-        if header is None:
+        bundle = await _load_flow_bundle(client, resolved_sys_id)
+        if bundle is None:
             return _error(correlation_id, f"Flow {resolved_sys_id} not found.")
 
-        inputs = await client.list_flow_inputs(resolved_sys_id)
-        outputs = await client.list_flow_outputs(resolved_sys_id)
-        variables = await client.list_flow_variables(resolved_sys_id)
-        actions_v2 = await client.list_action_instances_v2(resolved_sys_id)
-        actions_v1 = await client.list_action_instances_v1(resolved_sys_id)
-        logic_v2 = await client.list_logic_instances_v2(resolved_sys_id)
-        logic_v1 = await client.list_logic_instances_v1(resolved_sys_id)
-        triggers_v2 = await client.list_trigger_instances_v2(resolved_sys_id)
-        triggers_v1 = await client.list_trigger_instances_v1(resolved_sys_id)
-
-        remote_ids = sorted({_v(t.get("remote_trigger_id")) for t in triggers_v2 if _v(t.get("remote_trigger_id"))})
-        record_triggers = await client.list_record_triggers(remote_ids) if remote_ids else []
-
-        action_type_ids = sorted({_v(a.get("action_type")) for a in actions_v2 if _v(a.get("action_type"))})
-        action_type_rows = await client.get_action_type_definitions(action_type_ids) if action_type_ids else []
-
-        v1_action_ids = sorted({_v(a.get("sys_id")) for a in actions_v1 if _v(a.get("sys_id"))})
-        v1_variable_values = await client.list_v1_variable_values(v1_action_ids) if v1_action_ids else []
-
-    # Build lookups.
-    action_type_lookup = _index_by_sys_id(action_type_rows)
-    condition_lookup: dict[str, str] = {
-        _v(row.get("sys_id")): _v(row.get("condition")) for row in record_triggers if _v(row.get("sys_id"))
-    }
-
-    # Build canvas nodes (actions + logic, both V2), sorted by ``order``.
-    nodes: list[dict[str, Any]] = [
-        _build_v2_node(row, kind="action", action_type_lookup=action_type_lookup) for row in actions_v2
-    ]
-    nodes.extend(_build_v2_node(row, kind="logic") for row in logic_v2)
-    nodes.sort(key=lambda n: _safe_int(n["order"]))
-    canvas = _assemble_canvas(nodes)
-
-    # Triggers - V2 first (stitched), then V1.
-    triggers: list[dict[str, Any]] = [_v2_trigger_entry(row, condition_lookup=condition_lookup) for row in triggers_v2]
-    triggers.extend(_v1_trigger_entry(row) for row in triggers_v1)
-
+    header = bundle["header"]
     master = _v(header.get("master_snapshot"))
     latest = _v(header.get("latest_snapshot"))
     drift = bool(master and latest and master != latest)
+    flow_payload = _flow_header_payload(header)
 
-    warnings = _build_inspect_warnings(
+    triggers: list[dict[str, Any]] = list(bundle["triggers_v2_entries"])
+    triggers.extend(bundle["triggers_v1_entries"])
+
+    warnings = _build_warnings(
+        flow_active=flow_payload["active"],
         drift=drift,
         master=master,
         latest=latest,
-        actions_v1=actions_v1,
-        logic_v1=logic_v1,
-        triggers_v1=triggers_v1,
-        actions_v2=actions_v2,
-        logic_v2=logic_v2,
-        triggers_v2=triggers_v2,
-        action_type_lookup=action_type_lookup,
+        actions_v1=bundle["actions_v1"],
+        logic_v1=bundle["logic_v1"],
+        triggers_v1=bundle["triggers_v1_rows"],
+        actions_v2=bundle["actions_v2"],
+        logic_v2=bundle["logic_v2"],
+        triggers_v2_entries=bundle["triggers_v2_entries"],
+        action_type_lookup=bundle["action_type_lookup"],
+        canvas=bundle["canvas"],
+        unresolved_refs=bundle["unresolved_refs"],
+        decode_failure_count=bundle["decode_failure_count"],
     )
 
     payload: dict[str, Any] = {
-        "flow": {
-            "sys_id": _v(header.get("sys_id")),
-            "name": _d(header.get("name")),
-            "internal_name": _v(header.get("internal_name")),
-            "type": _v(header.get("type")),
-            "active": _v(header.get("active")) == "true",
-            "description": _v(header.get("description")),
-            "sys_scope": _d(header.get("sys_scope")),
-        },
+        "flow": flow_payload,
         "published_state": {
             "master_snapshot": master,
             "latest_snapshot": latest,
             "drift": drift,
         },
-        "inputs": [_flatten_record(row) for row in inputs],
-        "outputs": [_flatten_record(row) for row in outputs],
-        "variables": [_flatten_record(row) for row in variables],
+        "inputs": [_flatten_record(row) for row in bundle["inputs"]],
+        "outputs": [_flatten_record(row) for row in bundle["outputs"]],
+        "variables": [_flatten_record(row) for row in bundle["variables"]],
         "triggers": triggers,
-        "canvas": canvas,
-        "v1_actions": [_flatten_record(row) for row in actions_v1],
-        "v1_variable_values": [_flatten_record(row) for row in v1_variable_values],
+        "canvas": bundle["canvas"],
         "warnings": warnings,
     }
+
+    # v1_actions / v1_variable_values are noise on the modern (V2-only)
+    # flows that dominate real installs; surface them only when populated.
+    if bundle["actions_v1"]:
+        payload["v1_actions"] = [_flatten_record(row) for row in bundle["actions_v1"]]
+    if bundle["v1_variable_values"]:
+        payload["v1_variable_values"] = [_flatten_record(row) for row in bundle["v1_variable_values"]]
+
     return format_response(data=payload, correlation_id=correlation_id)
 
 
-def _safe_int(value: str) -> int:
-    """Best-effort int conversion for sorting; non-numeric sorts last."""
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 10**9
+# ---------------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------------
 
 
-def _flatten_record(row: dict[str, Any]) -> dict[str, Any]:
-    """Collapse a display_value=all row to its raw ``value`` per field."""
-    return {key: _v(val) for key, val in row.items()}
+def _summary_trigger(triggers_v2_entries: list[dict[str, Any]]) -> dict[str, Any]:
+    """Flatten triggers to a single, leaner object - first V2 trigger wins.
+
+    Real flows have one trigger; the array shape on ``inspect`` exists to
+    cover edge cases. ``summary`` always returns the same flat object,
+    using sentinel values when no V2 trigger exists.
+    """
+    if not triggers_v2_entries:
+        return {"type": "", "table": "", "active": False, "condition": ""}
+    first = triggers_v2_entries[0]
+    return {
+        "type": first["type"],
+        "table": first["table"],
+        "active": first["active"],
+        "condition": first["condition"],
+    }
+
+
+def _summary_steps(
+    flat_nodes: list[dict[str, Any]],
+    parent_lookup: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project the flat node list down to summary step rows.
+
+    Each step carries enough identity (``sys_id``, ``ui_uuid``, ``order``,
+    ``kind``, ``name``, ``label``, ``comment``) and branch context
+    (``branch_parent_ui_uuid``, ``branch_label``) to be useful on its own
+    without the heavy ``values_decoded`` payload.
+    """
+    steps: list[dict[str, Any]] = []
+    for node in flat_nodes:
+        action_type = node.get("action_type") or {}
+        resolved_name = action_type.get("name", "") if isinstance(action_type, dict) else ""
+        parent_id = node["parent_ui_id"]
+        parent = parent_lookup.get(parent_id)
+        steps.append(
+            {
+                "order": _safe_int(node["order"]),
+                "sys_id": node["sys_id"],
+                "ui_uuid": node["ui_uuid"],
+                "kind": node["kind"],
+                "name": resolved_name or node["name"],
+                "label": node["label"],
+                "comment": node["comment"],
+                "branch_parent_ui_uuid": parent_id,
+                "branch_label": parent["label"] if parent else "",
+            }
+        )
+    return steps
+
+
+def _summary_branches(canvas: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Strip decoded values + datapill refs from the canvas tree, keep structure only."""
+    return [
+        {
+            "ui_uuid": node["ui_uuid"],
+            "sys_id": node["sys_id"],
+            "order": _safe_int(node["order"]),
+            "name": node["label"] or node["name"],
+            "children": _summary_branches(node.get("children", [])),
+        }
+        for node in canvas
+    ]
+
+
+def _summary_datapill_graph(
+    flat_nodes: list[dict[str, Any]],
+    canvas_map: dict[str, dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Flatten every node's datapill refs into a single graph of consumer->producer edges."""
+    graph: list[dict[str, Any]] = []
+    for node in flat_nodes:
+        for ref in node.get("datapill_refs", []):
+            producer = canvas_map.get(ref["producer_ui_uuid"])
+            graph.append(
+                {
+                    "consumer_step_sys_id": node["sys_id"],
+                    "consumer_field": ref["field"],
+                    "producer_ui_uuid": ref["producer_ui_uuid"],
+                    "producer_sys_id_if_resolved": producer["sys_id"] if producer else "",
+                    "producer_name_if_resolved": producer["name"] if producer else "",
+                    "raw_reference": ref["ref"],
+                }
+            )
+    return graph
+
+
+async def _action_summary(
+    *,
+    sys_id: str,
+    name: str,
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+    correlation_id: str,
+) -> str:
+    if sys_id and name:
+        return _error(correlation_id, "Provide exactly one of sys_id or name (not both).")
+    if not sys_id and not name:
+        return _error(correlation_id, "Either sys_id or name is required.")
+    if sys_id:
+        validate_sys_id(sys_id)
+
+    async with ServiceNowClient(settings, auth_provider) as client:
+        resolved_sys_id, err = await _resolve_inspect_sys_id(client, sys_id, name, correlation_id)
+        if err is not None:
+            return err
+        bundle = await _load_flow_bundle(client, resolved_sys_id)
+        if bundle is None:
+            return _error(correlation_id, f"Flow {resolved_sys_id} not found.")
+
+    header = bundle["header"]
+    master = _v(header.get("master_snapshot"))
+    latest = _v(header.get("latest_snapshot"))
+    drift = bool(master and latest and master != latest)
+    flow_payload = _flow_header_payload(header)
+
+    parent_lookup: dict[str, dict[str, Any]] = {
+        node["ui_uuid"]: node for node in bundle["flat_nodes"] if node["ui_uuid"]
+    }
+
+    actions_v2 = bundle["actions_v2"]
+    logic_v2 = bundle["logic_v2"]
+    warnings = _build_warnings(
+        flow_active=flow_payload["active"],
+        drift=drift,
+        master=master,
+        latest=latest,
+        actions_v1=bundle["actions_v1"],
+        logic_v1=bundle["logic_v1"],
+        triggers_v1=bundle["triggers_v1_rows"],
+        actions_v2=actions_v2,
+        logic_v2=logic_v2,
+        triggers_v2_entries=bundle["triggers_v2_entries"],
+        action_type_lookup=bundle["action_type_lookup"],
+        canvas=bundle["canvas"],
+        unresolved_refs=bundle["unresolved_refs"],
+        decode_failure_count=bundle["decode_failure_count"],
+    )
+
+    payload: dict[str, Any] = {
+        "flow": flow_payload,
+        "trigger": _summary_trigger(bundle["triggers_v2_entries"]),
+        "steps": _summary_steps(bundle["flat_nodes"], parent_lookup),
+        "branches": _summary_branches(bundle["canvas"]),
+        "datapill_graph": _summary_datapill_graph(bundle["flat_nodes"], bundle["canvas_map"]),
+        "warnings": warnings,
+        "counts": {
+            "steps": len(bundle["flat_nodes"]),
+            "actions": len(actions_v2),
+            "logic": len(logic_v2),
+            "triggers": len(bundle["triggers_v2_entries"]) + len(bundle["triggers_v1_entries"]),
+            "inputs": len(bundle["inputs"]),
+            "outputs": len(bundle["outputs"]),
+            "variables": len(bundle["variables"]),
+        },
+    }
+    return format_response(data=payload, correlation_id=correlation_id)
 
 
 # ---------------------------------------------------------------------------
@@ -650,9 +1062,9 @@ def register_tools(
         """Inspect Flow Designer flows, triggers, and value blobs (read-only).
 
         Args:
-            action: 'inspect' | 'find_by_table' | 'decode_values' | 'list_triggers' | 'describe'.
-            sys_id: Flow sys_id (inspect; mutually exclusive with name).
-            name: Flow name (inspect; mutually exclusive with sys_id).
+            action: 'inspect' | 'summary' | 'find_by_table' | 'decode_values' | 'list_triggers' | 'describe'.
+            sys_id: Flow sys_id (inspect/summary; mutually exclusive with name).
+            name: Flow name (inspect/summary; mutually exclusive with sys_id).
             value: gzip+base64+JSON blob to decode (decode_values).
             table: Target table (find_by_table; optional filter for list_triggers).
             trigger_type: Trigger type filter (list_triggers, e.g. 'record_update').
@@ -673,6 +1085,15 @@ def register_tools(
 
         if action == "inspect":
             return await _action_inspect(
+                sys_id=sys_id,
+                name=name,
+                settings=settings,
+                auth_provider=auth_provider,
+                correlation_id=correlation_id,
+            )
+
+        if action == "summary":
+            return await _action_summary(
                 sys_id=sys_id,
                 name=name,
                 settings=settings,

--- a/src/servicenow_mcp/tools/flow.py
+++ b/src/servicenow_mcp/tools/flow.py
@@ -49,7 +49,7 @@ _DEFAULT_TRIGGER_LIMIT: Final[int] = 100
 # canvas UUID (lowercase hex with dashes, 36 chars). The field part may
 # contain dots, brackets, and underscores; we capture lazily up to the
 # closing braces.
-_DATAPILL_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{\{([0-9a-f-]{36})\.([^}]+)\}\}")
+_DATAPILL_PATTERN: Final[re.Pattern[str]] = re.compile(r"\{\{([0-9a-fA-F-]{36})\.([^}]+)\}\}")
 
 # Verbatim "Add your code here" stub Flow Designer drops into every new
 # calculated-field input/output/variable. Stripping it keeps real custom
@@ -306,7 +306,7 @@ def _build_canvas_map(flat_nodes: list[dict[str, Any]]) -> dict[str, dict[str, s
             continue
         action_type = node.get("action_type")
         action_type_name = action_type.get("name", "") if isinstance(action_type, dict) else ""
-        canvas_map[uuid] = {
+        canvas_map[uuid.lower()] = {
             "sys_id": node["sys_id"],
             "name": node["label"] or node["name"],
             "action_type_name": action_type_name,
@@ -342,7 +342,7 @@ def _resolve_refs_for_node(
         return []
     resolved: list[dict[str, Any]] = []
     for raw, producer_uuid, field in _find_datapill_refs_in(decoded):
-        producer = canvas_map.get(producer_uuid)
+        producer = canvas_map.get(producer_uuid.lower())
         resolved.append(
             {
                 "ref": raw,
@@ -438,7 +438,7 @@ def _build_warnings(
             )
 
     if _detect_order_gaps(canvas):
-        warnings.append("canvas_order_gap: sibling step orders are not uniformly spaced on at least one branch.")
+        warnings.append("canvas_order_nonuniform: sibling step orders are not uniformly spaced on at least one branch.")
 
     for producer_uuid, consumer_sys_id in unresolved_refs.items():
         warnings.append(
@@ -748,7 +748,7 @@ def _summary_datapill_graph(
     graph: list[dict[str, Any]] = []
     for node in flat_nodes:
         for ref in node.get("datapill_refs", []):
-            producer = canvas_map.get(ref["producer_ui_uuid"])
+            producer = canvas_map.get(ref["producer_ui_uuid"].lower())
             graph.append(
                 {
                     "consumer_step_sys_id": node["sys_id"],

--- a/src/servicenow_mcp/tools/flow.py
+++ b/src/servicenow_mcp/tools/flow.py
@@ -15,7 +15,9 @@ Six actions:
 
 The decoder lives in :mod:`servicenow_mcp.tools._flow_values`; canvas-tree
 assembly stays inline. We deliberately do not touch ``/api/now/processflow/*``
-endpoints (undocumented) or ``sys_hub_flow_snapshot`` (opaque cache).
+endpoints (undocumented). ``sys_hub_flow_snapshot`` itself is opaque, but
+its plain-JSON ``label_cache`` column is read to enrich the
+``unresolved_datapill_ref`` warning with last-known producer step labels.
 """
 
 from __future__ import annotations
@@ -470,7 +472,8 @@ def _build_warnings(
     logic_v2: list[dict[str, Any]],
     triggers_v2_entries: list[dict[str, Any]],
     action_type_lookup: dict[str, dict[str, Any]],
-    unresolved_refs: dict[str, str],
+    unresolved_refs: dict[str, list[tuple[int, str]]],
+    snapshot_label_map: dict[str, str],
     decode_failure_count: int,
 ) -> list[str]:
     """Assemble the warning list shared by ``inspect`` and ``summary``."""
@@ -500,11 +503,13 @@ def _build_warnings(
             f"{len(spoke_actions)} spoke action type(s) referenced; their decoded values may depend on scoped types."
         )
 
-    for producer_uid, consumer_sys_id in unresolved_refs.items():
-        warnings.append(
-            f"unresolved_datapill_ref: producer_ui_id={producer_uid!r} is referenced by step "
-            f"{consumer_sys_id!r} but is not present on the canvas."
-        )
+    for producer_uid, consumers in unresolved_refs.items():
+        consumers_sorted = sorted(consumers, key=lambda c: c[0])
+        orders = ", ".join(str(order) for order, _ in consumers_sorted)
+        fields = ", ".join(field for _, field in consumers_sorted)
+        label = snapshot_label_map.get(producer_uid.lower())
+        head = f"producer {label!r} (deleted; ui_id={producer_uid!r})" if label else f"producer_ui_id={producer_uid!r}"
+        warnings.append(f"unresolved_datapill_ref: {head} referenced by orders {orders} (fields: {fields})")
 
     if decode_failure_count:
         warnings.append(
@@ -562,6 +567,14 @@ async def _load_flow_bundle(
     if header is None:
         return None
 
+    # Fetch the published snapshot's label_cache (plain JSON column,
+    # unlike the gzip+base64 ``values`` blobs). It preserves last-known
+    # step labels and so resolves the names of producers that have since
+    # been deleted from the canvas - the only data point that lets us
+    # enrich ``unresolved_datapill_ref`` warnings with a human name.
+    latest_snapshot_id = _v(header.get("latest_snapshot"))
+    snapshot_label_map = await client.get_flow_snapshot_label_cache(latest_snapshot_id) if latest_snapshot_id else {}
+
     inputs = await client.list_flow_inputs(resolved_sys_id)
     outputs = await client.list_flow_outputs(resolved_sys_id)
     variables = await client.list_flow_variables(resolved_sys_id)
@@ -607,8 +620,10 @@ async def _load_flow_bundle(
     canvas_map = _build_canvas_map(flat_nodes)
 
     # Attach datapill refs before nesting so we can walk the flat list and
-    # collect the global unresolved-producer set in one pass.
-    unresolved_refs: dict[str, str] = {}
+    # collect the global unresolved-producer set in one pass. Each entry
+    # in ``unresolved_refs`` records every consumer (order, field) pair so
+    # the warning can name them all.
+    unresolved_refs: dict[str, list[tuple[int, str]]] = {}
     decode_failure_count = 0
     for node in flat_nodes:
         if "decode_error" in node:
@@ -617,8 +632,10 @@ async def _load_flow_bundle(
         if refs:
             node["datapill_refs"] = refs
             for ref in refs:
-                if not ref["resolved"] and ref["producer_ui_id"] not in unresolved_refs:
-                    unresolved_refs[ref["producer_ui_id"]] = node["sys_id"]
+                if not ref["resolved"]:
+                    unresolved_refs.setdefault(ref["producer_ui_id"], []).append(
+                        (_safe_int(node["order"]), ref["field"])
+                    )
 
     canvas = _assemble_canvas(flat_nodes)
 
@@ -645,6 +662,7 @@ async def _load_flow_bundle(
         "triggers_v2_entries": triggers_v2_entries,
         "triggers_v1_entries": triggers_v1_entries,
         "unresolved_refs": unresolved_refs,
+        "snapshot_label_map": snapshot_label_map,
         "decode_failure_count": decode_failure_count,
     }
 
@@ -711,6 +729,7 @@ async def _action_inspect(
         triggers_v2_entries=bundle["triggers_v2_entries"],
         action_type_lookup=bundle["action_type_lookup"],
         unresolved_refs=bundle["unresolved_refs"],
+        snapshot_label_map=bundle["snapshot_label_map"],
         decode_failure_count=bundle["decode_failure_count"],
     )
 
@@ -882,6 +901,7 @@ async def _action_summary(
         triggers_v2_entries=bundle["triggers_v2_entries"],
         action_type_lookup=bundle["action_type_lookup"],
         unresolved_refs=bundle["unresolved_refs"],
+        snapshot_label_map=bundle["snapshot_label_map"],
         decode_failure_count=bundle["decode_failure_count"],
     )
 

--- a/src/servicenow_mcp/tools/flow.py
+++ b/src/servicenow_mcp/tools/flow.py
@@ -619,6 +619,21 @@ async def _load_flow_bundle(
 
     canvas_map = _build_canvas_map(flat_nodes)
 
+    # Index V1 action instances by ui_uuid so that datapill
+    # references to subflow-call nodes (which are stored as V1 rows
+    # on the instance) resolve correctly.
+    for v1_row in actions_v1:
+        uid = _v(v1_row.get("ui_uuid"))
+        if not uid:
+            continue
+        # V2 wins if there's a conflict (unlikely but safe)
+        if uid.lower() not in canvas_map:
+            canvas_map[uid.lower()] = {
+                "sys_id": _v(v1_row.get("sys_id")),
+                "name": _d(v1_row.get("name")),
+                "action_type_name": _d(v1_row.get("action_type")),
+            }
+
     # Attach datapill refs before nesting so we can walk the flat list and
     # collect the global unresolved-producer set in one pass. Each entry
     # in ``unresolved_refs`` records every consumer (order, field) pair so

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1518,3 +1518,26 @@ class TestServiceNowClientFlowDesigner:
 
         async with ServiceNowClient(settings, auth_provider) as client:
             assert await client.get_flows_bulk([]) == []
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_list_flow_variables_filters_by_model_not_flow(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """``list_flow_variables`` must filter on ``model=``, not ``flow=``.
+
+        Using ``flow=`` makes ServiceNow silently ignore the filter and
+        return every row in ``sys_hub_flow_variable`` (hundreds across all
+        action_types), which is the bug this assertion guards.
+        """
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow_variable").mock(
+            return_value=httpx.Response(200, json={"result": []}),
+        )
+        flow_id = "f" * 32
+        async with ServiceNowClient(settings, auth_provider) as client:
+            await client.list_flow_variables(flow_id)
+
+        query = route.calls.last.request.url.params["sysparm_query"]
+        assert query == f"model={flow_id}^ORDERBYorder"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1416,6 +1416,74 @@ class TestServiceNowClientFlowDesigner:
 
     @pytest.mark.asyncio()
     @respx.mock
+    async def test_get_flow_snapshot_label_cache_parses_plain_json(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """``label_cache`` is plain JSON; entries collapse to ``ui_id -> step label``."""
+        import json as _json
+
+        from servicenow_mcp.client import ServiceNowClient
+
+        producer = "40fe31e9-c64d-4ea3-8a03-03615894a2f4"
+        payload = _json.dumps(
+            [
+                {"name": f"{producer}.status", "label": "10 - Provision AD Group Membership\u279bstatus"},
+                {"name": f"{producer}.message", "label": "10 - Provision AD Group Membership\u279bmessage"},
+            ]
+        )
+        snap_id = "d55117088715cb508643202cbbbb3567"
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow_snapshot/{snap_id}").mock(
+            return_value=httpx.Response(200, json={"result": {"label_cache": payload}}),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            label_map = await client.get_flow_snapshot_label_cache(snap_id)
+
+        assert route.calls.last.request.url.params["sysparm_fields"] == "label_cache"
+        assert label_map == {producer: "10 - Provision AD Group Membership"}
+
+    @pytest.mark.asyncio()
+    async def test_get_flow_snapshot_label_cache_empty_sys_id_no_http_call(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """An empty sys_id short-circuits to ``{}`` without an HTTP call."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            assert await client.get_flow_snapshot_label_cache("") == {}
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_get_flow_snapshot_label_cache_404_returns_empty(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """A missing snapshot row yields ``{}`` instead of raising."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow_snapshot/missing").mock(
+            return_value=httpx.Response(404, json={"error": {"message": "no record"}}),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            assert await client.get_flow_snapshot_label_cache("missing") == {}
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_get_flow_snapshot_label_cache_blank_column_returns_empty(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """An empty ``label_cache`` column yields ``{}`` without raising."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow_snapshot/snap1").mock(
+            return_value=httpx.Response(200, json={"result": {"label_cache": ""}}),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            assert await client.get_flow_snapshot_label_cache("snap1") == {}
+
+    @pytest.mark.asyncio()
+    @respx.mock
     async def test_find_flows_by_name_builds_or_query(
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1456,15 +1456,67 @@ class TestServiceNowClientFlowDesigner:
 
     @pytest.mark.asyncio()
     @respx.mock
-    async def test_list_record_triggers_empty_input_no_http_call(
+    async def test_get_action_type_definitions_targets_base_table(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Action-type metadata is fetched from ``sys_hub_action_type_base``.
+
+        The ``_definition`` table does not exist on this platform and
+        responds 404; ``_base`` is the correct ref target.
+        """
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_action_type_base").mock(
+            return_value=httpx.Response(200, json={"result": []}),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            await client.get_action_type_definitions(["aaa", "bbb"])
+
+        query = route.calls.last.request.url.params["sysparm_query"]
+        assert query == "sys_idINaaa,bbb"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_get_action_type_definitions_empty_input_no_http_call(
         self, settings: Settings, auth_provider: BasicAuthProvider
     ) -> None:
         """Empty input short-circuits to ``[]`` without touching the network."""
         from servicenow_mcp.client import ServiceNowClient
 
-        # No respx route registered: any HTTP call would raise.
         async with ServiceNowClient(settings, auth_provider) as client:
-            result = await client.list_record_triggers([])
+            result = await client.get_action_type_definitions([])
+
+        assert result == []
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_get_logic_definitions_targets_logic_definition_table(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Logic-definition metadata is fetched from ``sys_hub_flow_logic_definition``."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        route = respx.get(f"{BASE_URL}/api/now/table/sys_hub_flow_logic_definition").mock(
+            return_value=httpx.Response(200, json={"result": []}),
+        )
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            await client.get_logic_definitions(["if_def", "else_def"])
+
+        query = route.calls.last.request.url.params["sysparm_query"]
+        assert query == "sys_idINif_def,else_def"
+
+    @pytest.mark.asyncio()
+    @respx.mock
+    async def test_get_logic_definitions_empty_input_no_http_call(
+        self, settings: Settings, auth_provider: BasicAuthProvider
+    ) -> None:
+        """Empty input short-circuits to ``[]`` without touching the network."""
+        from servicenow_mcp.client import ServiceNowClient
+
+        async with ServiceNowClient(settings, auth_provider) as client:
+            result = await client.get_logic_definitions([])
 
         assert result == []
 

--- a/tests/test_code_search.py
+++ b/tests/test_code_search.py
@@ -1,0 +1,222 @@
+"""Tests for the unified ``code_search`` tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import respx
+from httpx import Response
+
+from servicenow_mcp.auth import BasicAuthProvider
+from servicenow_mcp.config import Settings
+from tests.helpers import decode_response, get_tool_functions
+
+
+@pytest.fixture()
+def auth_provider(settings: Settings) -> BasicAuthProvider:
+    """BasicAuthProvider for the unified-tool test scope."""
+    return BasicAuthProvider(settings)
+
+
+INSTANCE_URL: str = "https://test.service-now.com"
+SEARCH_URL: str = f"{INSTANCE_URL}/api/sn_codesearch/code_search/search"
+TABLES_URL: str = f"{INSTANCE_URL}/api/sn_codesearch/code_search/tables"
+
+
+def _register_and_get_tools(settings: Settings, auth_provider: BasicAuthProvider) -> dict[str, Any]:
+    """Register the unified ``code_search`` tool on a fresh MCP and return callables."""
+    from mcp.server.fastmcp import FastMCP
+
+    from servicenow_mcp.tools.code_search import register_tools
+
+    mcp = FastMCP("test")
+    register_tools(mcp, settings, auth_provider)
+    return get_tool_functions(mcp)
+
+
+# ---------------------------------------------------------------------------
+# search action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_search_success(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """A successful code search returns formatted results."""
+    mock_response: dict[str, Any] = {
+        "result": [
+            {"table": "sys_script_include", "name": "MyScript", "match": "function myFunc()", "sys_id": "abc123"},
+            {"table": "sys_script_include", "name": "MyScript", "match": "function myFunc()", "sys_id": "def456"},
+        ],
+    }
+    with respx.mock:
+        respx.get(SEARCH_URL).mock(return_value=Response(200, json=mock_response))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["code_search"](action="search", term="myFunc")
+        result = decode_response(raw)
+
+    assert result["status"] == "success"
+    assert isinstance(result["data"], list)
+    assert len(result["data"]) == 2
+
+
+@pytest.mark.asyncio()
+async def test_search_empty_term(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """An empty search term is rejected with an error before any API call."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    raw = await tools["code_search"](action="search", term="")
+    result = decode_response(raw)
+
+    assert result["status"] == "error"
+    assert "term is required" in result["error"]["message"].lower()
+
+
+@pytest.mark.asyncio()
+async def test_search_with_table_filter(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """When ``table`` is provided it is passed through to the client."""
+    mock_response: dict[str, Any] = {"result": [{"table": "sys_script_include", "name": "MyScript", "match": "fn"}]}
+    with respx.mock:
+        route = respx.get(SEARCH_URL).mock(return_value=Response(200, json=mock_response))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["code_search"](action="search", term="fn", table="sys_script_include")
+        result = decode_response(raw)
+
+    assert result["status"] == "success"
+    # Verify table param was sent
+    assert route.calls.last.request.url.params.get("table") == "sys_script_include"
+
+
+@pytest.mark.asyncio()
+async def test_search_clamps_limit_above_max(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """A limit > 500 is clamped to 500."""
+    mock_response: dict[str, Any] = {"result": []}
+    with respx.mock:
+        route = respx.get(SEARCH_URL).mock(return_value=Response(200, json=mock_response))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["code_search"](action="search", term="fn", limit=9999)
+        result = decode_response(raw)
+
+    assert result["status"] == "success"
+    assert route.calls.last.request.url.params.get("limit") == "500"
+
+
+@pytest.mark.asyncio()
+async def test_search_clamps_limit_below_min(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """A limit < 1 is clamped to 1."""
+    mock_response: dict[str, Any] = {"result": []}
+    with respx.mock:
+        route = respx.get(SEARCH_URL).mock(return_value=Response(200, json=mock_response))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["code_search"](action="search", term="fn", limit=0)
+        result = decode_response(raw)
+
+    assert result["status"] == "success"
+    assert route.calls.last.request.url.params.get("limit") == "1"
+
+
+@pytest.mark.asyncio()
+async def test_search_passes_search_group(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """When ``search_group`` is provided it is passed to the client."""
+    mock_response: dict[str, Any] = {"result": []}
+    with respx.mock:
+        route = respx.get(SEARCH_URL).mock(return_value=Response(200, json=mock_response))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["code_search"](action="search", term="fn", search_group="my_group")
+        result = decode_response(raw)
+
+    assert result["status"] == "success"
+    assert route.calls.last.request.url.params.get("search_group") == "my_group"
+
+
+# ---------------------------------------------------------------------------
+# tables action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_tables_action(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """The tables action fetches and returns the list of searchable tables."""
+    mock_response: dict[str, Any] = {
+        "result": [
+            {"name": "sys_script_include", "label": "Script Includes"},
+            {"name": "sys_script", "label": "Business Rules"},
+        ],
+    }
+    with respx.mock:
+        respx.get(TABLES_URL).mock(return_value=Response(200, json=mock_response))
+
+        tools = _register_and_get_tools(settings, auth_provider)
+        raw = await tools["code_search"](action="tables")
+        result = decode_response(raw)
+
+    assert result["status"] == "success"
+    assert isinstance(result["data"], list)
+    assert len(result["data"]) == 2
+    assert result["data"][0]["name"] == "sys_script_include"
+
+
+# ---------------------------------------------------------------------------
+# describe action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_describe_action(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """The describe action returns metadata without any API call."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    raw = await tools["code_search"](action="describe")
+    result = decode_response(raw)
+
+    assert result["status"] == "success"
+    assert "actions" in result["data"]
+    assert "search" in result["data"]["actions"]
+    assert "tables" in result["data"]["actions"]
+    assert "describe" in result["data"]["actions"]
+
+
+# ---------------------------------------------------------------------------
+# unknown action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_unknown_action_returns_error(
+    settings: Settings,
+    auth_provider: BasicAuthProvider,
+) -> None:
+    """An unknown action value is rejected with a clear error message."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    raw = await tools["code_search"](action="nonexistent")
+    result = decode_response(raw)
+
+    assert result["status"] == "error"
+    assert "nonexistent" in result["error"]["message"]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -217,6 +217,7 @@ def _empty_inspect_kwargs(header_sys_id: str = SYS_ID_FLOW) -> dict[str, Any]:
         "get_action_type_definitions": [],
         "get_logic_definitions": [],
         "list_v1_variable_values": [],
+        "get_flow_snapshot_label_cache": {},
     }
 
 
@@ -782,10 +783,14 @@ async def test_inspect_resolves_datapill_ref_case_insensitively(
 
 @pytest.mark.asyncio()
 async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """A reference to a producer not on the canvas emits one ``unresolved_datapill_ref`` warning."""
+    """A reference to a missing producer emits one aggregated ``unresolved_datapill_ref`` warning."""
     tools = _register_and_get_tools(settings, auth_provider)
-    consumer_blob = _encode_values([{"target": f"{{{{{_UUID_GHOST}.foo}}}}"}])
-    actions_v2 = [_action_row(sys_id="a2", ui_id=_UUID_B, order="100", values=consumer_blob)]
+    blob_a = _encode_values([{"target": f"{{{{{_UUID_GHOST}.status}}}}"}])
+    blob_b = _encode_values([{"target": f"{{{{{_UUID_GHOST}.message}}}}", "other": f"{{{{{_UUID_GHOST}.message}}}}"}])
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_id=_UUID_A, order="11", values=blob_a),
+        _action_row(sys_id="a2", ui_id=_UUID_B, order="12", values=blob_b),
+    ]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
     client = _make_client_mock(**kwargs)
@@ -794,11 +799,41 @@ async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, aut
         raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
     data = decode_response(raw)["data"]
 
-    consumer = data["canvas"][0]
+    consumer = next(n for n in data["canvas"] if n["sys_id"] == "a1")
     assert consumer["datapill_refs"][0]["resolved"] is False
     matches = [w for w in data["warnings"] if "unresolved_datapill_ref" in w]
     assert len(matches) == 1
-    assert _UUID_GHOST in matches[0]
+    warning = matches[0]
+    assert _UUID_GHOST in warning
+    assert f"producer_ui_id={_UUID_GHOST!r}" in warning
+    assert "orders 11, 12" in warning
+    assert "fields: status, message" in warning
+
+
+@pytest.mark.asyncio()
+async def test_inspect_unresolved_datapill_uses_snapshot_label(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """When ``label_cache`` carries the deleted producer, the warning names it."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    consumer_blob = _encode_values([{"target": f"{{{{{_UUID_GHOST}.status}}}}"}])
+    actions_v2 = [_action_row(sys_id="a1", ui_id=_UUID_B, order="11", values=consumer_blob)]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    kwargs["get_flow_snapshot_label_cache"] = {_UUID_GHOST: "10 - Provision AD Group Membership"}
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    matches = [w for w in data["warnings"] if "unresolved_datapill_ref" in w]
+    assert len(matches) == 1
+    warning = matches[0]
+    assert "producer '10 - Provision AD Group Membership'" in warning
+    assert f"(deleted; ui_id={_UUID_GHOST!r})" in warning
+    assert "orders 11" in warning
+    assert "fields: status" in warning
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -804,10 +804,9 @@ async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, aut
     matches = [w for w in data["warnings"] if "unresolved_datapill_ref" in w]
     assert len(matches) == 1
     warning = matches[0]
-    assert _UUID_GHOST in warning
-    assert f"producer_ui_id={_UUID_GHOST!r}" in warning
-    assert "orders 11, 12" in warning
-    assert "fields: status, message" in warning
+    assert warning == (
+        f"unresolved_datapill_ref: producer_ui_id={_UUID_GHOST!r} referenced by orders 11, 12 (fields: status, message)"
+    )
 
 
 @pytest.mark.asyncio()
@@ -830,10 +829,36 @@ async def test_inspect_unresolved_datapill_uses_snapshot_label(
     matches = [w for w in data["warnings"] if "unresolved_datapill_ref" in w]
     assert len(matches) == 1
     warning = matches[0]
-    assert "producer '10 - Provision AD Group Membership'" in warning
-    assert f"(deleted; ui_id={_UUID_GHOST!r})" in warning
-    assert "orders 11" in warning
-    assert "fields: status" in warning
+    assert warning == (
+        f"unresolved_datapill_ref: producer '10 - Provision AD Group Membership' "
+        f"(deleted; ui_id={_UUID_GHOST!r}) referenced by orders 11 (fields: status)"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_inspect_unresolved_datapill_keeps_cross_node_duplicate_fields(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """Two distinct consumers referencing the same ghost field both surface in ``fields:``."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    blob_a = _encode_values([{"target": f"{{{{{_UUID_GHOST}.message}}}}"}])
+    blob_b = _encode_values([{"target": f"{{{{{_UUID_GHOST}.message}}}}"}])
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_id=_UUID_A, order="12", values=blob_a),
+        _action_row(sys_id="a2", ui_id=_UUID_B, order="15", values=blob_b),
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    matches = [w for w in data["warnings"] if "unresolved_datapill_ref" in w]
+    assert len(matches) == 1
+    assert "orders 12, 15" in matches[0]
+    assert "fields: message, message" in matches[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -734,6 +734,37 @@ async def test_inspect_attaches_resolved_datapill_refs(settings: Settings, auth_
 
 
 @pytest.mark.asyncio()
+async def test_inspect_resolves_datapill_ref_case_insensitively(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """An uppercase-UUID reference resolves against a lowercase canvas ``ui_uuid`` without warning."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    upper_ref = _UUID_A.upper()
+    producer_blob = _encode_values([{"k": "static"}])
+    consumer_blob = _encode_values([{"target": f"{{{{{upper_ref}.number}}}}"}])
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer", values=producer_blob),
+        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", label="Consumer", values=consumer_blob),
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    consumer = next(n for n in data["canvas"] if n["sys_id"] == "a2")
+    refs = consumer["datapill_refs"]
+    assert len(refs) == 1
+    assert refs[0]["resolved"] is True
+    assert refs[0]["producer_sys_id"] == "a1"
+    # Original-case literal is preserved in the returned ``ref`` field.
+    assert upper_ref in refs[0]["ref"]
+    assert not any("unresolved_datapill_ref" in w for w in data["warnings"])
+
+
+@pytest.mark.asyncio()
 async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """A reference to a producer not on the canvas emits one ``unresolved_datapill_ref`` warning."""
     tools = _register_and_get_tools(settings, auth_provider)
@@ -808,8 +839,8 @@ async def test_inspect_missing_record_trigger_condition(settings: Settings, auth
 
 
 @pytest.mark.asyncio()
-async def test_inspect_canvas_order_gap_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """A non-uniform sibling order sequence (100, 200, 400) emits ``canvas_order_gap``."""
+async def test_inspect_canvas_order_nonuniform_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """A non-uniform sibling order sequence (100, 200, 400) emits ``canvas_order_nonuniform``."""
     tools = _register_and_get_tools(settings, auth_provider)
     actions_v2 = [
         _action_row(sys_id="a1", ui_uuid="u1", order="100"),
@@ -823,7 +854,7 @@ async def test_inspect_canvas_order_gap_warning(settings: Settings, auth_provide
     with _patch_client(client):
         raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
     data = decode_response(raw)["data"]
-    assert any("canvas_order_gap" in w for w in data["warnings"])
+    assert any("canvas_order_nonuniform" in w for w in data["warnings"])
 
 
 @pytest.mark.asyncio()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -63,6 +63,21 @@ def _encode_values(payload: Any) -> str:
     return base64.b64encode(gzip.compress(raw)).decode("ascii")
 
 
+def _encode_trigger_inputs(entries: list[dict[str, Any]]) -> str:
+    """Build a gzip+base64+json ``trigger_inputs`` blob for V2 trigger fixtures."""
+    return _encode_values(entries)
+
+
+def _record_trigger_inputs(table: str, condition: str, *, table_display: str = "") -> str:
+    """Convenience: encode a record-trigger ``trigger_inputs`` blob with table+condition entries."""
+    return _encode_trigger_inputs(
+        [
+            {"id": "i1", "name": "table", "value": table, "displayValue": table_display or table},
+            {"id": "i2", "name": "condition", "value": condition, "displayValue": condition},
+        ]
+    )
+
+
 def _ref(value: str, display: str = "") -> dict[str, str]:
     """Mimic a display_value=all reference field shape."""
     return {"value": value, "display_value": display or value}
@@ -199,8 +214,8 @@ def _empty_inspect_kwargs(header_sys_id: str = SYS_ID_FLOW) -> dict[str, Any]:
         "list_logic_instances_v1": [],
         "list_trigger_instances_v2": [],
         "list_trigger_instances_v1": [],
-        "list_record_triggers": [],
         "get_action_type_definitions": [],
+        "get_logic_definitions": [],
         "list_v1_variable_values": [],
     }
 
@@ -278,16 +293,14 @@ async def test_inspect_happy_path_assembles_canvas(settings: Settings, auth_prov
     tools = _register_and_get_tools(settings, auth_provider)
 
     action_type_id = "atype_001"
-    trigger_remote_id = "rt_001"
+    logic_def_id = "if_def_001"
 
     actions_v2 = [
         {
             "sys_id": _ref("a1"),
-            "ui_uuid": _ref("ui_a1"),
-            "parent_ui_uuid": _ref(""),
+            "ui_id": _ref("ui_a1"),
+            "parent_ui_id": _ref(""),
             "order": _ref("100"),
-            "label": _ref("Create incident"),
-            "name": _ref(""),
             "comment": _ref(""),
             "action_type": _ref(action_type_id, "Create Record"),
             "values": _ref(_encode_values([{"k": "v"}])),
@@ -296,28 +309,21 @@ async def test_inspect_happy_path_assembles_canvas(settings: Settings, auth_prov
     logic_v2 = [
         {
             "sys_id": _ref("l1"),
-            "ui_uuid": _ref("ui_l1"),
-            "parent_ui_uuid": _ref(""),
+            "ui_id": _ref("ui_l1"),
+            "parent_ui_id": _ref(""),
             "order": _ref("200"),
-            "label": _ref("If"),
-            "name": _ref(""),
             "comment": _ref(""),
-            "logic_definition": _ref("if_def", "If"),
+            "logic_definition": _ref(logic_def_id, "If"),
             "values": _ref(""),
         },
     ]
     triggers_v2 = [
         {
             "sys_id": _ref("t1"),
-            "type": _ref("record_update"),
-            "active": _ref("true"),
-            "table": _ref("incident"),
-            "remote_trigger_id": _ref(trigger_remote_id),
-            "values": _ref(""),
+            "trigger_type": _ref("record_update"),
+            "name": _ref("Record Updated"),
+            "trigger_inputs": _ref(_record_trigger_inputs("incident", "active=true")),
         },
-    ]
-    record_triggers = [
-        {"sys_id": _ref(trigger_remote_id), "condition": _ref("active=true")},
     ]
     action_types = [
         {
@@ -327,6 +333,7 @@ async def test_inspect_happy_path_assembles_canvas(settings: Settings, auth_prov
             "sys_scope": _ref("global", "Global"),
         },
     ]
+    logic_defs = [{"sys_id": _ref(logic_def_id), "name": _ref("If")}]
 
     client = _make_client_mock(
         get_flow_by_sys_id=_minimal_flow_header(),
@@ -339,8 +346,8 @@ async def test_inspect_happy_path_assembles_canvas(settings: Settings, auth_prov
         list_logic_instances_v1=[],
         list_trigger_instances_v2=triggers_v2,
         list_trigger_instances_v1=[],
-        list_record_triggers=record_triggers,
         get_action_type_definitions=action_types,
+        get_logic_definitions=logic_defs,
         list_v1_variable_values=[],
     )
 
@@ -363,11 +370,19 @@ async def test_inspect_happy_path_assembles_canvas(settings: Settings, auth_prov
     parent_ids = {node["parent_ui_id"] for node in canvas}
     assert parent_ids == {""}
 
-    # Triggers stitched with record-trigger condition
+    # Labels derive from action_type / logic_definition lookups.
+    by_kind = {node["kind"]: node for node in canvas}
+    assert by_kind["action"]["label"] == "Create Record"
+    assert by_kind["logic"]["label"] == "If"
+
+    # Triggers carry the decoded trigger_inputs projection.
     triggers = data["triggers"]
     assert len(triggers) == 1
-    assert triggers[0]["version"] == "v2"
-    assert triggers[0]["condition"] == "active=true"
+    trig = triggers[0]
+    assert trig["version"] == "v2"
+    assert trig["type"] == "record_update"
+    assert trig["table"] == "incident"
+    assert trig["condition"] == "active=true"
 
     # No V1 + V2 mix, no drift, no v1 logic, no spoke -> empty warnings
     assert data["warnings"] == []
@@ -400,11 +415,9 @@ async def test_inspect_decode_failure_resilient(settings: Settings, auth_provide
     actions_v2 = [
         {
             "sys_id": _ref("a1"),
-            "ui_uuid": _ref("ui_a1"),
-            "parent_ui_uuid": _ref(""),
+            "ui_id": _ref("ui_a1"),
+            "parent_ui_id": _ref(""),
             "order": _ref("100"),
-            "label": _ref("Bad"),
-            "name": _ref(""),
             "comment": _ref(""),
             "action_type": _ref("atype_x"),
             # Looks compressed but isn't valid base64
@@ -684,36 +697,39 @@ _UUID_GHOST = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 def _action_row(
     *,
     sys_id: str,
-    ui_uuid: str,
+    ui_id: str,
     order: str,
-    label: str = "",
     values: Any = "",
-    parent_ui_uuid: str = "",
+    parent_ui_id: str = "",
     action_type: str = "atype_x",
+    action_type_label: str = "Create Record",
 ) -> dict[str, Any]:
-    """Build a minimal V2 action-instance row for tests."""
+    """Build a minimal V2 action-instance row for tests.
+
+    V2 rows expose ``ui_id``/``parent_ui_id`` (not ``ui_uuid``) and have
+    no ``name``/``label``/``active`` columns - the visible label comes
+    from the action-type lookup.
+    """
     return {
         "sys_id": _ref(sys_id),
-        "ui_uuid": _ref(ui_uuid),
-        "parent_ui_uuid": _ref(parent_ui_uuid),
+        "ui_id": _ref(ui_id),
+        "parent_ui_id": _ref(parent_ui_id),
         "order": _ref(order),
-        "label": _ref(label),
-        "name": _ref(""),
         "comment": _ref(""),
-        "action_type": _ref(action_type, "Create Record"),
+        "action_type": _ref(action_type, action_type_label),
         "values": _ref(values),
     }
 
 
 @pytest.mark.asyncio()
 async def test_inspect_attaches_resolved_datapill_refs(settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """A consumer node's decoded payload referencing a producer's ui_uuid yields a resolved ref."""
+    """A consumer node's decoded payload referencing a producer's ui_id yields a resolved ref."""
     tools = _register_and_get_tools(settings, auth_provider)
     producer_blob = _encode_values([{"k": "static"}])
     consumer_blob = _encode_values([{"target": f"{{{{{_UUID_A}.number}}}}"}])
     actions_v2 = [
-        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer", values=producer_blob),
-        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", label="Consumer", values=consumer_blob),
+        _action_row(sys_id="a1", ui_id=_UUID_A, order="100", values=producer_blob, action_type_label="Producer"),
+        _action_row(sys_id="a2", ui_id=_UUID_B, order="200", values=consumer_blob, action_type_label="Consumer"),
     ]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
@@ -727,7 +743,7 @@ async def test_inspect_attaches_resolved_datapill_refs(settings: Settings, auth_
     refs = consumer["datapill_refs"]
     assert len(refs) == 1
     assert refs[0]["resolved"] is True
-    assert refs[0]["producer_ui_uuid"] == _UUID_A
+    assert refs[0]["producer_ui_id"] == _UUID_A
     assert refs[0]["producer_sys_id"] == "a1"
     assert refs[0]["producer_name"] == "Producer"
     assert refs[0]["field"] == "number"
@@ -737,14 +753,14 @@ async def test_inspect_attaches_resolved_datapill_refs(settings: Settings, auth_
 async def test_inspect_resolves_datapill_ref_case_insensitively(
     settings: Settings, auth_provider: BasicAuthProvider
 ) -> None:
-    """An uppercase-UUID reference resolves against a lowercase canvas ``ui_uuid`` without warning."""
+    """An uppercase-UUID reference resolves against a lowercase canvas ``ui_id`` without warning."""
     tools = _register_and_get_tools(settings, auth_provider)
     upper_ref = _UUID_A.upper()
     producer_blob = _encode_values([{"k": "static"}])
     consumer_blob = _encode_values([{"target": f"{{{{{upper_ref}.number}}}}"}])
     actions_v2 = [
-        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer", values=producer_blob),
-        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", label="Consumer", values=consumer_blob),
+        _action_row(sys_id="a1", ui_id=_UUID_A, order="100", values=producer_blob, action_type_label="Producer"),
+        _action_row(sys_id="a2", ui_id=_UUID_B, order="200", values=consumer_blob, action_type_label="Consumer"),
     ]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
@@ -769,7 +785,7 @@ async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, aut
     """A reference to a producer not on the canvas emits one ``unresolved_datapill_ref`` warning."""
     tools = _register_and_get_tools(settings, auth_provider)
     consumer_blob = _encode_values([{"target": f"{{{{{_UUID_GHOST}.foo}}}}"}])
-    actions_v2 = [_action_row(sys_id="a2", ui_uuid=_UUID_B, order="100", values=consumer_blob)]
+    actions_v2 = [_action_row(sys_id="a2", ui_id=_UUID_B, order="100", values=consumer_blob)]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
     client = _make_client_mock(**kwargs)
@@ -786,82 +802,15 @@ async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, aut
 
 
 # ---------------------------------------------------------------------------
-# inspect: new warnings
+# inspect: warnings (kept after the V2-schema repair)
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio()
-async def test_inspect_flow_active_with_inactive_trigger(settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """Active flow with only inactive V2 triggers emits ``flow_active_with_inactive_trigger``."""
-    tools = _register_and_get_tools(settings, auth_provider)
-    kwargs = _empty_inspect_kwargs()
-    kwargs["list_trigger_instances_v2"] = [
-        {
-            "sys_id": _ref("t1"),
-            "type": _ref("record_update"),
-            "active": _ref("false"),
-            "table": _ref("incident"),
-            "remote_trigger_id": _ref(""),
-            "values": _ref(""),
-        }
-    ]
-    client = _make_client_mock(**kwargs)
-
-    with _patch_client(client):
-        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
-    data = decode_response(raw)["data"]
-    assert any("flow_active_with_inactive_trigger" in w for w in data["warnings"])
-
-
-@pytest.mark.asyncio()
-async def test_inspect_missing_record_trigger_condition(settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """V2 trigger with a remote_trigger_id but no stitched condition emits a warning."""
-    tools = _register_and_get_tools(settings, auth_provider)
-    kwargs = _empty_inspect_kwargs()
-    kwargs["list_trigger_instances_v2"] = [
-        {
-            "sys_id": _ref("t1"),
-            "type": _ref("record_update"),
-            "active": _ref("true"),
-            "table": _ref("incident"),
-            "remote_trigger_id": _ref("rt_orphan"),
-            "values": _ref(""),
-        }
-    ]
-    # No matching record-trigger row -> empty condition.
-    kwargs["list_record_triggers"] = []
-    client = _make_client_mock(**kwargs)
-
-    with _patch_client(client):
-        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
-    data = decode_response(raw)["data"]
-    assert any("missing_record_trigger_condition" in w for w in data["warnings"])
-
-
-@pytest.mark.asyncio()
-async def test_inspect_canvas_order_nonuniform_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
-    """A non-uniform sibling order sequence (100, 200, 400) emits ``canvas_order_nonuniform``."""
-    tools = _register_and_get_tools(settings, auth_provider)
-    actions_v2 = [
-        _action_row(sys_id="a1", ui_uuid="u1", order="100"),
-        _action_row(sys_id="a2", ui_uuid="u2", order="200"),
-        _action_row(sys_id="a3", ui_uuid="u3", order="400"),
-    ]
-    kwargs = _empty_inspect_kwargs()
-    kwargs["list_action_instances_v2"] = actions_v2
-    client = _make_client_mock(**kwargs)
-
-    with _patch_client(client):
-        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
-    data = decode_response(raw)["data"]
-    assert any("canvas_order_nonuniform" in w for w in data["warnings"])
 
 
 @pytest.mark.asyncio()
 async def test_inspect_step_decode_failure_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
     """At least one node with ``decode_error`` aggregates into a ``step_decode_failure`` warning."""
     tools = _register_and_get_tools(settings, auth_provider)
-    actions_v2 = [_action_row(sys_id="a1", ui_uuid="u1", order="100", values="H4sIA!!!bad!!!")]
+    actions_v2 = [_action_row(sys_id="a1", ui_id="u1", order="100", values="H4sIA!!!bad!!!")]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
     client = _make_client_mock(**kwargs)
@@ -870,6 +819,123 @@ async def test_inspect_step_decode_failure_warning(settings: Settings, auth_prov
         raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
     data = decode_response(raw)["data"]
     assert any("step_decode_failure: 1" in w for w in data["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# inspect: label resolution from action_type / logic_definition lookups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_inspect_labels_from_action_type_and_logic_definition_lookups(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """Action labels come from ``sys_hub_action_type_base``; logic labels from ``sys_hub_flow_logic_definition``."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    actions_v2 = [
+        {
+            "sys_id": _ref("a1"),
+            "ui_id": _ref("ui_a1"),
+            "parent_ui_id": _ref(""),
+            "order": _ref("100"),
+            "comment": _ref(""),
+            "action_type": _ref("atype_ar"),
+            "values": _ref(""),
+        }
+    ]
+    logic_v2 = [
+        {
+            "sys_id": _ref("l1"),
+            "ui_id": _ref("ui_l1"),
+            "parent_ui_id": _ref(""),
+            "order": _ref("200"),
+            "comment": _ref(""),
+            "logic_definition": _ref("ldef_foreach"),
+            "values": _ref(""),
+        }
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    kwargs["list_logic_instances_v2"] = logic_v2
+    kwargs["get_action_type_definitions"] = [{"sys_id": _ref("atype_ar"), "name": _ref("Ask For Approval")}]
+    kwargs["get_logic_definitions"] = [{"sys_id": _ref("ldef_foreach"), "name": _ref("For Each")}]
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    by_kind = {n["kind"]: n for n in data["canvas"]}
+    assert by_kind["action"]["label"] == "Ask For Approval"
+    assert by_kind["action"]["action_type"]["name"] == "Ask For Approval"
+    assert by_kind["logic"]["label"] == "For Each"
+    assert by_kind["logic"]["logic_definition"]["name"] == "For Each"
+
+
+# ---------------------------------------------------------------------------
+# inspect: V2 trigger projection from decoded trigger_inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_inspect_v2_trigger_projects_table_and_condition_from_inputs(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """A record-trigger row projects ``table``/``condition`` from the decoded ``trigger_inputs`` blob."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_trigger_instances_v2"] = [
+        {
+            "sys_id": _ref("t1"),
+            "trigger_type": _ref("record_create"),
+            "name": _ref("Record Created"),
+            "trigger_inputs": _ref(_record_trigger_inputs("incident", "state=1", table_display="Incident")),
+        }
+    ]
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    trig = data["triggers"][0]
+    assert trig["type"] == "record_create"
+    assert trig["name"] == "Record Created"
+    assert trig["table"] == "incident"
+    assert trig["table_display"] == "Incident"
+    assert trig["condition"] == "state=1"
+    assert trig["schedule"] == {}
+
+
+@pytest.mark.asyncio()
+async def test_summary_trigger_projects_record_trigger_inputs(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """``summary`` flattens the V2 trigger to a single object with table/condition/schedule fields."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_trigger_instances_v2"] = [
+        {
+            "sys_id": _ref("t1"),
+            "trigger_type": _ref("record_update"),
+            "name": _ref("Record Updated"),
+            "trigger_inputs": _ref(_record_trigger_inputs("incident", "active=true")),
+        }
+    ]
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="summary", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    assert data["trigger"] == {
+        "type": "record_update",
+        "name": "Record Updated",
+        "table": "incident",
+        "table_display": "incident",
+        "condition": "active=true",
+        "schedule": {},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -882,23 +948,20 @@ async def test_summary_happy_path_compact_projection(settings: Settings, auth_pr
     """``summary`` returns compact projection with single trigger, steps, branches, counts."""
     tools = _register_and_get_tools(settings, auth_provider)
     actions_v2 = [
-        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer"),
-        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", label="Consumer"),
+        _action_row(sys_id="a1", ui_id=_UUID_A, order="100", action_type_label="Producer"),
+        _action_row(sys_id="a2", ui_id=_UUID_B, order="200", action_type_label="Consumer"),
     ]
     triggers_v2 = [
         {
             "sys_id": _ref("t1"),
-            "type": _ref("record_update"),
-            "active": _ref("true"),
-            "table": _ref("incident"),
-            "remote_trigger_id": _ref("rt1"),
-            "values": _ref(""),
+            "trigger_type": _ref("record_update"),
+            "name": _ref("Record Updated"),
+            "trigger_inputs": _ref(_record_trigger_inputs("incident", "active=true")),
         }
     ]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
     kwargs["list_trigger_instances_v2"] = triggers_v2
-    kwargs["list_record_triggers"] = [{"sys_id": _ref("rt1"), "condition": _ref("active=true")}]
     client = _make_client_mock(**kwargs)
 
     with _patch_client(client):
@@ -906,18 +969,15 @@ async def test_summary_happy_path_compact_projection(settings: Settings, auth_pr
     data = decode_response(raw)["data"]
 
     # trigger is a single object, not a list
-    assert data["trigger"] == {
-        "type": "record_update",
-        "table": "incident",
-        "active": True,
-        "condition": "active=true",
-    }
+    assert data["trigger"]["type"] == "record_update"
+    assert data["trigger"]["table"] == "incident"
+    assert data["trigger"]["condition"] == "active=true"
     # steps are flat, ordered, no values_decoded
     assert [s["sys_id"] for s in data["steps"]] == ["a1", "a2"]
     assert all("values_decoded" not in s for s in data["steps"])
     # branches keep structure only
     assert {n["sys_id"] for n in data["branches"]} == {"a1", "a2"}
-    assert all(set(n.keys()) == {"ui_uuid", "sys_id", "order", "name", "children"} for n in data["branches"])
+    assert all(set(n.keys()) == {"ui_id", "sys_id", "order", "label", "children"} for n in data["branches"])
     # counts match
     assert data["counts"]["steps"] == 2
     assert data["counts"]["actions"] == 2
@@ -936,8 +996,8 @@ async def test_summary_datapill_graph_emits_resolved_and_unresolved(
         ]
     )
     actions_v2 = [
-        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer"),
-        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", values=consumer_blob),
+        _action_row(sys_id="a1", ui_id=_UUID_A, order="100", action_type_label="Producer"),
+        _action_row(sys_id="a2", ui_id=_UUID_B, order="200", values=consumer_blob),
     ]
     kwargs = _empty_inspect_kwargs()
     kwargs["list_action_instances_v2"] = actions_v2
@@ -948,10 +1008,10 @@ async def test_summary_datapill_graph_emits_resolved_and_unresolved(
     data = decode_response(raw)["data"]
 
     graph = data["datapill_graph"]
-    by_uuid = {edge["producer_ui_uuid"]: edge for edge in graph}
-    assert by_uuid[_UUID_A]["producer_sys_id_if_resolved"] == "a1"
-    assert by_uuid[_UUID_A]["consumer_step_sys_id"] == "a2"
-    assert by_uuid[_UUID_GHOST]["producer_sys_id_if_resolved"] == ""
+    by_uid = {edge["producer_ui_id"]: edge for edge in graph}
+    assert by_uid[_UUID_A]["producer_sys_id_if_resolved"] == "a1"
+    assert by_uid[_UUID_A]["consumer_step_sys_id"] == "a2"
+    assert by_uid[_UUID_GHOST]["producer_sys_id_if_resolved"] == ""
 
 
 @pytest.mark.asyncio()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -609,3 +609,333 @@ async def test_inspect_rejects_invalid_sys_id_without_io(settings: Settings, aut
     # Validation must happen BEFORE opening the client; no flow methods should be called.
     client.get_flow_by_sys_id.assert_not_called()
     client.find_flows_by_name.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# inspect: payload trim (boilerplate calculation, empty v1 omission)
+# ---------------------------------------------------------------------------
+
+
+_CALC_BOILERPLATE = (
+    "(function calculatedFieldValue(current) {\n\n\t// Add your code here"
+    "\n\treturn '';  // return the calculated value\n\n})(current);"
+)
+
+
+@pytest.mark.asyncio()
+async def test_inspect_strips_boilerplate_calculation(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """Verbatim ``calculation`` boilerplate is dropped; custom calculation is preserved."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    inputs = [
+        {"sys_id": _ref("in1"), "name": _ref("a"), "calculation": _ref(_CALC_BOILERPLATE)},
+        {"sys_id": _ref("in2"), "name": _ref("b"), "calculation": _ref("return current.number;")},
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_flow_inputs"] = inputs
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    assert "calculation" not in data["inputs"][0]
+    assert data["inputs"][1]["calculation"] == "return current.number;"
+
+
+@pytest.mark.asyncio()
+async def test_inspect_omits_empty_v1_arrays(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """``v1_actions`` / ``v1_variable_values`` are dropped from the response when both are empty."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    client = _make_client_mock(**_empty_inspect_kwargs())
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    assert "v1_actions" not in data
+    assert "v1_variable_values" not in data
+
+
+@pytest.mark.asyncio()
+async def test_inspect_includes_v1_when_present(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """``v1_actions`` is surfaced when the flow has at least one V1 action."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v1"] = [{"sys_id": _ref("av1"), "name": _ref("legacy")}]
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    assert data["v1_actions"][0]["sys_id"] == "av1"
+
+
+# ---------------------------------------------------------------------------
+# inspect: datapill ref resolution
+# ---------------------------------------------------------------------------
+
+
+_UUID_A = "11111111-1111-1111-1111-111111111111"
+_UUID_B = "22222222-2222-2222-2222-222222222222"
+_UUID_GHOST = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+
+def _action_row(
+    *,
+    sys_id: str,
+    ui_uuid: str,
+    order: str,
+    label: str = "",
+    values: Any = "",
+    parent_ui_uuid: str = "",
+    action_type: str = "atype_x",
+) -> dict[str, Any]:
+    """Build a minimal V2 action-instance row for tests."""
+    return {
+        "sys_id": _ref(sys_id),
+        "ui_uuid": _ref(ui_uuid),
+        "parent_ui_uuid": _ref(parent_ui_uuid),
+        "order": _ref(order),
+        "label": _ref(label),
+        "name": _ref(""),
+        "comment": _ref(""),
+        "action_type": _ref(action_type, "Create Record"),
+        "values": _ref(values),
+    }
+
+
+@pytest.mark.asyncio()
+async def test_inspect_attaches_resolved_datapill_refs(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """A consumer node's decoded payload referencing a producer's ui_uuid yields a resolved ref."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    producer_blob = _encode_values([{"k": "static"}])
+    consumer_blob = _encode_values([{"target": f"{{{{{_UUID_A}.number}}}}"}])
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer", values=producer_blob),
+        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", label="Consumer", values=consumer_blob),
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    consumer = next(n for n in data["canvas"] if n["sys_id"] == "a2")
+    refs = consumer["datapill_refs"]
+    assert len(refs) == 1
+    assert refs[0]["resolved"] is True
+    assert refs[0]["producer_ui_uuid"] == _UUID_A
+    assert refs[0]["producer_sys_id"] == "a1"
+    assert refs[0]["producer_name"] == "Producer"
+    assert refs[0]["field"] == "number"
+
+
+@pytest.mark.asyncio()
+async def test_inspect_unresolved_datapill_emits_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """A reference to a producer not on the canvas emits one ``unresolved_datapill_ref`` warning."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    consumer_blob = _encode_values([{"target": f"{{{{{_UUID_GHOST}.foo}}}}"}])
+    actions_v2 = [_action_row(sys_id="a2", ui_uuid=_UUID_B, order="100", values=consumer_blob)]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    consumer = data["canvas"][0]
+    assert consumer["datapill_refs"][0]["resolved"] is False
+    matches = [w for w in data["warnings"] if "unresolved_datapill_ref" in w]
+    assert len(matches) == 1
+    assert _UUID_GHOST in matches[0]
+
+
+# ---------------------------------------------------------------------------
+# inspect: new warnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_inspect_flow_active_with_inactive_trigger(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """Active flow with only inactive V2 triggers emits ``flow_active_with_inactive_trigger``."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_trigger_instances_v2"] = [
+        {
+            "sys_id": _ref("t1"),
+            "type": _ref("record_update"),
+            "active": _ref("false"),
+            "table": _ref("incident"),
+            "remote_trigger_id": _ref(""),
+            "values": _ref(""),
+        }
+    ]
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+    assert any("flow_active_with_inactive_trigger" in w for w in data["warnings"])
+
+
+@pytest.mark.asyncio()
+async def test_inspect_missing_record_trigger_condition(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """V2 trigger with a remote_trigger_id but no stitched condition emits a warning."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_trigger_instances_v2"] = [
+        {
+            "sys_id": _ref("t1"),
+            "type": _ref("record_update"),
+            "active": _ref("true"),
+            "table": _ref("incident"),
+            "remote_trigger_id": _ref("rt_orphan"),
+            "values": _ref(""),
+        }
+    ]
+    # No matching record-trigger row -> empty condition.
+    kwargs["list_record_triggers"] = []
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+    assert any("missing_record_trigger_condition" in w for w in data["warnings"])
+
+
+@pytest.mark.asyncio()
+async def test_inspect_canvas_order_gap_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """A non-uniform sibling order sequence (100, 200, 400) emits ``canvas_order_gap``."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_uuid="u1", order="100"),
+        _action_row(sys_id="a2", ui_uuid="u2", order="200"),
+        _action_row(sys_id="a3", ui_uuid="u3", order="400"),
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+    assert any("canvas_order_gap" in w for w in data["warnings"])
+
+
+@pytest.mark.asyncio()
+async def test_inspect_step_decode_failure_warning(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """At least one node with ``decode_error`` aggregates into a ``step_decode_failure`` warning."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    actions_v2 = [_action_row(sys_id="a1", ui_uuid="u1", order="100", values="H4sIA!!!bad!!!")]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="inspect", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+    assert any("step_decode_failure: 1" in w for w in data["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_summary_happy_path_compact_projection(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """``summary`` returns compact projection with single trigger, steps, branches, counts."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer"),
+        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", label="Consumer"),
+    ]
+    triggers_v2 = [
+        {
+            "sys_id": _ref("t1"),
+            "type": _ref("record_update"),
+            "active": _ref("true"),
+            "table": _ref("incident"),
+            "remote_trigger_id": _ref("rt1"),
+            "values": _ref(""),
+        }
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    kwargs["list_trigger_instances_v2"] = triggers_v2
+    kwargs["list_record_triggers"] = [{"sys_id": _ref("rt1"), "condition": _ref("active=true")}]
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="summary", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    # trigger is a single object, not a list
+    assert data["trigger"] == {
+        "type": "record_update",
+        "table": "incident",
+        "active": True,
+        "condition": "active=true",
+    }
+    # steps are flat, ordered, no values_decoded
+    assert [s["sys_id"] for s in data["steps"]] == ["a1", "a2"]
+    assert all("values_decoded" not in s for s in data["steps"])
+    # branches keep structure only
+    assert {n["sys_id"] for n in data["branches"]} == {"a1", "a2"}
+    assert all(set(n.keys()) == {"ui_uuid", "sys_id", "order", "name", "children"} for n in data["branches"])
+    # counts match
+    assert data["counts"]["steps"] == 2
+    assert data["counts"]["actions"] == 2
+    assert data["counts"]["triggers"] == 1
+
+
+@pytest.mark.asyncio()
+async def test_summary_datapill_graph_emits_resolved_and_unresolved(
+    settings: Settings, auth_provider: BasicAuthProvider
+) -> None:
+    """``datapill_graph`` lists one edge per consumer ref, with producer fields populated when resolved."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    consumer_blob = _encode_values(
+        [
+            {"a": f"{{{{{_UUID_A}.number}}}}", "b": f"{{{{{_UUID_GHOST}.foo}}}}"},
+        ]
+    )
+    actions_v2 = [
+        _action_row(sys_id="a1", ui_uuid=_UUID_A, order="100", label="Producer"),
+        _action_row(sys_id="a2", ui_uuid=_UUID_B, order="200", values=consumer_blob),
+    ]
+    kwargs = _empty_inspect_kwargs()
+    kwargs["list_action_instances_v2"] = actions_v2
+    client = _make_client_mock(**kwargs)
+
+    with _patch_client(client):
+        raw = await tools["flow"](action="summary", sys_id=SYS_ID_FLOW)
+    data = decode_response(raw)["data"]
+
+    graph = data["datapill_graph"]
+    by_uuid = {edge["producer_ui_uuid"]: edge for edge in graph}
+    assert by_uuid[_UUID_A]["producer_sys_id_if_resolved"] == "a1"
+    assert by_uuid[_UUID_A]["consumer_step_sys_id"] == "a2"
+    assert by_uuid[_UUID_GHOST]["producer_sys_id_if_resolved"] == ""
+
+
+@pytest.mark.asyncio()
+async def test_summary_rejects_neither_sys_id_nor_name(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """``summary`` validates the identifier contract the same way as ``inspect``."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    raw = await tools["flow"](action="summary")
+    result = decode_response(raw)
+    assert result["status"] == "error"
+    assert "required" in result["error"]["message"].lower()
+
+
+@pytest.mark.asyncio()
+async def test_describe_now_includes_summary(settings: Settings, auth_provider: BasicAuthProvider) -> None:
+    """``describe`` advertises the new ``summary`` action."""
+    tools = _register_and_get_tools(settings, auth_provider)
+    raw = await tools["flow"](action="describe")
+    assert "summary" in decode_response(raw)["data"]["actions"]

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -19,6 +19,7 @@ from servicenow_mcp.packages import (
 
 EXPECTED_PRESETS = {"full", "readonly", "core_readonly", "none"}
 EXPECTED_GROUPS = {
+    "code_search",
     "query",
     "describe",
     "record_write",
@@ -39,9 +40,9 @@ class TestPackageRegistry:
     def test_registry_has_exactly_four_presets(self) -> None:
         assert set(PACKAGE_REGISTRY.keys()) == EXPECTED_PRESETS
 
-    def test_full_contains_ten_unified_groups(self) -> None:
+    def test_full_contains_twelve_unified_groups(self) -> None:
         assert set(PACKAGE_REGISTRY["full"]) == EXPECTED_GROUPS
-        assert len(PACKAGE_REGISTRY["full"]) == 11
+        assert len(PACKAGE_REGISTRY["full"]) == 12
 
     def test_readonly_is_strict_subset_of_full(self) -> None:
         readonly = set(PACKAGE_REGISTRY["readonly"])


### PR DESCRIPTION
## Summary

Adds a new `code_search` tool that wraps the ServiceNow Code Search API (`/api/sn_codesearch/code_search/search`).

### Actions

- **`search`** (default) — Search for code/script patterns across ServiceNow script-bearing tables. Supports optional `table` and `search_group` filters with a `limit` clamped to [1, 500].
- **`tables`** — List all searchable tables from the Code Search API.
- **`describe`** — Return tool metadata without making API calls.

### Packages

Included in `full` and `readonly` packages.

### Files Changed

- `src/servicenow_mcp/tools/code_search.py` (new)
- `src/servicenow_mcp/packages.py` — registered group + packages
- `tests/test_code_search.py` (new) — 9 tests
- `tests/test_packages.py` — updated expected group count